### PR TITLE
Allow passing type parameters on generateSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- In `SchemaGenerator.generateSchema(Type)` also allow passing type parameters via `SchemaGenerator.generateSchema(Type, Type...)`.
 
 ## [3.1.0] – 2019-06-18
 ### Changed

--- a/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
@@ -75,11 +75,12 @@ public class SchemaGenerator {
      * Generate a {@link JsonNode} containing the JSON Schema representation of the given type.
      *
      * @param mainTargetType type for which to generate the JSON Schema
+     * @param typeParameters optional type parameters (in case of the {@code mainTargetType} being a parameterised type)
      * @return generated JSON Schema
      */
-    public JsonNode generateSchema(Class<?> mainTargetType) {
+    public JsonNode generateSchema(Type mainTargetType, Type... typeParameters) {
         SchemaGenerationContext generationContext = new SchemaGenerationContext(this.config, this.typeContext);
-        ResolvedType mainType = generationContext.getTypeContext().resolve(mainTargetType);
+        ResolvedType mainType = generationContext.getTypeContext().resolve(mainTargetType, typeParameters);
         this.traverseGenericType(mainType, null, false, generationContext);
 
         ObjectNode jsonSchemaResult = this.config.createObjectNode();


### PR DESCRIPTION
Underlying type resolution allows for a parameterized type to passed-in together with its type parameters.

This is simply being exposed here on the main `SchemaGenerator.generateSchema()` method, while still being backward-compatible, i.e. if no type parameters are provided for a given parameterized type, only the lower bounds of the respective type parameters will be considered (if there are any).