### PR TITLE
Update jackson dependency version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Increase dependency version for jackson-databind (and jackson-core) to resolve security alerts.
 
 ## [3.2.0] – 2019-09-01
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.github.victools</groupId>
     <artifactId>jsonschema-generator</artifactId>
-    <version>3.3.0-SNAPSHOT</version>
+    <version>3.2.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <licenses>
@@ -69,8 +69,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <version.classmate>1.5.0</version.classmate>
-        <version.jackson-core>2.9.9</version.jackson-core>
-        <version.jackson-databind>2.9.9.3</version.jackson-databind>
+        <version.jackson>2.9.10</version.jackson>
         <version.jsonassert>1.5.0</version.jsonassert>
         <version.junit>4.12</version.junit>
         <version.junitparams>1.1.1</version.junitparams>
@@ -88,12 +87,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${version.jackson-core}</version>
+            <version>${version.jackson}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${version.jackson-databind}</version>
+            <version>${version.jackson}</version>
         </dependency>
         <!-- log4j implementation is optional and left up to the library users to determine whether it is desired -->
         <dependency>


### PR DESCRIPTION
Suggested dependency upgrade to fix the following security alerts:
- [CVE-2019-14540](https://nvd.nist.gov/vuln/detail/CVE-2019-14540)
- [CVE-2019-16335](https://nvd.nist.gov/vuln/detail/CVE-2019-16335)

Both are categorised as "Polymorphic Typing issues" with "critical severity".