### PR TITLE
fix: apply collected attributes also to container types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Collected attributes should also be applied to container types (Issue #15)
 
 ## [3.4.0] - 2019-11-29
 ### Added

--- a/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
@@ -386,10 +386,13 @@ public class SchemaGenerator {
         CustomDefinition customDefinition = this.config.getCustomDefinition(javaType, generationContext.getTypeContext());
         if (collectedAttributes == null
                 || collectedAttributes.size() == 0
-                || (customDefinition != null && customDefinition.isMeantToBeInline())
-                || generationContext.getTypeContext().isContainerType(javaType)) {
+                || (customDefinition != null && customDefinition.isMeantToBeInline())) {
             // no need for the allOf, can use the sub-schema instance directly as reference
             referenceContainer = targetNode;
+        } else if (generationContext.getTypeContext().isContainerType(javaType)) {
+            // same as above, but the collected attributes should be applied also for containers/arrays
+            referenceContainer = targetNode;
+            referenceContainer.setAll(collectedAttributes);
         } else {
             // avoid mixing potential "$ref" element with contextual attributes by introducing an "allOf" wrapper
             referenceContainer = this.config.createObjectNode();

--- a/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorTest.java
+++ b/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorTest.java
@@ -78,8 +78,8 @@ public class SchemaGeneratorTest {
 
     private static void populateConfigPart(SchemaGeneratorConfigPart<?> configPart, String descriptionPrefix) {
         configPart
-                .withArrayMinItemsResolver(member -> member.isContainerType() ? 0 : null)
-                .withArrayMaxItemsResolver(member -> member.isContainerType() ? Integer.MAX_VALUE : null)
+                .withArrayMinItemsResolver(member -> member.isContainerType() ? 2 : null)
+                .withArrayMaxItemsResolver(member -> member.isContainerType() ? 100 : null)
                 .withArrayUniqueItemsResolver(member -> member.isContainerType() ? false : null)
                 .withDefaultResolver(member -> member.getType().isInstanceOf(Number.class) ? 1 : null)
                 .withDescriptionResolver(member -> descriptionPrefix + member.getContext().getSimpleTypeDescription(member.getType()))

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass1-PLAIN_JSON-attributes.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass1-PLAIN_JSON-attributes.json
@@ -3,6 +3,11 @@
     "type": "object",
     "properties": {
         "genericArray": {
+            "title": "String[]<String>",
+            "description": "looked-up from field: String[]<String>",
+            "minItems": 2,
+            "maxItems": 100,
+            "uniqueItems": false,
             "type": ["array", "null"],
             "items": {
                 "type": "string"

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-attributes.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-attributes.json
@@ -35,6 +35,11 @@
                         }]
                 },
                 "values()": {
+                    "title": "RoundingMode[]",
+                    "description": "looked-up from method: RoundingMode[]",
+                    "minItems": 2,
+                    "maxItems": 100,
+                    "uniqueItems": false,
                     "type": ["array", "null"],
                     "items": {
                         "$ref": "#/definitions/RoundingMode"
@@ -221,6 +226,11 @@
                             }
                         },
                         "getGenericValue()": {
+                            "title": "TestClass1[]",
+                            "description": "looked-up from method: TestClass1[]",
+                            "minItems": 2,
+                            "maxItems": 100,
+                            "uniqueItems": false,
                             "type": ["array", "null"],
                             "items": {
                                 "$ref": "#/definitions/TestClass1"
@@ -245,6 +255,11 @@
                 }]
         },
         "getNestedLongList()": {
+            "title": "List<TestClass2<Long>>",
+            "description": "looked-up from method: List<TestClass2<Long>>",
+            "minItems": 2,
+            "maxItems": 100,
+            "uniqueItems": false,
             "type": ["array", "null"],
             "items": {
                 "$ref": "#/definitions/TestClass2<Long>"

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-attributes.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-attributes.json
@@ -5,6 +5,11 @@
             "type": "object",
             "properties": {
                 "genericArray": {
+                    "title": "String[]<String>",
+                    "description": "looked-up from field: String[]<String>",
+                    "minItems": 2,
+                    "maxItems": 100,
+                    "uniqueItems": false,
                     "type": ["array", "null"],
                     "items": {
                         "type": "string"
@@ -43,6 +48,11 @@
             "type": "object",
             "properties": {
                 "genericArray": {
+                    "title": "Long[]<Long>",
+                    "description": "looked-up from field: Long[]<Long>",
+                    "minItems": 2,
+                    "maxItems": 100,
+                    "uniqueItems": false,
                     "type": ["array", "null"],
                     "items": {
                         "type": "integer"
@@ -66,6 +76,11 @@
             "type": "object",
             "properties": {
                 "genericArray": {
+                    "title": "String[]<String>",
+                    "description": "looked-up from field: String[]<String>",
+                    "minItems": 2,
+                    "maxItems": 100,
+                    "uniqueItems": false,
                     "type": ["array", "null"],
                     "items": {
                         "type": "string"
@@ -95,6 +110,11 @@
                                     "type": ["object", "null"],
                                     "properties": {
                                         "genericArray": {
+                                            "title": "TestClass2[]<TestClass2<String>>",
+                                            "description": "looked-up from field: TestClass2[]<TestClass2<String>>",
+                                            "minItems": 2,
+                                            "maxItems": 100,
+                                            "uniqueItems": false,
                                             "type": ["array", "null"],
                                             "items": {
                                                 "$ref": "#/definitions/TestClass2<String>"
@@ -139,6 +159,11 @@
                     "type": "object",
                     "properties": {
                         "genericArray": {
+                            "title": "TestClass1[][]<TestClass1[]>",
+                            "description": "looked-up from field: TestClass1[][]<TestClass1[]>",
+                            "minItems": 2,
+                            "maxItems": 100,
+                            "uniqueItems": false,
                             "type": ["array", "null"],
                             "items": {
                                 "type": "array",
@@ -148,6 +173,11 @@
                             }
                         },
                         "genericValue": {
+                            "title": "TestClass1[]",
+                            "description": "looked-up from field: TestClass1[]",
+                            "minItems": 2,
+                            "maxItems": 100,
+                            "uniqueItems": false,
                             "type": ["array", "null"],
                             "items": {
                                 "$ref": "#/definitions/TestClass1"
@@ -168,6 +198,11 @@
                 }]
         },
         "nestedLongList": {
+            "title": "List<TestClass2<Long>>",
+            "description": "looked-up from field: List<TestClass2<Long>>",
+            "minItems": 2,
+            "maxItems": 100,
+            "uniqueItems": false,
             "type": "array",
             "items": {
                 "$ref": "#/definitions/TestClass2<Long>"


### PR DESCRIPTION
Fixes issue reported #15 that the majority of collected attributes are ignored for container types (i.e. arrays and collections).

As it turns out, the bug was already visible in the existing tests – I just didn't realize it. 😞