### PR TITLE
fix: avoid white-spaces in definition keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- avoid white-spaces in definition keys
 
 ## [4.0.0] - 2020-01-03
 ### Added

--- a/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
@@ -103,7 +103,7 @@ public class SchemaGenerator {
             List<ObjectNode> nullableReferences = types.stream()
                     .flatMap(type -> generationContext.getNullableReferences(type).stream())
                     .collect(Collectors.toList());
-            String alias = aliasEntry.getKey();
+            String alias = aliasEntry.getKey().replaceAll("[ ]+", "");
             final String referenceKey;
             boolean referenceInline = !types.contains(mainSchemaTarget)
                     && (referencingNodes.isEmpty() || (!createDefinitionsForAll && (referencingNodes.size() + nullableReferences.size()) < 2));
@@ -131,7 +131,7 @@ public class SchemaGenerator {
                 }
                 generationContext.makeNullable(definition);
                 if (createDefinitionsForAll || nullableReferences.size() > 1) {
-                    String nullableAlias = alias + " (nullable)";
+                    String nullableAlias = alias + "(nullable)";
                     String nullableReferenceKey = SchemaConstants.TAG_REF_PREFIX + nullableAlias;
                     definitionsNode.set(nullableAlias, definition);
                     nullableReferences.forEach(referenceNode -> referenceNode.put(SchemaConstants.TAG_REF, nullableReferenceKey));

--- a/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorTest.java
+++ b/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorTest.java
@@ -262,7 +262,7 @@ public class SchemaGeneratorTest {
         private TestClass2<Long> nestedLong;
         private TestClass2<TestClass1[]> nestedClass1Array;
         private List<? extends TestClass2<Long>> nestedLongList;
-        private TestClass4<String> class4;
+        private TestClass4<Integer, String> class4;
 
         public TestClass2<Long> getNestedLong() {
             return this.nestedLong;
@@ -276,15 +276,15 @@ public class SchemaGeneratorTest {
             return this.nestedLongList;
         }
 
-        public TestClass4<String> getClass4() {
+        public TestClass4<Integer, String> getClass4() {
             return this.class4;
         }
     }
 
-    private static class TestClass4<T> {
+    private static class TestClass4<S, T> {
 
         private TestClass2<TestClass2<T>> class2OfClass2OfT;
-        public Optional<T> optionalT;
+        public Optional<S> optionalS;
         public static final RoundingMode DEFAULT_ROUNDING_MODE = RoundingMode.HALF_UP;
 
         public TestClass2<TestClass2<T>> getClass2OfClass2OfT() {

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass1-FULL_DOCUMENTATION.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass1-FULL_DOCUMENTATION.json
@@ -1,6 +1,6 @@
 {
     "definitions": {
-        "Integer (nullable)": {
+        "Integer(nullable)": {
             "$comment": "custom definition for Integer.class"
         }
     },
@@ -20,7 +20,7 @@
             "type": ["string", "null"]
         },
         "ignoredInternalValue": {
-            "$ref": "#/definitions/Integer (nullable)"
+            "$ref": "#/definitions/Integer(nullable)"
         },
         "primitiveValue": {
             "type": "integer"

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION-attributes.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION-attributes.json
@@ -1,20 +1,20 @@
 {
     "definitions": {
-        "Optional<String> (nullable)": {
+        "Optional<Integer>(nullable)": {
             "type": ["object", "null"],
             "properties": {
                 "get()": {
-                    "type": ["string", "null"]
+                    "type": ["integer", "null"]
                 },
                 "isPresent()": {
                     "type": "boolean"
                 },
-                "orElse(String)": {
-                    "type": ["string", "null"]
+                "orElse(Integer)": {
+                    "type": ["integer", "null"]
                 }
             },
-            "title": "Optional<String>",
-            "description": "for type in general: Optional<String>"
+            "title": "Optional<Integer>",
+            "description": "for type in general: Optional<Integer>"
         },
         "RoundingMode": {
             "type": "object",
@@ -36,10 +36,10 @@
                     "enum": ["UP", "DOWN", "CEILING", "FLOOR", "HALF_UP", "HALF_DOWN", "HALF_EVEN", "UNNECESSARY"]
                 },
                 "valueOf(String)": {
-                    "$ref": "#/definitions/RoundingMode (nullable)"
+                    "$ref": "#/definitions/RoundingMode(nullable)"
                 },
                 "valueOf(int)": {
-                    "$ref": "#/definitions/RoundingMode (nullable)"
+                    "$ref": "#/definitions/RoundingMode(nullable)"
                 },
                 "values()": {
                     "type": ["array", "null"],
@@ -56,7 +56,7 @@
             "title": "RoundingMode",
             "description": "for type in general: RoundingMode"
         },
-        "RoundingMode (nullable)": {
+        "RoundingMode(nullable)": {
             "oneOf": [{
                     "type": "null"
                 }, {
@@ -144,7 +144,7 @@
             "title": "TestClass2<Long>",
             "description": "for type in general: TestClass2<Long>"
         },
-        "TestClass2<Long> (nullable)": {
+        "TestClass2<Long>(nullable)": {
             "oneOf": [{
                     "type": "null"
                 }, {
@@ -182,14 +182,14 @@
             "title": "TestClass2<String>",
             "description": "for type in general: TestClass2<String>"
         },
-        "TestClass2<String> (nullable)": {
+        "TestClass2<String>(nullable)": {
             "oneOf": [{
                     "type": "null"
                 }, {
                     "$ref": "#/definitions/TestClass2<String>"
                 }]
         },
-        "TestClass2<TestClass1[]> (nullable)": {
+        "TestClass2<TestClass1[]>(nullable)": {
             "type": ["object", "null"],
             "properties": {
                 "genericArray": {
@@ -237,7 +237,7 @@
             "title": "TestClass2<TestClass1[]>",
             "description": "for type in general: TestClass2<TestClass1[]>"
         },
-        "TestClass2<TestClass2<String>> (nullable)": {
+        "TestClass2<TestClass2<String>>(nullable)": {
             "type": ["object", "null"],
             "properties": {
                 "genericArray": {
@@ -252,16 +252,16 @@
                     "uniqueItems": false
                 },
                 "genericValue": {
-                    "$ref": "#/definitions/TestClass2<String> (nullable)"
+                    "$ref": "#/definitions/TestClass2<String>(nullable)"
                 },
                 "getGenericValue()": {
-                    "$ref": "#/definitions/TestClass2<String> (nullable)"
+                    "$ref": "#/definitions/TestClass2<String>(nullable)"
                 }
             },
             "title": "TestClass2<TestClass2<String>>",
             "description": "for type in general: TestClass2<TestClass2<String>>"
         },
-        "TestClass4<String> (nullable)": {
+        "TestClass4<Integer,String>(nullable)": {
             "type": ["object", "null"],
             "properties": {
                 "DEFAULT_ROUNDING_MODE": {
@@ -272,29 +272,29 @@
                         }]
                 },
                 "class2OfClass2OfT": {
-                    "$ref": "#/definitions/TestClass2<TestClass2<String>> (nullable)"
+                    "$ref": "#/definitions/TestClass2<TestClass2<String>>(nullable)"
                 },
-                "optionalT": {
-                    "$ref": "#/definitions/Optional<String> (nullable)"
+                "optionalS": {
+                    "$ref": "#/definitions/Optional<Integer>(nullable)"
                 },
                 "getClass2OfClass2OfT()": {
-                    "$ref": "#/definitions/TestClass2<TestClass2<String>> (nullable)"
+                    "$ref": "#/definitions/TestClass2<TestClass2<String>>(nullable)"
                 }
             },
-            "title": "TestClass4<String>",
-            "description": "for type in general: TestClass4<String>"
+            "title": "TestClass4<Integer, String>",
+            "description": "for type in general: TestClass4<Integer, String>"
         }
     },
     "type": "object",
     "properties": {
         "class4": {
-            "$ref": "#/definitions/TestClass4<String> (nullable)"
+            "$ref": "#/definitions/TestClass4<Integer,String>(nullable)"
         },
         "nestedClass1Array": {
-            "$ref": "#/definitions/TestClass2<TestClass1[]> (nullable)"
+            "$ref": "#/definitions/TestClass2<TestClass1[]>(nullable)"
         },
         "nestedLong": {
-            "$ref": "#/definitions/TestClass2<Long> (nullable)"
+            "$ref": "#/definitions/TestClass2<Long>(nullable)"
         },
         "nestedLongList": {
             "type": ["array", "null"],
@@ -308,13 +308,13 @@
             "uniqueItems": false
         },
         "getClass4()": {
-            "$ref": "#/definitions/TestClass4<String> (nullable)"
+            "$ref": "#/definitions/TestClass4<Integer,String>(nullable)"
         },
         "getNestedClass1Array()": {
-            "$ref": "#/definitions/TestClass2<TestClass1[]> (nullable)"
+            "$ref": "#/definitions/TestClass2<TestClass1[]>(nullable)"
         },
         "getNestedLong()": {
-            "$ref": "#/definitions/TestClass2<Long> (nullable)"
+            "$ref": "#/definitions/TestClass2<Long>(nullable)"
         },
         "getNestedLongList()": {
             "type": ["array", "null"],

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION.json
@@ -1,19 +1,19 @@
 {
     "definitions": {
-        "Integer (nullable)": {
+        "Integer(nullable)": {
             "$comment": "custom definition for Integer.class"
         },
-        "Optional<String> (nullable)": {
+        "Optional<Integer>(nullable)": {
             "type": ["object", "null"],
             "properties": {
                 "get()": {
-                    "type": ["string", "null"]
+                    "$ref": "#/definitions/Integer(nullable)"
                 },
                 "isPresent()": {
                     "type": "boolean"
                 },
-                "orElse(String)": {
-                    "type": ["string", "null"]
+                "orElse(Integer)": {
+                    "$ref": "#/definitions/Integer(nullable)"
                 }
             }
         },
@@ -37,10 +37,10 @@
                     "enum": ["UP", "DOWN", "CEILING", "FLOOR", "HALF_UP", "HALF_DOWN", "HALF_EVEN", "UNNECESSARY"]
                 },
                 "valueOf(String)": {
-                    "$ref": "#/definitions/RoundingMode (nullable)"
+                    "$ref": "#/definitions/RoundingMode(nullable)"
                 },
                 "valueOf(int)": {
-                    "$ref": "#/definitions/RoundingMode (nullable)"
+                    "$ref": "#/definitions/RoundingMode(nullable)"
                 },
                 "values()": {
                     "type": ["array", "null"],
@@ -50,7 +50,7 @@
                 }
             }
         },
-        "RoundingMode (nullable)": {
+        "RoundingMode(nullable)": {
             "oneOf": [{
                     "type": "null"
                 }, {
@@ -74,7 +74,7 @@
                     "type": ["string", "null"]
                 },
                 "ignoredInternalValue": {
-                    "$ref": "#/definitions/Integer (nullable)"
+                    "$ref": "#/definitions/Integer(nullable)"
                 },
                 "primitiveValue": {
                     "type": "integer"
@@ -108,7 +108,7 @@
                 }
             }
         },
-        "TestClass2<Long> (nullable)": {
+        "TestClass2<Long>(nullable)": {
             "oneOf": [{
                     "type": "null"
                 }, {
@@ -132,14 +132,14 @@
                 }
             }
         },
-        "TestClass2<String> (nullable)": {
+        "TestClass2<String>(nullable)": {
             "oneOf": [{
                     "type": "null"
                 }, {
                     "$ref": "#/definitions/TestClass2<String>"
                 }]
         },
-        "TestClass2<TestClass1[]> (nullable)": {
+        "TestClass2<TestClass1[]>(nullable)": {
             "type": ["object", "null"],
             "properties": {
                 "genericArray": {
@@ -165,7 +165,7 @@
                 }
             }
         },
-        "TestClass2<TestClass2<String>> (nullable)": {
+        "TestClass2<TestClass2<String>>(nullable)": {
             "type": ["object", "null"],
             "properties": {
                 "genericArray": {
@@ -175,14 +175,14 @@
                     }
                 },
                 "genericValue": {
-                    "$ref": "#/definitions/TestClass2<String> (nullable)"
+                    "$ref": "#/definitions/TestClass2<String>(nullable)"
                 },
                 "getGenericValue()": {
-                    "$ref": "#/definitions/TestClass2<String> (nullable)"
+                    "$ref": "#/definitions/TestClass2<String>(nullable)"
                 }
             }
         },
-        "TestClass4<String> (nullable)": {
+        "TestClass4<Integer,String>(nullable)": {
             "type": ["object", "null"],
             "properties": {
                 "DEFAULT_ROUNDING_MODE": {
@@ -193,13 +193,13 @@
                         }]
                 },
                 "class2OfClass2OfT": {
-                    "$ref": "#/definitions/TestClass2<TestClass2<String>> (nullable)"
+                    "$ref": "#/definitions/TestClass2<TestClass2<String>>(nullable)"
                 },
-                "optionalT": {
-                    "$ref": "#/definitions/Optional<String> (nullable)"
+                "optionalS": {
+                    "$ref": "#/definitions/Optional<Integer>(nullable)"
                 },
                 "getClass2OfClass2OfT()": {
-                    "$ref": "#/definitions/TestClass2<TestClass2<String>> (nullable)"
+                    "$ref": "#/definitions/TestClass2<TestClass2<String>>(nullable)"
                 }
             }
         }
@@ -207,13 +207,13 @@
     "type": "object",
     "properties": {
         "class4": {
-            "$ref": "#/definitions/TestClass4<String> (nullable)"
+            "$ref": "#/definitions/TestClass4<Integer,String>(nullable)"
         },
         "nestedClass1Array": {
-            "$ref": "#/definitions/TestClass2<TestClass1[]> (nullable)"
+            "$ref": "#/definitions/TestClass2<TestClass1[]>(nullable)"
         },
         "nestedLong": {
-            "$ref": "#/definitions/TestClass2<Long> (nullable)"
+            "$ref": "#/definitions/TestClass2<Long>(nullable)"
         },
         "nestedLongList": {
             "type": ["array", "null"],
@@ -222,13 +222,13 @@
             }
         },
         "getClass4()": {
-            "$ref": "#/definitions/TestClass4<String> (nullable)"
+            "$ref": "#/definitions/TestClass4<Integer,String>(nullable)"
         },
         "getNestedClass1Array()": {
-            "$ref": "#/definitions/TestClass2<TestClass1[]> (nullable)"
+            "$ref": "#/definitions/TestClass2<TestClass1[]>(nullable)"
         },
         "getNestedLong()": {
-            "$ref": "#/definitions/TestClass2<Long> (nullable)"
+            "$ref": "#/definitions/TestClass2<Long>(nullable)"
         },
         "getNestedLongList()": {
             "type": ["array", "null"],

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-attributes.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-attributes.json
@@ -20,7 +20,7 @@
                 },
                 "valueOf(String)": {
                     "allOf": [{
-                            "$ref": "#/definitions/RoundingMode (nullable)"
+                            "$ref": "#/definitions/RoundingMode(nullable)"
                         }, {
                             "title": "RoundingMode",
                             "description": "looked-up from method: RoundingMode"
@@ -28,7 +28,7 @@
                 },
                 "valueOf(int)": {
                     "allOf": [{
-                            "$ref": "#/definitions/RoundingMode (nullable)"
+                            "$ref": "#/definitions/RoundingMode(nullable)"
                         }, {
                             "title": "RoundingMode",
                             "description": "looked-up from method: RoundingMode"
@@ -47,7 +47,7 @@
                 }
             }
         },
-        "RoundingMode (nullable)": {
+        "RoundingMode(nullable)": {
             "oneOf": [{
                     "type": "null"
                 }, {
@@ -148,33 +148,37 @@
                                     "const": "HALF_UP"
                                 }]
                         },
-                        "optionalT": {
+                        "optionalS": {
                             "type": "object",
                             "properties": {
                                 "get()": {
-                                    "type": ["string", "null"],
-                                    "title": "String",
-                                    "description": "looked-up from method: String",
-                                    "const": "constant string value",
-                                    "minLength": 1,
-                                    "maxLength": 256,
-                                    "format": "date",
-                                    "pattern": "^.{1,256}$"
+                                    "type": ["integer", "null"],
+                                    "title": "Integer",
+                                    "description": "looked-up from method: Integer",
+                                    "default": 1,
+                                    "enum": [1, 2, 3, 4, 5],
+                                    "minimum": 1,
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 1E+1,
+                                    "exclusiveMaximum": 11,
+                                    "multipleOf": 1
                                 },
                                 "isPresent()": {
                                     "type": ["boolean", "null"],
                                     "title": "boolean",
                                     "description": "looked-up from method: boolean"
                                 },
-                                "orElse(String)": {
-                                    "type": ["string", "null"],
-                                    "title": "String",
-                                    "description": "looked-up from method: String",
-                                    "const": "constant string value",
-                                    "minLength": 1,
-                                    "maxLength": 256,
-                                    "format": "date",
-                                    "pattern": "^.{1,256}$"
+                                "orElse(Integer)": {
+                                    "type": ["integer", "null"],
+                                    "title": "Integer",
+                                    "description": "looked-up from method: Integer",
+                                    "default": 1,
+                                    "enum": [1, 2, 3, 4, 5],
+                                    "minimum": 1,
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 1E+1,
+                                    "exclusiveMaximum": 11,
+                                    "multipleOf": 1
                                 }
                             }
                         },
@@ -208,8 +212,8 @@
                         }
                     }
                 }, {
-                    "title": "TestClass4<String>",
-                    "description": "looked-up from method: TestClass4<String>"
+                    "title": "TestClass4<Integer, String>",
+                    "description": "looked-up from method: TestClass4<Integer, String>"
                 }]
         },
         "getNestedClass1Array()": {

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-attributes.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-attributes.json
@@ -138,20 +138,22 @@
                                     "description": "looked-up from field: TestClass2<TestClass2<String>>"
                                 }]
                         },
-                        "optionalT": {
-                            "type": ["string", "null"],
-                            "title": "String",
-                            "description": "looked-up from field: String",
-                            "const": "constant string value",
-                            "minLength": 1,
-                            "maxLength": 256,
-                            "format": "date",
-                            "pattern": "^.{1,256}$"
+                        "optionalS": {
+                            "type": ["integer", "null"],
+                            "title": "Integer",
+                            "description": "looked-up from field: Integer",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
                         }
                     }
                 }, {
-                    "title": "TestClass4<String>",
-                    "description": "looked-up from field: TestClass4<String>"
+                    "title": "TestClass4<Integer, String>",
+                    "description": "looked-up from field: TestClass4<Integer, String>"
                 }]
         },
         "nestedClass1Array": {


### PR DESCRIPTION
As reported in #19, some validators like https://jsonschemalint.com/#!/version/draft-07/markup/json report generated schemas as valid when there are white-spaces in the values provided to `$ref`.

This affects two kinds of references:
- In case of generic types with more than one type parameter, e.g. `Map<String, String>`.
- When specifically handling `null`-able definitions, which get the `" (nullable)"` suffix.

----

Simple fix here: remove any whitespaces in the definition keys, consequently not using those invalid keys as `$ref`.

To show-case the changed behavior, the existing tests for the schema generation can be extended to include a generic with two parameters. Nullable examples are already present.