### PR TITLE
Introduce new Option.FLATTENED_ENUMS_FROM_TOSTRING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- new `Option.FLATTENED_ENUMS_FROM_TOSTRING`, using `toString()` instead of `name()` as per `Option.FLATTENED_ENUMS`
 
 ## [4.0.2] - 2020-01-30
 ### Fixed

--- a/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -74,8 +76,15 @@ public class SchemaGeneratorConfigBuilder {
                 .collect(Collectors.toMap(
                         option -> option,
                         option -> this.options.getOrDefault(option, this.preset.isOptionEnabledByDefault(option))));
+        Set<Option> enabledOptions = completeSetOfOptions.entrySet()
+                .stream()
+                .filter(Map.Entry::getValue)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+        Predicate<Option> isValid = (configuredOption) -> enabledOptions.stream().noneMatch(enabledOne -> enabledOne.isOverriding(configuredOption));
         completeSetOfOptions.entrySet()
                 .stream()
+                .filter(setting -> !setting.getValue() || isValid.test(setting.getKey()))
                 .map(setting -> setting.getKey().getModule(setting.getValue()))
                 .filter(Objects::nonNull)
                 .forEach(this::with);

--- a/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorTest.java
+++ b/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorTest.java
@@ -189,6 +189,7 @@ public class SchemaGeneratorTest {
         Module typeInGeneralModule = configBuilder -> populateTypeConfigPart(configBuilder.forTypesInGeneral(), "for type in general: ");
         Module methodModule = configBuilder -> populateConfigPart(configBuilder.forMethods(), "looked-up from method: ");
         Module fieldModule = configBuilder -> populateConfigPart(configBuilder.forFields(), "looked-up from field: ");
+        Module enumToStringModule = configBuilder -> configBuilder.with(Option.FLATTENED_ENUMS_FROM_TOSTRING);
         return new Object[][]{
             {"testclass1-FULL_DOCUMENTATION", OptionPreset.FULL_DOCUMENTATION, TestClass1.class, neutralModule},
             {"testclass1-FULL_DOCUMENTATION-attributes", OptionPreset.FULL_DOCUMENTATION, TestClass1.class, typeInGeneralModule},
@@ -198,7 +199,10 @@ public class SchemaGeneratorTest {
             {"testclass3-FULL_DOCUMENTATION", OptionPreset.FULL_DOCUMENTATION, TestClass3.class, neutralModule},
             {"testclass3-FULL_DOCUMENTATION-attributes", OptionPreset.FULL_DOCUMENTATION, TestClass3.class, typeInGeneralModule},
             {"testclass3-JAVA_OBJECT-attributes", OptionPreset.JAVA_OBJECT, TestClass3.class, methodModule},
-            {"testclass3-PLAIN_JSON-attributes", OptionPreset.PLAIN_JSON, TestClass3.class, fieldModule}
+            {"testclass3-PLAIN_JSON-attributes", OptionPreset.PLAIN_JSON, TestClass3.class, fieldModule},
+            {"testenum-PLAIN_JSON-default", OptionPreset.PLAIN_JSON, TestEnum.class, neutralModule},
+            {"testenum-FULL_DOCUMENTATION-default", OptionPreset.FULL_DOCUMENTATION, TestEnum.class, neutralModule},
+            {"testenum-PLAIN_JSON-viaToString", OptionPreset.PLAIN_JSON, TestEnum.class, enumToStringModule}
         };
     }
 
@@ -300,6 +304,15 @@ public class SchemaGeneratorTest {
 
         public TestClass2<TestClass2<T>> getClass2OfClass2OfT() {
             return this.class2OfClass2OfT;
+        }
+    }
+
+    private static enum TestEnum {
+        VALUE1, VALUE2, VALUE3;
+
+        @Override
+        public String toString() {
+            return "toString_" + this.name();
         }
     }
 }

--- a/src/test/resources/com/github/victools/jsonschema/generator/testenum-FULL_DOCUMENTATION-default.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testenum-FULL_DOCUMENTATION-default.json
@@ -1,0 +1,39 @@
+{
+    "definitions": {
+        "TestEnum-nullable": {
+            "oneOf": [{
+                    "type": "null"
+                }, {
+                    "$ref": "#"
+                }]
+        }
+    },
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": ["string", "null"]
+        },
+        "ordinal": {
+            "type": "integer"
+        },
+        "compareTo(TestEnum)": {
+            "type": "integer"
+        },
+        "name()": {
+            "type": "string",
+            "enum": ["VALUE1", "VALUE2", "VALUE3"]
+        },
+        "toString()": {
+            "type": ["string", "null"]
+        },
+        "valueOf(String)": {
+            "$ref": "#/definitions/TestEnum-nullable"
+        },
+        "values()": {
+            "type": ["array", "null"],
+            "items": {
+                "$ref": "#"
+            }
+        }
+    }
+}

--- a/src/test/resources/com/github/victools/jsonschema/generator/testenum-PLAIN_JSON-default.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testenum-PLAIN_JSON-default.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "string",
+    "enum": ["VALUE1", "VALUE2", "VALUE3"]
+}

--- a/src/test/resources/com/github/victools/jsonschema/generator/testenum-PLAIN_JSON-viaToString.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testenum-PLAIN_JSON-viaToString.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "string",
+    "enum": ["toString_VALUE1", "toString_VALUE2", "toString_VALUE3"]
+}


### PR DESCRIPTION
Also introducing explicit overrides between related options.

While the new `Option.FLATTENED_ENUMS_FROM_TOSTRING` is not being added to any existing `OptionPreset` by default – to ensure backward-compatibility – it is treated as the one with highest priority of the three enum related options:
- `Option.SIMPLIFIED_ENUMS`
- `Option.FLATTENED_ENUMS`
- `Option.FLATTENED_ENUMS_FROM_TOSTRING`

That means, the other options don't need to be explicitly disabled to use the new `Option`.