### PR TITLE
Offer safer/convenient type parameter look-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Support for "additionalProperties" property via `SchemaGeneratorConfigPart.withAdditionalPropertiesResolver()`
+- Offer `TypeScope.getTypeParameterFor()` and `TypeContext.getTypeParameterFor()` convenience methods
 
 ## [4.1.0] - 2020-02-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ configBuilder.forTypesInGeneral()
     .withAdditionalPropertiesResolver((scope) -> {
         if (scope.getType().isInstanceOf(Map.class)) {
             // within a Map<Key, Value> allow additionalProperties of the Value type
-            return scope.getType().typeParametersFor(Map.class).get(1);
+            return scope.getTypeParameterFor(Map.class, 1);
         }
         if (scope.getType().isPrimitive()
                 || scope.getType().isInstanceOf(Number.class)

--- a/src/main/java/com/github/victools/jsonschema/generator/TypeScope.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/TypeScope.java
@@ -59,6 +59,18 @@ public class TypeScope {
      * Convenience methods for targeted type *
      * ===================================== */
     /**
+     * Find type parameterization for the specified (super) type at return the type parameter at the given index.
+     *
+     * @param erasedSuperType (super) type to find declared type parameter for
+     * @param parameterIndex index of the single type parameter's declared type to return
+     * @return declared parameter type; or Object.class if no parameters are defined; or null if the given type or index are invalid
+     * @see TypeContext#getTypeParameterFor(ResolvedType, Class, int)
+     */
+    public ResolvedType getTypeParameterFor(Class<?> erasedSuperType, int parameterIndex) {
+        return this.context.getTypeParameterFor(this.type, erasedSuperType, parameterIndex);
+    }
+
+    /**
      * Determine whether this targeted type should be treated as "{@value SchemaConstants#TAG_TYPE_ARRAY}" in the generated schema.
      * <br>
      * This is equivalent to calling: {@code scope.getContext().isContainerType(scope.getType())}

--- a/src/main/java/com/github/victools/jsonschema/generator/impl/module/FlattenedOptionalModule.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/impl/module/FlattenedOptionalModule.java
@@ -38,8 +38,7 @@ public class FlattenedOptionalModule implements Module {
      * @return the wrapped component type (or null if it is not an {@link Optional} (sub) type
      */
     private ResolvedType resolveOptionalComponentType(MemberScope<?, ?> fieldOrMethod) {
-        ResolvedType javaType = fieldOrMethod.getType();
-        return FlattenedOptionalModule.isOptional(javaType) ? javaType.typeParametersFor(Optional.class).get(0) : null;
+        return FlattenedOptionalModule.isOptional(fieldOrMethod.getType()) ? fieldOrMethod.getTypeParameterFor(Optional.class, 0) : null;
     }
 
     @Override

--- a/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorTest.java
+++ b/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorTest.java
@@ -177,7 +177,7 @@ public class SchemaGeneratorTest {
             return Object.class;
         }
         if (scope.getType().isInstanceOf(TestClass4.class)) {
-            return scope.getType().typeParametersFor(TestClass4.class).get(1);
+            return scope.getTypeParameterFor(TestClass4.class, 1);
         }
         return Void.class;
     }


### PR DESCRIPTION
The goal is to enable simpler configurations by already taking care of some edge cases like a generic type (e.g. Map<K, V>` being used without type parameters (i.e. as raw `Map`), by simply returning `Object` as lower boundary then.

For simplicity's sake, the actual look-up of boundaries of the generic type itself is being left-out here, especially since the handling of union types is not that straightforward.