### PR TITLE
feat: default for additional/patternProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for "additionalProperties" property via `SchemaGeneratorTypeConfigPart.withAdditionalPropertiesResolver()`
 - Support for "patternProperties" property via `SchemaGeneratorTypeConfigPart.withPatternPropertiesResolver()`
+- Introduce new `Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT` for more convenient usage
 - Offer `TypeScope.getTypeParameterFor()` and `TypeContext.getTypeParameterFor()` convenience methods
 
 ## [4.1.0] - 2020-02-18

--- a/README.md
+++ b/README.md
@@ -132,27 +132,16 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import java.util.Map;
 ```
 ```java
-SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(objectMapper);
+SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(objectMapper)
+    .with(Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT);
 configBuilder.forTypesInGeneral()
     .withAdditionalPropertiesResolver((scope) -> {
         if (scope.getType().isInstanceOf(Map.class)) {
             // within a Map<Key, Value> allow additionalProperties of the Value type
+            // if no type parameters are defined, this will result in additionalProperties to be omitted (by way of return Object.class)
             return scope.getTypeParameterFor(Map.class, 1);
         }
-        if (scope.getType().isPrimitive()
-                || scope.getType().isInstanceOf(Number.class)
-                || scope.getType().isInstanceOf(CharSequence.class)) {
-            // explicitly cause the "additionalProperties" to be omitted for these non-object types – only do this if you are sure
-            // when in doubt: rather return null
-            return Object.class;
-        }
-        if (scope.isContainerType()) {
-            // mark this resolver as neutral, i.e. falling back on what the next resolver may decide
-            // if no other resolver provides a specific value, the default logic applies: omitting the "additionalProperties"
-            return null;
-        }
-        // set "additionalProperties" to "false" for all remaining objects
-        return Void.class;
+        return null;
     });
 ```
 

--- a/src/main/java/com/github/victools/jsonschema/generator/Option.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/Option.java
@@ -16,6 +16,7 @@
 
 package com.github.victools.jsonschema.generator;
 
+import com.github.victools.jsonschema.generator.impl.module.AdditionalPropertiesModule;
 import com.github.victools.jsonschema.generator.impl.module.ConstantValueModule;
 import com.github.victools.jsonschema.generator.impl.module.EnumModule;
 import com.github.victools.jsonschema.generator.impl.module.FieldExclusionModule;
@@ -193,6 +194,12 @@ public enum Option {
      * Default: false (disabled)
      */
     NULLABLE_METHOD_RETURN_VALUES_BY_DEFAULT(null, null),
+    /**
+     * Whether a schema's "additionalProperties" should be set to "false" if no specific configuration says otherwise.
+     * <br>
+     * Default: false (omitting the "additionalProperties" keyword and thereby allowing any additional properties in an object schema)
+     */
+    FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT(AdditionalPropertiesModule::forbiddenForAllObjectsButContainers, null),
     /**
      * Whether all referenced objects should be listed in the schema's "definitions", otherwise single occurrences are defined in-line.
      * <br>

--- a/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Default implementation of a schema generator's configuration.
@@ -47,7 +48,7 @@ import java.util.Optional;
 public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
 
     private final ObjectMapper objectMapper;
-    private final Map<Option, Boolean> options;
+    private final Set<Option> enabledOptions;
     private final SchemaGeneratorTypeConfigPart<TypeScope> typesInGeneralConfigPart;
     private final SchemaGeneratorConfigPart<FieldScope> fieldConfigPart;
     private final SchemaGeneratorConfigPart<MethodScope> methodConfigPart;
@@ -58,7 +59,7 @@ public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
      * Constructor of a configuration instance.
      *
      * @param objectMapper supplier for object and array nodes for the JSON structure being generated
-     * @param options specifically configured settings/options (thereby overriding the default enabled/disabled flag)
+     * @param enabledOptions enabled settings/options (either by default or explicitly set)
      * @param typesInGeneralConfigPart configuration part for context-independent attribute collection
      * @param fieldConfigPart configuration part for fields
      * @param methodConfigPart configuration part for methods
@@ -66,14 +67,14 @@ public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
      * @param typeAttributeOverrides applicable type attribute overrides
      */
     public SchemaGeneratorConfigImpl(ObjectMapper objectMapper,
-            Map<Option, Boolean> options,
+            Set<Option> enabledOptions,
             SchemaGeneratorTypeConfigPart<TypeScope> typesInGeneralConfigPart,
             SchemaGeneratorConfigPart<FieldScope> fieldConfigPart,
             SchemaGeneratorConfigPart<MethodScope> methodConfigPart,
             List<CustomDefinitionProviderV2> customDefinitions,
             List<TypeAttributeOverride> typeAttributeOverrides) {
         this.objectMapper = objectMapper;
-        this.options = options;
+        this.enabledOptions = enabledOptions;
         this.typesInGeneralConfigPart = typesInGeneralConfigPart;
         this.fieldConfigPart = fieldConfigPart;
         this.methodConfigPart = methodConfigPart;
@@ -88,7 +89,7 @@ public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
      * @return whether the given generator option is enabled
      */
     private boolean isOptionEnabled(Option setting) {
-        return this.options.getOrDefault(setting, false);
+        return this.enabledOptions.contains(setting);
     }
 
     @Override

--- a/src/main/java/com/github/victools/jsonschema/generator/impl/module/AdditionalPropertiesModule.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/impl/module/AdditionalPropertiesModule.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.generator.impl.module;
+
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.TypeScope;
+import java.lang.reflect.Type;
+import java.util.function.Predicate;
+
+/**
+ * Default module being included if {@code Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT} is enabled.
+ */
+public class AdditionalPropertiesModule implements Module {
+
+    /**
+     * Create module instance that forbids additional properties everywhere but on container types.
+     * <br>
+     * This assumes that the respective {@link SimpleTypeModule} instance is being applied first and already enforces the "additionProperties" keyword
+     * to be omitted on other non-object schemas.
+     *
+     * @return module instance
+     */
+    public static AdditionalPropertiesModule forbiddenForAllObjectsButContainers() {
+        return new AdditionalPropertiesModule(scope -> !scope.isContainerType());
+    }
+
+    private final Predicate<TypeScope> exclusionCheck;
+
+    /**
+     * Constructor.
+     *
+     * @param exclusionCheck determining whether additionalProperties should be forbidden on a given scope
+     */
+    public AdditionalPropertiesModule(Predicate<TypeScope> exclusionCheck) {
+        this.exclusionCheck = exclusionCheck;
+    }
+
+    @Override
+    public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+        builder.forTypesInGeneral()
+                .withAdditionalPropertiesResolver(this::resolveAdditionalProperties);
+    }
+
+    /**
+     * Either forbid additionProperties (according to the specified check) or leave it up to other configurations.
+     *
+     * @param scope type scope for which to determine whether additionalProperties should be forbidden
+     * @return either Void.class to indicate forbidden additionalProperties or null
+     */
+    private Type resolveAdditionalProperties(TypeScope scope) {
+        if (this.exclusionCheck.test(scope)) {
+            return Void.class;
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImplTest.java
+++ b/src/test/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImplTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.github.victools.jsonschema.generator.impl;
 
 import com.fasterxml.classmate.ResolvedType;

--- a/src/test/java/com/github/victools/jsonschema/generator/impl/module/SimpleTypeModuleTest.java
+++ b/src/test/java/com/github/victools/jsonschema/generator/impl/module/SimpleTypeModuleTest.java
@@ -21,22 +21,32 @@ import com.github.victools.jsonschema.generator.FieldScope;
 import com.github.victools.jsonschema.generator.MethodScope;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigPart;
+import com.github.victools.jsonschema.generator.SchemaGeneratorTypeConfigPart;
+import com.github.victools.jsonschema.generator.TypeScope;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Test for {@link SimpleTypeModule} class.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class SimpleTypeModuleTest {
 
     private SimpleTypeModule instance;
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private SchemaGeneratorConfigBuilder builder;
+    @Mock(answer = Answers.RETURNS_SELF)
+    private SchemaGeneratorTypeConfigPart<TypeScope> typeConfigPart;
 
     @Before
     public void setUp() {
         this.instance = new SimpleTypeModule();
-        this.builder = Mockito.mock(SchemaGeneratorConfigBuilder.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(this.builder.forTypesInGeneral()).thenReturn(this.typeConfigPart);
     }
 
     @Test
@@ -52,6 +62,11 @@ public class SimpleTypeModuleTest {
         Mockito.verify(methodConfigPart).withNullableCheck(Mockito.any());
         Mockito.verifyNoMoreInteractions(methodConfigPart);
         Mockito.verify(this.builder, Mockito.times(2)).forMethods();
+
+        Mockito.verify(this.typeConfigPart).withAdditionalPropertiesResolver(Mockito.any());
+        Mockito.verify(this.typeConfigPart).withPatternPropertiesResolver(Mockito.any());
+        Mockito.verifyNoMoreInteractions(this.typeConfigPart);
+        Mockito.verify(this.builder).forTypesInGeneral();
 
         Mockito.verify(this.builder).getObjectMapper();
         Mockito.verify(this.builder).with(Mockito.any(CustomDefinitionProviderV2.class));

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
@@ -23,8 +23,7 @@
                             "$ref": "#/definitions/RoundingMode-nullable"
                         }, {
                             "title": "RoundingMode",
-                            "description": "looked-up from method: RoundingMode",
-                            "additionalProperties": false
+                            "description": "looked-up from method: RoundingMode"
                         }]
                 },
                 "valueOf(int)": {
@@ -32,8 +31,7 @@
                             "$ref": "#/definitions/RoundingMode-nullable"
                         }, {
                             "title": "RoundingMode",
-                            "description": "looked-up from method: RoundingMode",
-                            "additionalProperties": false
+                            "description": "looked-up from method: RoundingMode"
                         }]
                 },
                 "values()": {


### PR DESCRIPTION
Changes made in the interest of making the usage of `additionalProperties`/`patternProperties` more convenient (as per #22):
- Specifically omit both newly supported keywords in case of the custom definitions for simple types (i.e. the non-`object` ones as well as the base `Object.class`).
- Introduce new `Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT` that applies to all definitions except for the specifically ones mentioned above and anything with `TypeScope.isContainerType()` being `true`.