### PR TITLE
Improved object handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- not declare any "type" for `Object.class` by default
 
 ## [4.2.0] - 2020-02-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- limit collected type attributes by declared "type"
+
 ### Fixed
 - not declare any "type" for `Object.class` by default
 

--- a/src/main/java/com/github/victools/jsonschema/generator/impl/AttributeCollector.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/impl/AttributeCollector.java
@@ -318,9 +318,7 @@ public class AttributeCollector {
             for (Map.Entry<String, Type> entry : patternProperties.entrySet()) {
                 ObjectNode singlePatternSchema = this.objectMapper.createObjectNode();
                 ResolvedType targetType = generationContext.getTypeContext().resolve(entry.getValue());
-                if (targetType.getErasedType() != Object.class) {
-                    generationContext.traverseGenericType(targetType, singlePatternSchema, false);
-                }
+                generationContext.traverseGenericType(targetType, singlePatternSchema, false);
                 patternPropertiesNode.set(entry.getKey(), singlePatternSchema);
             }
             node.set(SchemaConstants.TAG_PATTERN_PROPERTIES, patternPropertiesNode);

--- a/src/main/java/com/github/victools/jsonschema/generator/impl/AttributeCollector.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/impl/AttributeCollector.java
@@ -32,6 +32,7 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,9 +128,11 @@ public class AttributeCollector {
      *
      * @param scope the scope/type representation for which to collect JSON schema attributes
      * @param generationContext generation context, including configuration to apply when looking-up attribute values
+     * @param allowedSchemaTypes declared schema types determining which attributes are meaningful to be included
      * @return node holding all collected attributes (possibly empty)
      */
-    public static ObjectNode collectTypeAttributes(TypeScope scope, SchemaGenerationContextImpl generationContext) {
+    public static ObjectNode collectTypeAttributes(TypeScope scope, SchemaGenerationContextImpl generationContext,
+            Set<String> allowedSchemaTypes) {
         SchemaGeneratorConfig config = generationContext.getGeneratorConfig();
         ObjectNode node = config.createObjectNode();
         AttributeCollector collector = new AttributeCollector(config.getObjectMapper());
@@ -137,20 +140,29 @@ public class AttributeCollector {
         collector.setDescription(node, config.resolveDescriptionForType(scope));
         collector.setDefault(node, config.resolveDefaultForType(scope));
         collector.setEnum(node, config.resolveEnumForType(scope));
-        collector.setAdditionalProperties(node, config.resolveAdditionalPropertiesForType(scope), generationContext);
-        collector.setPatternProperties(node, config.resolvePatternPropertiesForType(scope), generationContext);
-        collector.setStringMinLength(node, config.resolveStringMinLengthForType(scope));
-        collector.setStringMaxLength(node, config.resolveStringMaxLengthForType(scope));
-        collector.setStringFormat(node, config.resolveStringFormatForType(scope));
-        collector.setStringPattern(node, config.resolveStringPatternForType(scope));
-        collector.setNumberInclusiveMinimum(node, config.resolveNumberInclusiveMinimumForType(scope));
-        collector.setNumberExclusiveMinimum(node, config.resolveNumberExclusiveMinimumForType(scope));
-        collector.setNumberInclusiveMaximum(node, config.resolveNumberInclusiveMaximumForType(scope));
-        collector.setNumberExclusiveMaximum(node, config.resolveNumberExclusiveMaximumForType(scope));
-        collector.setNumberMultipleOf(node, config.resolveNumberMultipleOfForType(scope));
-        collector.setArrayMinItems(node, config.resolveArrayMinItemsForType(scope));
-        collector.setArrayMaxItems(node, config.resolveArrayMaxItemsForType(scope));
-        collector.setArrayUniqueItems(node, config.resolveArrayUniqueItemsForType(scope));
+        if (allowedSchemaTypes.isEmpty() || allowedSchemaTypes.contains(SchemaConstants.TAG_TYPE_OBJECT)) {
+            collector.setAdditionalProperties(node, config.resolveAdditionalPropertiesForType(scope), generationContext);
+            collector.setPatternProperties(node, config.resolvePatternPropertiesForType(scope), generationContext);
+        }
+        if (allowedSchemaTypes.isEmpty() || allowedSchemaTypes.contains(SchemaConstants.TAG_TYPE_STRING)) {
+            collector.setStringMinLength(node, config.resolveStringMinLengthForType(scope));
+            collector.setStringMaxLength(node, config.resolveStringMaxLengthForType(scope));
+            collector.setStringFormat(node, config.resolveStringFormatForType(scope));
+            collector.setStringPattern(node, config.resolveStringPatternForType(scope));
+        }
+        if (allowedSchemaTypes.isEmpty() || allowedSchemaTypes.contains(SchemaConstants.TAG_TYPE_INTEGER)
+                || allowedSchemaTypes.contains(SchemaConstants.TAG_TYPE_NUMBER)) {
+            collector.setNumberInclusiveMinimum(node, config.resolveNumberInclusiveMinimumForType(scope));
+            collector.setNumberExclusiveMinimum(node, config.resolveNumberExclusiveMinimumForType(scope));
+            collector.setNumberInclusiveMaximum(node, config.resolveNumberInclusiveMaximumForType(scope));
+            collector.setNumberExclusiveMaximum(node, config.resolveNumberExclusiveMaximumForType(scope));
+            collector.setNumberMultipleOf(node, config.resolveNumberMultipleOfForType(scope));
+        }
+        if (allowedSchemaTypes.isEmpty() || allowedSchemaTypes.contains(SchemaConstants.TAG_TYPE_ARRAY)) {
+            collector.setArrayMinItems(node, config.resolveArrayMinItemsForType(scope));
+            collector.setArrayMaxItems(node, config.resolveArrayMaxItemsForType(scope));
+            collector.setArrayUniqueItems(node, config.resolveArrayUniqueItemsForType(scope));
+        }
         return node;
     }
 

--- a/src/main/java/com/github/victools/jsonschema/generator/impl/module/EnumModule.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/impl/module/EnumModule.java
@@ -20,7 +20,6 @@ import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.victools.jsonschema.generator.CustomDefinition;
-import com.github.victools.jsonschema.generator.CustomDefinitionProvider;
 import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2;
 import com.github.victools.jsonschema.generator.MethodScope;
 import com.github.victools.jsonschema.generator.Module;
@@ -128,7 +127,7 @@ public class EnumModule implements Module {
     }
 
     /**
-     * Implementation of the {@link CustomDefinitionProvider} interface for treating enum types as plain strings.
+     * Implementation of the {@link CustomDefinitionProviderV2} interface for treating enum types as plain strings.
      */
     private static class EnumAsStringDefinitionProvider implements CustomDefinitionProviderV2 {
 

--- a/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorTest.java
+++ b/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorTest.java
@@ -53,7 +53,7 @@ public class SchemaGeneratorTest {
 
     Object parametersForTestGenerateSchema_SimpleType() {
         return new Object[][]{
-            {Object.class, SchemaConstants.TAG_TYPE_OBJECT},
+            {Object.class, null},
             {String.class, SchemaConstants.TAG_TYPE_STRING},
             {Character.class, SchemaConstants.TAG_TYPE_STRING},
             {char.class, SchemaConstants.TAG_TYPE_STRING},
@@ -81,8 +81,12 @@ public class SchemaGeneratorTest {
         SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper()).build();
         SchemaGenerator generator = new SchemaGenerator(config);
         JsonNode result = generator.generateSchema(targetType);
-        Assert.assertEquals(1, result.size());
-        Assert.assertEquals(expectedJsonSchemaType, result.get(SchemaConstants.TAG_TYPE).asText());
+        if (expectedJsonSchemaType == null) {
+            Assert.assertTrue(result.isEmpty());
+        } else {
+            Assert.assertEquals(1, result.size());
+            Assert.assertEquals(expectedJsonSchemaType, result.get(SchemaConstants.TAG_TYPE).asText());
+        }
     }
 
     @Test
@@ -93,8 +97,12 @@ public class SchemaGeneratorTest {
                 .build();
         SchemaGenerator generator = new SchemaGenerator(config);
         JsonNode result = generator.generateSchema(targetType);
-        Assert.assertEquals(1, result.size());
-        Assert.assertEquals(expectedJsonSchemaType, result.get(SchemaConstants.TAG_TYPE).asText());
+        if (expectedJsonSchemaType == null) {
+            Assert.assertTrue(result.isEmpty());
+        } else {
+            Assert.assertEquals(1, result.size());
+            Assert.assertEquals(expectedJsonSchemaType, result.get(SchemaConstants.TAG_TYPE).asText());
+        }
     }
 
     @Test

--- a/src/test/java/com/github/victools/jsonschema/generator/impl/AttributeCollectorTest.java
+++ b/src/test/java/com/github/victools/jsonschema/generator/impl/AttributeCollectorTest.java
@@ -128,7 +128,7 @@ public class AttributeCollectorTest {
         Assert.assertTrue(patternPropertiesNode.isObject());
         Assert.assertEquals(1, patternPropertiesNode.size());
         Assert.assertTrue(patternPropertiesNode.get("^objectClass.*$").isObject());
-        Assert.assertFalse(this.generationContext.containsDefinition(this.generationContext.getTypeContext().resolve(Object.class)));
+        Assert.assertTrue(this.generationContext.containsDefinition(this.generationContext.getTypeContext().resolve(Object.class)));
     }
 
     @Test
@@ -142,7 +142,7 @@ public class AttributeCollectorTest {
         Assert.assertTrue(patternPropertiesNode.isObject());
         Assert.assertEquals(1, patternPropertiesNode.size());
         Assert.assertTrue(patternPropertiesNode.get("^resolvedObjectClass.*$").isObject());
-        Assert.assertFalse(this.generationContext.containsDefinition(this.generationContext.getTypeContext().resolve(Object.class)));
+        Assert.assertTrue(this.generationContext.containsDefinition(this.generationContext.getTypeContext().resolve(Object.class)));
     }
 
     @Test

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass2-array.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass2-array.json
@@ -5,16 +5,10 @@
             "properties": {
                 "genericArray": {
                     "type": ["array", "null"],
-                    "items": {
-                        "type": "object"
-                    }
+                    "items": {}
                 },
-                "genericValue": {
-                    "type": ["object", "null"]
-                },
-                "getGenericValue()": {
-                    "type": ["object", "null"]
-                }
+                "genericValue": {},
+                "getGenericValue()": {}
             }
         }
     },


### PR DESCRIPTION
The `Object.class` is currently represented by the following schema by default:
```javascript
{
    "type": "object"
}
```
However, that means any kind of element (e.g. "string", "number", "array") would fail the validation against this schema, even though from a Java perspective everything is an `Object`. Therefore changing this here now to simply omit the `"type"` for an otherwise unspecified `Object`.

----

Additionally, some collected attributes may not be valid in combination with the declared `"type"` in a sub-schema.
For now, only in the `SchemaGeneratorConfigBuilder.forTypesInGeneral()` the collection of some attributes is being skipped, if the existing `"type"` makes them invalid:
- `"string"` attributes are only collected if that `"type"` is declared (or no `"type"` at all)
- `"number"`/`"integer"` attributes are only collected if that `"type"` is declared (or no `"type"` at all)
- `"array"` attributes are only collected if that `"type"` is declared (or no `"type"` at all)
- `"object"` attributes are only collected if that `"type"` is declared (or no `"type"` at all)
This also affects the recently added `Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT` which was adding the `"additionalProperties"` in too many places when non-`object` custom definitions were involved.