### PR TITLE
feat: introduce clean-up of unnecessary allOf elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Explicit indication of targeted JSON Schema version (for now: Draft 7 or 2019-09)
 - Support for renamed keywords between Draft versions through new `SchemaKeyword` enum (replacing static `SchemaConstants` interface)
+- Support for `$ref` alongside other attributes (from Draft 2019-09 onwards) thereby reducing number of `allOf` elements
+- Introduce `Option.ALLOF_CLEANUP_AT_THE_END` (also included in all standard `OptionPreset`s) for toggling-off this improvement if not desired
+
+### Changed
+- Reduce number of `allOf` elements in generated schema when contained schema parts are distinct (and in case of Draft 7: don't contain `$ref`)
 
 ### Deprecated
-- `SchemaConstants` interface containing static `String` constants for tag names/values
+- `SchemaConstants` interface containing static `String` constants for tag names/values (in favour of version-aware `SchemaKeyword` enum)
 - Internal `AttributeCollector` API without generation context as parameter
 - `SchemaGeneratorConfigBuilder` constructors without explicit JSON Schema version indication
 

--- a/src/main/java/com/github/victools/jsonschema/generator/Option.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/Option.java
@@ -201,11 +201,19 @@ public enum Option {
      */
     FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT(AdditionalPropertiesModule::forbiddenForAllObjectsButContainers, null),
     /**
-     * Whether all referenced objects should be listed in the schema's "definitions", otherwise single occurrences are defined in-line.
+     * Whether all referenced objects should be listed in the schema's "definitions"/"$defs", otherwise single occurrences are defined in-line.
      * <br>
      * Default: false (disabled)
      */
-    DEFINITIONS_FOR_ALL_OBJECTS(null, null);
+    DEFINITIONS_FOR_ALL_OBJECTS(null, null),
+    /**
+     * Whether as the last step of the schema generation, unnecessary "allOf" elements (i.e. where there are no conflicts/overlaps between the
+     * contained sub-schemas) should be merged into one, in order to make the generated schema more readable. This also applies to manually added
+     * "allOf" elements, e.g. through custom definitions or attribute overrides.
+     * <br>
+     * Default: false (disabled)
+     */
+    ALLOF_CLEANUP_AT_THE_END(null, null);
 
     /**
      * Optional: the module realising the setting/option if it is enabled.

--- a/src/main/java/com/github/victools/jsonschema/generator/OptionPreset.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/OptionPreset.java
@@ -45,7 +45,8 @@ public class OptionPreset {
             Option.SIMPLIFIED_OPTIONALS,
             Option.DEFINITIONS_FOR_ALL_OBJECTS,
             Option.NULLABLE_FIELDS_BY_DEFAULT,
-            Option.NULLABLE_METHOD_RETURN_VALUES_BY_DEFAULT
+            Option.NULLABLE_METHOD_RETURN_VALUES_BY_DEFAULT,
+            Option.ALLOF_CLEANUP_AT_THE_END
     );
 
     /**
@@ -59,7 +60,8 @@ public class OptionPreset {
             Option.VALUES_FROM_CONSTANT_FIELDS,
             Option.PUBLIC_NONSTATIC_FIELDS,
             Option.NONPUBLIC_NONSTATIC_FIELDS_WITH_GETTERS,
-            Option.NONPUBLIC_NONSTATIC_FIELDS_WITHOUT_GETTERS
+            Option.NONPUBLIC_NONSTATIC_FIELDS_WITHOUT_GETTERS,
+            Option.ALLOF_CLEANUP_AT_THE_END
     );
 
     /**
@@ -74,7 +76,8 @@ public class OptionPreset {
             Option.GETTER_METHODS,
             Option.NONSTATIC_NONVOID_NONGETTER_METHODS,
             Option.SIMPLIFIED_ENUMS,
-            Option.SIMPLIFIED_OPTIONALS
+            Option.SIMPLIFIED_OPTIONALS,
+            Option.ALLOF_CLEANUP_AT_THE_END
     );
 
     private final Set<Option> defaultEnabledOptions;

--- a/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
@@ -85,7 +85,9 @@ public class SchemaGenerator {
         }
         ObjectNode mainSchemaNode = generationContext.getDefinition(mainType);
         jsonSchemaResult.setAll(mainSchemaNode);
-        this.discardUnnecessaryAllOfWrappers(jsonSchemaResult);
+        if (this.config.shouldCleanupUnnecessaryAllOfElements()) {
+            this.discardUnnecessaryAllOfWrappers(jsonSchemaResult);
+        }
         return jsonSchemaResult;
     }
 

--- a/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
@@ -18,14 +18,21 @@ package com.github.victools.jsonschema.generator;
 
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.victools.jsonschema.generator.impl.SchemaGenerationContextImpl;
 import com.github.victools.jsonschema.generator.impl.TypeContextFactory;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Generator for JSON Schema definitions via reflection based analysis of a given class.
@@ -78,6 +85,7 @@ public class SchemaGenerator {
         }
         ObjectNode mainSchemaNode = generationContext.getDefinition(mainType);
         jsonSchemaResult.setAll(mainSchemaNode);
+        this.discardUnnecessaryAllOfWrappers(jsonSchemaResult);
         return jsonSchemaResult;
     }
 
@@ -150,5 +158,135 @@ public class SchemaGenerator {
             }
         }
         return definitionsNode;
+    }
+
+    /**
+     * Collect names of schema tags that may contain sub-schemas, i.e. {@link SchemaKeyword#TAG_ADDITIONAL_PROPERTIES} and
+     * {@link SchemaKeyword#TAG_ITEMS}.
+     *
+     * @return names of eligible tags as per the designated JSON Schema version
+     * @see #discardUnnecessaryAllOfWrappers(ObjectNode)
+     */
+    private Set<String> getTagNamesContainingSchema() {
+        SchemaVersion schemaVersion = this.config.getSchemaVersion();
+        return Stream.of(SchemaKeyword.TAG_ADDITIONAL_PROPERTIES, SchemaKeyword.TAG_ITEMS)
+                .map(keyword -> keyword.forVersion(schemaVersion))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Collect names of schema tags that may contain arrays of sub-schemas, i.e. {@link SchemaKeyword#TAG_ALLOF}, {@link SchemaKeyword#TAG_ANYOF} and
+     * {@link SchemaKeyword#TAG_ONEOF}.
+     *
+     * @return names of eligible tags as per the designated JSON Schema version
+     * @see #discardUnnecessaryAllOfWrappers(ObjectNode)
+     */
+    private Set<String> getTagNamesContainingSchemaArray() {
+        SchemaVersion schemaVersion = this.config.getSchemaVersion();
+        return Stream.of(SchemaKeyword.TAG_ALLOF, SchemaKeyword.TAG_ANYOF, SchemaKeyword.TAG_ONEOF)
+                .map(keyword -> keyword.forVersion(schemaVersion))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Collect names of schema tags that may contain objects with sub-schemas as values, i.e. {@link SchemaKeyword#TAG_PATTERN_PROPERTIES} and
+     * {@link SchemaKeyword#TAG_PROPERTIES}.
+     *
+     * @return names of eligible tags as per the designated JSON Schema version
+     * @see #discardUnnecessaryAllOfWrappers(ObjectNode)
+     */
+    private Set<String> getTagNamesContainingSchemaObject() {
+        SchemaVersion schemaVersion = this.config.getSchemaVersion();
+        return Stream.of(SchemaKeyword.TAG_PATTERN_PROPERTIES, SchemaKeyword.TAG_PROPERTIES)
+                .map(keyword -> keyword.forVersion(schemaVersion))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Iterate through a generated and fully populated schema and remove extraneous {@link SchemaKeyword#TAG_ALLOF} nodes, that are included due to
+     * the way how type references are handled during schema generation but are strictly not necessary. This makes for more readable schemas being
+     * generated but has the side-effect that any manually added {@link SchemaKeyword#TAG_ALLOF} (e.g. through a custom definition of attribute
+     * overrides) may be removed as well if it isn't strictly speaking necessary.
+     *
+     * @param schemaNode generated schema to clean-up
+     */
+    private void discardUnnecessaryAllOfWrappers(ObjectNode schemaNode) {
+        List<ObjectNode> nextNodesToCheck = new ArrayList<>();
+        Consumer<JsonNode> addNodeToCheck = node -> {
+            if (node instanceof ObjectNode) {
+                nextNodesToCheck.add((ObjectNode) node);
+            }
+        };
+        nextNodesToCheck.add(schemaNode);
+        SchemaVersion schemaVersion = this.config.getSchemaVersion();
+        Optional.ofNullable(schemaNode.get(SchemaKeyword.TAG_DEFINITIONS.forVersion(schemaVersion)))
+                .filter(definitions -> definitions instanceof ObjectNode)
+                .ifPresent(definitions -> ((ObjectNode) definitions).forEach(addNodeToCheck));
+
+        String allOfTagName = SchemaKeyword.TAG_ALLOF.forVersion(schemaVersion);
+        Set<String> tagsWithSchemas = this.getTagNamesContainingSchema();
+        Set<String> tagsWithSchemaArrays = this.getTagNamesContainingSchemaArray();
+        Set<String> tagsWithSchemaObjects = this.getTagNamesContainingSchemaObject();
+        do {
+            List<ObjectNode> currentNodesToCheck = new ArrayList<>(nextNodesToCheck);
+            nextNodesToCheck.clear();
+            for (ObjectNode nodeToCheck : currentNodesToCheck) {
+                this.mergeAllOfPartsIfPossible(nodeToCheck, allOfTagName);
+                tagsWithSchemas.stream().map(nodeToCheck::get).forEach(addNodeToCheck);
+                tagsWithSchemaArrays.stream()
+                        .map(nodeToCheck::get)
+                        .filter(possibleArrayNode -> possibleArrayNode instanceof ArrayNode)
+                        .forEach(arrayNode -> arrayNode.forEach(addNodeToCheck));
+                tagsWithSchemaObjects.stream()
+                        .map(nodeToCheck::get)
+                        .filter(possibleObjectNode -> possibleObjectNode instanceof ObjectNode)
+                        .forEach(objectNode -> objectNode.forEach(addNodeToCheck));
+            }
+        } while (!nextNodesToCheck.isEmpty());
+    }
+
+    /**
+     * Check whether the given schema node and its {@link SchemaKeyword#TAG_ALLOF} elements (if there are any) are distinct. If yes, remove the
+     * {@link SchemaKeyword#TAG_ALLOF} node and merge all its elements with the given schema node instead.
+     *
+     * @param schemaNode single node representing a sub-schema to consolidate contained {@link SchemaKeyword#TAG_ALLOF} for (if present)
+     * @param allOfTagName name of the {@link SchemaKeyword#TAG_ALLOF} in the designated JSON Schema version
+     */
+    private void mergeAllOfPartsIfPossible(JsonNode schemaNode, String allOfTagName) {
+        if (!(schemaNode instanceof ObjectNode)) {
+            return;
+        }
+        JsonNode allOfTag = schemaNode.get(allOfTagName);
+        if (!(allOfTag instanceof ArrayNode)) {
+            return;
+        }
+        allOfTag.forEach(part -> this.mergeAllOfPartsIfPossible(part, allOfTagName));
+
+        List<JsonNode> allOfElements = new ArrayList<>();
+        allOfTag.forEach(allOfElements::add);
+        if (allOfElements.stream().anyMatch(part -> !(part instanceof ObjectNode) && !part.asBoolean())) {
+            return;
+        }
+        List<ObjectNode> parts = allOfElements.stream()
+                .filter(part -> part instanceof ObjectNode)
+                .map(part -> (ObjectNode) part)
+                .collect(Collectors.toList());
+
+        final ObjectNode schemaObjectNode = (ObjectNode) schemaNode;
+        final SchemaVersion schemaVersion = this.config.getSchemaVersion();
+        if (schemaVersion == SchemaVersion.DRAFT_7) {
+            // in Draft 7, any other attributes besides the $ref keyword were ignored
+            String refKeyword = SchemaKeyword.TAG_REF.forVersion(schemaVersion);
+            if (schemaObjectNode.has(refKeyword) || parts.stream().anyMatch(part -> part.has(refKeyword))) {
+                return;
+            }
+        }
+        Map<String, Integer> fieldCount = Stream.concat(Stream.of(schemaObjectNode), parts.stream())
+                .flatMap(part -> StreamSupport.stream(((Iterable<String>) () -> part.fieldNames()).spliterator(), false))
+                .collect(Collectors.toMap(fieldName -> fieldName, _value -> 1, (currentCount, nextCount) -> currentCount + nextCount));
+        if (fieldCount.values().stream().allMatch(count -> count == 1)) {
+            schemaObjectNode.remove(allOfTagName);
+            parts.forEach(schemaObjectNode::setAll);
+        }
     }
 }

--- a/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
@@ -63,6 +63,14 @@ public interface SchemaGeneratorConfig {
     boolean shouldIncludeSchemaVersionIndicator();
 
     /**
+     * Determine whether unnecessary {@link SchemaKeyword#TAG_ALLOF} elements should be removed and merged into their declaring schema when there are
+     * no conflicts between the sub-schemas.
+     *
+     * @return whether to clean-up {@link SchemaKeyword#TAG_ALLOF} elements as the last step during schema generation
+     */
+    boolean shouldCleanupUnnecessaryAllOfElements();
+
+    /**
      * Determine whether static fields should be included in the generated schema.
      *
      * @return whether to include static fields

--- a/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
@@ -106,6 +106,11 @@ public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
     }
 
     @Override
+    public boolean shouldCleanupUnnecessaryAllOfElements() {
+        return this.isOptionEnabled(Option.ALLOF_CLEANUP_AT_THE_END);
+    }
+
+    @Override
     public boolean shouldIncludeStaticFields() {
         return this.isOptionEnabled(Option.PUBLIC_STATIC_FIELDS) || this.isOptionEnabled(Option.NONPUBLIC_STATIC_FIELDS);
     }

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
@@ -138,155 +138,140 @@
     "type": "object",
     "properties": {
         "getClass4()": {
-            "allOf": [{
-                    "type": ["object", "null"],
+            "type": ["object", "null"],
+            "properties": {
+                "DEFAULT_ROUNDING_MODE": {
+                    "allOf": [{
+                            "$ref": "#/definitions/RoundingMode"
+                        }, {
+                            "const": "HALF_UP"
+                        }]
+                },
+                "optionalS": {
+                    "type": "object",
                     "properties": {
-                        "DEFAULT_ROUNDING_MODE": {
-                            "allOf": [{
-                                    "$ref": "#/definitions/RoundingMode"
-                                }, {
-                                    "const": "HALF_UP"
-                                }]
+                        "get()": {
+                            "type": ["integer", "null"],
+                            "title": "Integer",
+                            "description": "looked-up from method: Integer",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
                         },
-                        "optionalS": {
-                            "type": "object",
-                            "properties": {
-                                "get()": {
-                                    "type": ["integer", "null"],
-                                    "title": "Integer",
-                                    "description": "looked-up from method: Integer",
-                                    "default": 1,
-                                    "enum": [1, 2, 3, 4, 5],
-                                    "minimum": 1,
-                                    "exclusiveMinimum": 0,
-                                    "maximum": 1E+1,
-                                    "exclusiveMaximum": 11,
-                                    "multipleOf": 1
-                                },
-                                "isPresent()": {
-                                    "type": ["boolean", "null"],
-                                    "title": "boolean",
-                                    "description": "looked-up from method: boolean"
-                                },
-                                "orElse(Integer)": {
-                                    "type": ["integer", "null"],
-                                    "title": "Integer",
-                                    "description": "looked-up from method: Integer",
-                                    "default": 1,
-                                    "enum": [1, 2, 3, 4, 5],
-                                    "minimum": 1,
-                                    "exclusiveMinimum": 0,
-                                    "maximum": 1E+1,
-                                    "exclusiveMaximum": 11,
-                                    "multipleOf": 1
-                                }
-                            }
+                        "isPresent()": {
+                            "type": ["boolean", "null"],
+                            "title": "boolean",
+                            "description": "looked-up from method: boolean"
                         },
-                        "getClass2OfClass2OfT()": {
-                            "allOf": [{
-                                    "type": ["object", "null"],
-                                    "properties": {
-                                        "genericArray": {
-                                            "type": "array",
-                                            "items": {
-                                                "$ref": "#/definitions/TestClass2(String)"
-                                            }
-                                        },
-                                        "getGenericValue()": {
-                                            "allOf": [{
-                                                    "oneOf": [{
-                                                            "type": "null"
-                                                        }, {
-                                                            "$ref": "#/definitions/TestClass2(String)"
-                                                        }]
-                                                }, {
-                                                    "title": "TestClass2<String>",
-                                                    "description": "looked-up from method: TestClass2<String>",
-                                                    "additionalProperties": false,
-                                                    "patternProperties": {
-                                                        "^generic.+$": {
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                }]
-                                        }
-                                    }
-                                }, {
-                                    "title": "TestClass2<TestClass2<String>>",
-                                    "description": "looked-up from method: TestClass2<TestClass2<String>>",
-                                    "additionalProperties": false,
-                                    "patternProperties": {
-                                        "^generic.+$": {
-                                            "$ref": "#/definitions/TestClass2(String)"
-                                        }
-                                    }
-                                }]
+                        "orElse(Integer)": {
+                            "type": ["integer", "null"],
+                            "title": "Integer",
+                            "description": "looked-up from method: Integer",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
                         }
                     }
-                }, {
-                    "title": "TestClass4<Integer, String>",
-                    "description": "looked-up from method: TestClass4<Integer, String>",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }]
-        },
-        "getNestedClass1Array()": {
-            "allOf": [{
+                },
+                "getClass2OfClass2OfT()": {
                     "type": ["object", "null"],
                     "properties": {
                         "genericArray": {
                             "type": "array",
                             "items": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/TestClass1"
-                                }
+                                "$ref": "#/definitions/TestClass2(String)"
                             }
                         },
                         "getGenericValue()": {
-                            "title": "TestClass1[]",
-                            "description": "looked-up from method: TestClass1[]",
-                            "minItems": 2,
-                            "maxItems": 100,
-                            "uniqueItems": false,
-                            "type": ["array", "null"],
-                            "items": {
-                                "$ref": "#/definitions/TestClass1"
+                            "oneOf": [{
+                                    "type": "null"
+                                }, {
+                                    "$ref": "#/definitions/TestClass2(String)"
+                                }],
+                            "title": "TestClass2<String>",
+                            "description": "looked-up from method: TestClass2<String>",
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^generic.+$": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    }
-                }, {
-                    "title": "TestClass2<TestClass1[]>",
-                    "description": "looked-up from method: TestClass2<TestClass1[]>",
+                    },
+                    "title": "TestClass2<TestClass2<String>>",
+                    "description": "looked-up from method: TestClass2<TestClass2<String>>",
                     "additionalProperties": false,
                     "patternProperties": {
                         "^generic.+$": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/TestClass1"
-                            }
+                            "$ref": "#/definitions/TestClass2(String)"
                         }
                     }
-                }]
+                }
+            },
+            "title": "TestClass4<Integer, String>",
+            "description": "looked-up from method: TestClass4<Integer, String>",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "getNestedClass1Array()": {
+            "type": ["object", "null"],
+            "properties": {
+                "genericArray": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/TestClass1"
+                        }
+                    }
+                },
+                "getGenericValue()": {
+                    "title": "TestClass1[]",
+                    "description": "looked-up from method: TestClass1[]",
+                    "minItems": 2,
+                    "maxItems": 100,
+                    "uniqueItems": false,
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "#/definitions/TestClass1"
+                    }
+                }
+            },
+            "title": "TestClass2<TestClass1[]>",
+            "description": "looked-up from method: TestClass2<TestClass1[]>",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^generic.+$": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TestClass1"
+                    }
+                }
+            }
         },
         "getNestedLong()": {
-            "allOf": [{
-                    "oneOf": [{
-                            "type": "null"
-                        }, {
-                            "$ref": "#/definitions/TestClass2(Long)"
-                        }]
+            "oneOf": [{
+                    "type": "null"
                 }, {
-                    "title": "TestClass2<Long>",
-                    "description": "looked-up from method: TestClass2<Long>",
-                    "additionalProperties": false,
-                    "patternProperties": {
-                        "^generic.+$": {
-                            "type": "integer"
-                        }
-                    }
-                }]
+                    "$ref": "#/definitions/TestClass2(Long)"
+                }],
+            "title": "TestClass2<Long>",
+            "description": "looked-up from method: TestClass2<Long>",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^generic.+$": {
+                    "type": "integer"
+                }
+            }
         },
         "getNestedLongList()": {
             "title": "List<TestClass2<Long>>",

--- a/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-fieldattributes.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-fieldattributes.json
@@ -102,118 +102,106 @@
     "type": "object",
     "properties": {
         "class4": {
-            "allOf": [{
+            "type": ["object", "null"],
+            "properties": {
+                "class2OfClass2OfT": {
                     "type": ["object", "null"],
                     "properties": {
-                        "class2OfClass2OfT": {
-                            "allOf": [{
-                                    "type": ["object", "null"],
-                                    "properties": {
-                                        "genericArray": {
-                                            "title": "TestClass2[]<TestClass2<String>>",
-                                            "description": "looked-up from field: TestClass2[]<TestClass2<String>>",
-                                            "minItems": 2,
-                                            "maxItems": 100,
-                                            "uniqueItems": false,
-                                            "type": ["array", "null"],
-                                            "items": {
-                                                "$ref": "#/definitions/TestClass2(String)"
-                                            }
-                                        },
-                                        "genericValue": {
-                                            "allOf": [{
-                                                    "oneOf": [{
-                                                            "type": "null"
-                                                        }, {
-                                                            "$ref": "#/definitions/TestClass2(String)"
-                                                        }]
-                                                }, {
-                                                    "title": "TestClass2<String>",
-                                                    "description": "looked-up from field: TestClass2<String>",
-                                                    "additionalProperties": false,
-                                                    "patternProperties": {
-                                                        "^generic.+$": {
-                                                            "type": "string"
-                                                        }
-                                                    }
-                                                }]
-                                        }
-                                    }
-                                }, {
-                                    "title": "TestClass2<TestClass2<String>>",
-                                    "description": "looked-up from field: TestClass2<TestClass2<String>>",
-                                    "additionalProperties": false,
-                                    "patternProperties": {
-                                        "^generic.+$": {
-                                            "$ref": "#/definitions/TestClass2(String)"
-                                        }
-                                    }
-                                }]
-                        },
-                        "optionalS": {
-                            "type": ["integer", "null"],
-                            "title": "Integer",
-                            "description": "looked-up from field: Integer",
-                            "default": 1,
-                            "enum": [1, 2, 3, 4, 5],
-                            "minimum": 1,
-                            "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
-                            "exclusiveMaximum": 11,
-                            "multipleOf": 1
-                        }
-                    }
-                }, {
-                    "title": "TestClass4<Integer, String>",
-                    "description": "looked-up from field: TestClass4<Integer, String>",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }]
-        },
-        "nestedClass1Array": {
-            "allOf": [{
-                    "type": "object",
-                    "properties": {
                         "genericArray": {
-                            "title": "TestClass1[][]<TestClass1[]>",
-                            "description": "looked-up from field: TestClass1[][]<TestClass1[]>",
+                            "title": "TestClass2[]<TestClass2<String>>",
+                            "description": "looked-up from field: TestClass2[]<TestClass2<String>>",
                             "minItems": 2,
                             "maxItems": 100,
                             "uniqueItems": false,
                             "type": ["array", "null"],
                             "items": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/TestClass1"
-                                }
+                                "$ref": "#/definitions/TestClass2(String)"
                             }
                         },
                         "genericValue": {
-                            "title": "TestClass1[]",
-                            "description": "looked-up from field: TestClass1[]",
-                            "minItems": 2,
-                            "maxItems": 100,
-                            "uniqueItems": false,
-                            "type": ["array", "null"],
-                            "items": {
-                                "$ref": "#/definitions/TestClass1"
+                            "oneOf": [{
+                                    "type": "null"
+                                }, {
+                                    "$ref": "#/definitions/TestClass2(String)"
+                                }],
+                            "title": "TestClass2<String>",
+                            "description": "looked-up from field: TestClass2<String>",
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^generic.+$": {
+                                    "type": "string"
+                                }
                             }
                         }
-                    }
-                }, {
-                    "title": "TestClass2<TestClass1[]>",
-                    "description": "looked-up from field: TestClass2<TestClass1[]>",
+                    },
+                    "title": "TestClass2<TestClass2<String>>",
+                    "description": "looked-up from field: TestClass2<TestClass2<String>>",
                     "additionalProperties": false,
                     "patternProperties": {
                         "^generic.+$": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/TestClass1"
-                            }
+                            "$ref": "#/definitions/TestClass2(String)"
                         }
                     }
-                }]
+                },
+                "optionalS": {
+                    "type": ["integer", "null"],
+                    "title": "Integer",
+                    "description": "looked-up from field: Integer",
+                    "default": 1,
+                    "enum": [1, 2, 3, 4, 5],
+                    "minimum": 1,
+                    "exclusiveMinimum": 0,
+                    "maximum": 1E+1,
+                    "exclusiveMaximum": 11,
+                    "multipleOf": 1
+                }
+            },
+            "title": "TestClass4<Integer, String>",
+            "description": "looked-up from field: TestClass4<Integer, String>",
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "nestedClass1Array": {
+            "type": "object",
+            "properties": {
+                "genericArray": {
+                    "title": "TestClass1[][]<TestClass1[]>",
+                    "description": "looked-up from field: TestClass1[][]<TestClass1[]>",
+                    "minItems": 2,
+                    "maxItems": 100,
+                    "uniqueItems": false,
+                    "type": ["array", "null"],
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/TestClass1"
+                        }
+                    }
+                },
+                "genericValue": {
+                    "title": "TestClass1[]",
+                    "description": "looked-up from field: TestClass1[]",
+                    "minItems": 2,
+                    "maxItems": 100,
+                    "uniqueItems": false,
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "#/definitions/TestClass1"
+                    }
+                }
+            },
+            "title": "TestClass2<TestClass1[]>",
+            "description": "looked-up from field: TestClass2<TestClass1[]>",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^generic.+$": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TestClass1"
+                    }
+                }
+            }
         },
         "nestedLong": {
             "allOf": [{


### PR DESCRIPTION
- Removing unnecessary `allOf` elements when all contained attributes are distinct (i.e. can be merged into one schema without overriding each other).
- Allow co-existence of `$ref` with other attributes as per Draft 2019-09 (GH-14) but preserving previous behavior for Draft 7, where officially any attributes beside `$ref` were to be ignored.
- Introduce new `Option.ALLOF_CLEANUP_AT_THE_END` that is included in all standard `OptionPreset`s but can be turned off if desired (e.g. to preserve manually added `allOf` elements even though they are not necessary or in order to reduce overall schema generation time).