### PR TITLE
fix: handle multiple definitions with same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for "$id" property via `SchemaGeneratorGeneralConfigPart.withIdResolver()`
 - Support for "$anchor" property via `SchemaGeneratorGeneralConfigPart.withAnchorResolver()`
 
+### Fixed
+- Allow for multiple types with the same name (but different package) instead of picking one at random
+- Allow for multiple definitions for the same type (e.g. in case of a custom definition wrapping the standard definition)
+
 ### Deprecated
 - Configuration option for single target type override
 - Look-up of single target type override from configuration

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -199,7 +199,7 @@
         <!--<module name="FinalParameters" />-->
         <module name="InnerAssignment" />
         <module name="CyclomaticComplexity">
-            <property name="max" value="15"/>
+            <property name="max" value="16"/>
         </module>
     </module>
 </module>

--- a/src/main/java/com/github/victools/jsonschema/generator/TypeContext.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/TypeContext.java
@@ -207,12 +207,12 @@ public class TypeContext {
     }
 
     /**
-     * Returns the name to be associated with an entry in the generated schema's list of "definitions".
+     * Returns the name to be associated with an entry in the generated schema's list of "definitions"/"$defs".
      * <br>
-     * Beware: if multiple types have the same name, only one of them will be included in the schema's "definitions"
+     * Beware: if multiple types have the same name, the actual key in "definitions"/"$defs" may have a numeric counter appended to it
      *
-     * @param type the type to be represented in the generated schema's "definitions"
-     * @return name in "definitions"
+     * @param type the type to be represented in the generated schema's "definitions"/"$defs"
+     * @return name in "definitions"/"$defs"
      */
     public String getSchemaDefinitionName(ResolvedType type) {
         // known limitation: if two types have the same name and the only difference is their package, the resulting schema will only contain one

--- a/src/main/java/com/github/victools/jsonschema/generator/impl/DefinitionKey.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/impl/DefinitionKey.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.generator.impl;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2;
+
+/**
+ * Identifier for a particular sub-schema definition. This consists of the encountered type as well as some contextual information, as there may be
+ * multiple alternative definitions (e.g. a standard definition and one or multiple custom definitions) for a single type.
+ */
+public class DefinitionKey {
+
+    private final ResolvedType type;
+    private final CustomDefinitionProviderV2 ignoredDefinitionProvider;
+
+    /**
+     * Constructor.
+     *
+     * @param type encountered type a schema definition is associated with
+     * @param ignoredDefinitionProvider first custom definition provider that was ignored when creating the definition (is null in most cases)
+     */
+    DefinitionKey(ResolvedType type, CustomDefinitionProviderV2 ignoredDefinitionProvider) {
+        this.type = type;
+        this.ignoredDefinitionProvider = ignoredDefinitionProvider;
+    }
+
+    /**
+     * Getter for the associated java type.
+     *
+     * @return encountered type a schema definition is associated with
+     */
+    public ResolvedType getType() {
+        return this.type;
+    }
+
+    /**
+     * Getter for the a custom definition provider that was the first to be skipped during the generation of the schema definition. Ignoring a custom
+     * definition provider allows for the next custom definition provider to be applied, or if there is none or no custom definition is returned:
+     * falling-back on the standard definition for the targeted type.
+     *
+     * @return first custom definition provider that was ignored when creating the definition (is null in most cases)
+     */
+    CustomDefinitionProviderV2 getIgnoredDefinitionProvider() {
+        return this.ignoredDefinitionProvider;
+    }
+
+    /*
+     * Specific implementations of hashCode() and equals(Object) are required as this class is intended to be used as key in a Map.
+     */
+
+    @Override
+    public int hashCode() {
+        return this.type.hashCode()
+                + (this.ignoredDefinitionProvider == null ? 0 : this.ignoredDefinitionProvider.hashCode());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof DefinitionKey)) {
+            return false;
+        }
+        DefinitionKey otherReference = (DefinitionKey) other;
+        return this.type.equals(otherReference.getType()) && this.ignoredDefinitionProvider == otherReference.getIgnoredDefinitionProvider();
+    }
+}

--- a/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigPartTest.java
+++ b/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigPartTest.java
@@ -109,6 +109,7 @@ public class SchemaGeneratorConfigPartTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testTargetTypeOverride() {
         ResolvedType type1 = Mockito.mock(ResolvedType.class);
         ResolvedType type2 = Mockito.mock(ResolvedType.class);

--- a/src/test/java/com/github/victools/jsonschema/generator/impl/AttributeCollectorTest.java
+++ b/src/test/java/com/github/victools/jsonschema/generator/impl/AttributeCollectorTest.java
@@ -125,7 +125,7 @@ public class AttributeCollectorTest {
         Assert.assertNotNull(additionalPropertiesNode);
         Assert.assertTrue(additionalPropertiesNode.isObject());
         ResolvedType resolvedType = generationContext.getTypeContext().resolve(int.class);
-        Assert.assertTrue(generationContext.containsDefinition(resolvedType));
+        Assert.assertTrue(generationContext.containsDefinition(resolvedType, null));
     }
 
     @Test
@@ -155,7 +155,7 @@ public class AttributeCollectorTest {
         Assert.assertTrue(patternPropertiesNode.isObject());
         Assert.assertEquals(1, patternPropertiesNode.size());
         Assert.assertTrue(patternPropertiesNode.get("^objectClass.*$").isObject());
-        Assert.assertTrue(generationContext.containsDefinition(generationContext.getTypeContext().resolve(Object.class)));
+        Assert.assertTrue(generationContext.containsDefinition(generationContext.getTypeContext().resolve(Object.class), null));
     }
 
     @Test
@@ -171,7 +171,7 @@ public class AttributeCollectorTest {
         Assert.assertTrue(patternPropertiesNode.isObject());
         Assert.assertEquals(1, patternPropertiesNode.size());
         Assert.assertTrue(patternPropertiesNode.get("^resolvedObjectClass.*$").isObject());
-        Assert.assertTrue(generationContext.containsDefinition(generationContext.getTypeContext().resolve(Object.class)));
+        Assert.assertTrue(generationContext.containsDefinition(generationContext.getTypeContext().resolve(Object.class), null));
     }
 
     @Test
@@ -189,7 +189,7 @@ public class AttributeCollectorTest {
         Assert.assertEquals(2, patternPropertiesNode.size());
         Assert.assertTrue(patternPropertiesNode.get("^intClass.*$").isObject());
         Assert.assertTrue(patternPropertiesNode.get("^resolvedStringClass.*$").isObject());
-        Assert.assertTrue(generationContext.containsDefinition(generationContext.getTypeContext().resolve(int.class)));
-        Assert.assertTrue(generationContext.containsDefinition(generationContext.getTypeContext().resolve(String.class)));
+        Assert.assertTrue(generationContext.containsDefinition(generationContext.getTypeContext().resolve(int.class), null));
+        Assert.assertTrue(generationContext.containsDefinition(generationContext.getTypeContext().resolve(String.class), null));
     }
 }

--- a/src/test/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImplTest.java
+++ b/src/test/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImplTest.java
@@ -18,6 +18,7 @@ package com.github.victools.jsonschema.generator.impl;
 
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,69 +44,94 @@ public class SchemaGenerationContextImplTest {
     public void testHandlingDefinition_ExistentNode() {
         ResolvedType javaType = Mockito.mock(ResolvedType.class);
         ObjectNode definitionInput = Mockito.mock(ObjectNode.class);
-        SchemaGenerationContextImpl returnValue = this.context.putDefinition(javaType, definitionInput);
+        SchemaGenerationContextImpl returnValue = this.context.putDefinition(javaType, definitionInput, null);
 
         Assert.assertSame(this.context, returnValue);
-        Assert.assertTrue(this.context.containsDefinition(javaType));
-        Assert.assertSame(definitionInput, this.context.getDefinition(javaType));
-        Assert.assertEquals(Collections.singleton(javaType), this.context.getDefinedTypes());
+        Assert.assertTrue(this.context.containsDefinition(javaType, null));
+        DefinitionKey key = new DefinitionKey(javaType, null);
+        Assert.assertSame(definitionInput, this.context.getDefinition(key));
+        Assert.assertEquals(Collections.singleton(key), this.context.getDefinedTypes());
     }
 
     @Test
     public void testHandlingDefinition_EmptyContext() {
         ResolvedType javaType = Mockito.mock(ResolvedType.class);
+        DefinitionKey key = new DefinitionKey(javaType, null);
 
-        Assert.assertFalse(this.context.containsDefinition(javaType));
-        Assert.assertNull(this.context.getDefinition(javaType));
-        Assert.assertEquals(Collections.<ResolvedType>emptySet(), this.context.getDefinedTypes());
+        Assert.assertFalse(this.context.containsDefinition(javaType, null));
+        Assert.assertNull(this.context.getDefinition(key));
+        Assert.assertEquals(Collections.<DefinitionKey>emptySet(), this.context.getDefinedTypes());
     }
 
     @Test
     public void testReference_SameType() {
         ResolvedType javaType = Mockito.mock(ResolvedType.class);
+        DefinitionKey key = new DefinitionKey(javaType, null);
 
         // initially, all lists are empty
-        Assert.assertEquals(Collections.<ObjectNode>emptyList(), this.context.getReferences(javaType));
-        Assert.assertEquals(Collections.<ObjectNode>emptyList(), this.context.getNullableReferences(javaType));
+        Assert.assertEquals(Collections.<ObjectNode>emptyList(), this.context.getReferences(key));
+        Assert.assertEquals(Collections.<ObjectNode>emptyList(), this.context.getNullableReferences(key));
 
         // adding a not-nullable entry creates the "references" list
         ObjectNode referenceInputOne = Mockito.mock(ObjectNode.class);
-        SchemaGenerationContextImpl returnValue = this.context.addReference(javaType, referenceInputOne, false);
+        SchemaGenerationContextImpl returnValue = this.context.addReference(javaType, referenceInputOne, null, false);
         Assert.assertSame(this.context, returnValue);
-        Assert.assertEquals(Collections.singletonList(referenceInputOne), this.context.getReferences(javaType));
-        Assert.assertEquals(Collections.<ObjectNode>emptyList(), this.context.getNullableReferences(javaType));
+        Assert.assertEquals(Collections.singletonList(referenceInputOne), this.context.getReferences(key));
+        Assert.assertEquals(Collections.<ObjectNode>emptyList(), this.context.getNullableReferences(key));
 
         // adding another not-nullable entry adds it to the existing "references" list
         ObjectNode referenceInputTwo = Mockito.mock(ObjectNode.class);
-        returnValue = this.context.addReference(javaType, referenceInputTwo, false);
+        returnValue = this.context.addReference(javaType, referenceInputTwo, null, false);
         Assert.assertSame(this.context, returnValue);
-        Assert.assertEquals(Arrays.asList(referenceInputOne, referenceInputTwo), this.context.getReferences(javaType));
-        Assert.assertEquals(Collections.<ObjectNode>emptyList(), this.context.getNullableReferences(javaType));
+        Assert.assertEquals(Arrays.asList(referenceInputOne, referenceInputTwo), this.context.getReferences(key));
+        Assert.assertEquals(Collections.<ObjectNode>emptyList(), this.context.getNullableReferences(key));
 
         // adding a nullable entry creates the "nullableReferences" list
         ObjectNode referenceInputThree = Mockito.mock(ObjectNode.class);
-        returnValue = this.context.addReference(javaType, referenceInputThree, true);
+        returnValue = this.context.addReference(javaType, referenceInputThree, null, true);
         Assert.assertSame(this.context, returnValue);
-        Assert.assertEquals(Arrays.asList(referenceInputOne, referenceInputTwo), this.context.getReferences(javaType));
-        Assert.assertEquals(Collections.singletonList(referenceInputThree), this.context.getNullableReferences(javaType));
+        Assert.assertEquals(Arrays.asList(referenceInputOne, referenceInputTwo), this.context.getReferences(key));
+        Assert.assertEquals(Collections.singletonList(referenceInputThree), this.context.getNullableReferences(key));
     }
 
     @Test
     public void testReference_DifferentTypes() {
         ResolvedType javaTypeOne = Mockito.mock(ResolvedType.class);
+        DefinitionKey keyOne = new DefinitionKey(javaTypeOne, null);
         ResolvedType javaTypeTwo = Mockito.mock(ResolvedType.class);
+        DefinitionKey keyTwo = new DefinitionKey(javaTypeTwo, null);
 
         // adding an entry creates the "references" list for that type
         ObjectNode referenceInputOne = Mockito.mock(ObjectNode.class);
-        this.context.addReference(javaTypeOne, referenceInputOne, false);
-        Assert.assertEquals(Collections.singletonList(referenceInputOne), this.context.getReferences(javaTypeOne));
-        Assert.assertEquals(Collections.<ObjectNode>emptyList(), this.context.getReferences(javaTypeTwo));
+        this.context.addReference(javaTypeOne, referenceInputOne, null, false);
+        Assert.assertEquals(Collections.singletonList(referenceInputOne), this.context.getReferences(keyOne));
+        Assert.assertEquals(Collections.<ObjectNode>emptyList(), this.context.getReferences(keyTwo));
 
         // adding an entry for another type creates a separate "references" list for this other type
         ObjectNode referenceInputTwo = Mockito.mock(ObjectNode.class);
-        this.context.addReference(javaTypeTwo, referenceInputTwo, false);
-        Assert.assertEquals(Collections.singletonList(referenceInputOne), this.context.getReferences(javaTypeOne));
-        Assert.assertEquals(Collections.singletonList(referenceInputTwo), this.context.getReferences(javaTypeTwo));
+        this.context.addReference(javaTypeTwo, referenceInputTwo, null, false);
+        Assert.assertEquals(Collections.singletonList(referenceInputOne), this.context.getReferences(keyOne));
+        Assert.assertEquals(Collections.singletonList(referenceInputTwo), this.context.getReferences(keyTwo));
+    }
 
+    @Test
+    public void testReference_DifferentIgnoredDefinitionProvider() {
+        ResolvedType javaType = Mockito.mock(ResolvedType.class);
+        CustomDefinitionProviderV2 providerOne = null;
+        CustomDefinitionProviderV2 providerTwo = Mockito.mock(CustomDefinitionProviderV2.class);
+        DefinitionKey keyOne = new DefinitionKey(javaType, providerOne);
+        DefinitionKey keyTwo = new DefinitionKey(javaType, providerTwo);
+
+        // adding an entry creates the "references" list for that type
+        ObjectNode referenceInputOne = Mockito.mock(ObjectNode.class);
+        this.context.addReference(javaType, referenceInputOne, providerOne, false);
+        Assert.assertEquals(Collections.singletonList(referenceInputOne), this.context.getReferences(keyOne));
+        Assert.assertEquals(Collections.<ObjectNode>emptyList(), this.context.getReferences(keyTwo));
+
+        // adding an entry for the same type but other ignored definition provider creates a separate "references" list for this other type
+        ObjectNode referenceInputTwo = Mockito.mock(ObjectNode.class);
+        this.context.addReference(javaType, referenceInputTwo, providerTwo, false);
+        Assert.assertEquals(Collections.singletonList(referenceInputOne), this.context.getReferences(keyOne));
+        Assert.assertEquals(Collections.singletonList(referenceInputTwo), this.context.getReferences(keyTwo));
     }
 }

--- a/src/test/resources/com/github/victools/jsonschema/generator/multiple-definitions-one-type-DRAFT_2019_09.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/multiple-definitions-one-type-DRAFT_2019_09.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+        "String": {
+            "title": "Custom Definition #1 for String",
+            "anyOf": [{
+                    "type": "string"
+                }, {
+                    "type": "null"
+                }]
+        },
+        "TestDirectCircularClass-1": {
+            "type": "object",
+            "properties": {
+                "number": {
+                    "$ref": "#/$defs/int-2"
+                },
+                "self": {
+                    "$ref": "#"
+                },
+                "text": {
+                    "$ref": "#/$defs/String"
+                }
+            }
+        },
+        "TestDirectCircularClass-2": {
+            "title": "Custom Definition #2 for com.github.victools.jsonschema.generator.SchemaGeneratorCustomDefinitionsTest$TestDirectCircularClass",
+            "oneOf": [{
+                    "$ref": "#/$defs/TestDirectCircularClass-1"
+                }, {
+                    "type": "null"
+                }]
+        },
+        "int-1": {
+            "title": "Custom Definition #2 for int",
+            "oneOf": [{
+                    "type": "integer"
+                }, {
+                    "type": "null"
+                }]
+        },
+        "int-2": {
+            "title": "Custom Definition #1 for int",
+            "anyOf": [{
+                    "$ref": "#/$defs/int-1"
+                }, {
+                    "type": "null"
+                }]
+        }
+    },
+    "title": "Custom Definition #1 for TestDirectCircularClass",
+    "anyOf": [{
+            "$ref": "#/$defs/TestDirectCircularClass-2"
+        }, {
+            "type": "null"
+        }]
+}

--- a/src/test/resources/com/github/victools/jsonschema/generator/multiple-definitions-one-type-DRAFT_7.json
+++ b/src/test/resources/com/github/victools/jsonschema/generator/multiple-definitions-one-type-DRAFT_7.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "String": {
+            "title": "Custom Definition #1 for String",
+            "anyOf": [{
+                    "type": "string"
+                }, {
+                    "type": "null"
+                }]
+        },
+        "TestDirectCircularClass-1": {
+            "type": "object",
+            "properties": {
+                "number": {
+                    "$ref": "#/definitions/int-2"
+                },
+                "self": {
+                    "$ref": "#"
+                },
+                "text": {
+                    "$ref": "#/definitions/String"
+                }
+            }
+        },
+        "TestDirectCircularClass-2": {
+            "title": "Custom Definition #2 for com.github.victools.jsonschema.generator.SchemaGeneratorCustomDefinitionsTest$TestDirectCircularClass",
+            "oneOf": [{
+                    "$ref": "#/definitions/TestDirectCircularClass-1"
+                }, {
+                    "type": "null"
+                }]
+        },
+        "int-1": {
+            "title": "Custom Definition #2 for int",
+            "oneOf": [{
+                    "type": "integer"
+                }, {
+                    "type": "null"
+                }]
+        },
+        "int-2": {
+            "title": "Custom Definition #1 for int",
+            "anyOf": [{
+                    "$ref": "#/definitions/int-1"
+                }, {
+                    "type": "null"
+                }]
+        }
+    },
+    "title": "Custom Definition #1 for TestDirectCircularClass",
+    "anyOf": [{
+            "$ref": "#/definitions/TestDirectCircularClass-2"
+        }, {
+            "type": "null"
+        }]
+}


### PR DESCRIPTION
There was a limitation in the way non-inline definitions were remembered, which resulted in only one definition to be saved per type. This meant that using `SchemaGenerationContext.createStandardDefinitionReference()` in a custom definition resolver did not yield the expected results when the surrounding custom definition was not marked as to be "inline".

As a side-effect of this fix, another limitation is also being lifted: when multiple encountered types had the same class name (e.g. a "Vehicle" interface and a "Vehicle" class), the same issue occurred: only one entry was added to the schema's `definitions`.

Now, the different definitions are properly detected and added separately (with a numeric index appended to their key in the `definitions`, but only if necessary).
I.e. the previously correctly generated schemas are unaffected and are created exactly as before.