### PR TITLE
Custom Definitions for fields/methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for custom definitions in the scope of a particular field/method via `SchemaGeneratorConfigPart.withCustomDefinitionProvider()`
+- Ability to opt-out of normal "attribute collection" for custom definitions through new `CustomDefinition` constructor parameters
 
 ## [4.7.0] - 2020-03-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -188,3 +188,5 @@ configBuilder.forTypesInGeneral()
 |   31 | `maxItems` | Collected value according to configuration (`SchemaGeneratorConfigPart.withArrayMaxItemsResolver()`). |
 |   32 | `uniqueItems` | Collected value according to configuration (`SchemaGeneratorConfigPart.withArrayUniqueItemsResolver()`). |
 |   33 | any other | You can directly manipulate the generated `ObjectNode` of a sub-schema – e.g. setting additional attributes – via configuration based on a given type in general (`SchemaGeneratorConfigBuilder.with(TypeAttributeOverride)`) and/or in the context of a particular field/method (`SchemaGeneratorConfigPart.withInstanceAttributeOverride()`). |
+
+If all that is not flexible enough, you can freely define any schema definition for (parts of) your data structure through `SchemaGeneratorGeneralConfigPart.withCustomDefinitionProvider()`/`SchemaGeneratorConfigPart.withCustomDefinitionProvider()` respectively.

--- a/src/main/java/com/github/victools/jsonschema/generator/CustomDefinition.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/CustomDefinition.java
@@ -23,6 +23,19 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
  */
 public class CustomDefinition {
 
+    /**
+     * Alternative accessor for {@link DefinitionType#INLINE CustomDefinition.DefinitionType.INLINE}.
+     */
+    public static final DefinitionType INLINE_DEFINITION = DefinitionType.INLINE;
+    /**
+     * Alternative accessor for {@link AttributeInclusion#YES CustomDefinition.AttributeInclusion.YES}.
+     */
+    public static final AttributeInclusion INCLUDING_ATTRIBUTES = AttributeInclusion.YES;
+    /**
+     * Alternative accessor for {@link AttributeInclusion#NO CustomDefinition.AttributeInclusion.NO}.
+     */
+    public static final AttributeInclusion EXCLUDING_ATTRIBUTES = AttributeInclusion.NO;
+
     private final ObjectNode value;
     private final CustomDefinition.DefinitionType definitionType;
     private final AttributeInclusion attributeInclusion;
@@ -82,7 +95,7 @@ public class CustomDefinition {
      *
      * @return whether this custom definition should be inlined even if it occurs multiple times
      */
-    public boolean isMeantToBeInline() {
+    public final boolean isMeantToBeInline() {
         return this.definitionType == DefinitionType.INLINE;
     }
 

--- a/src/main/java/com/github/victools/jsonschema/generator/CustomPropertyDefinition.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/CustomPropertyDefinition.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.generator;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * The result of a custom definition look-up for a particular field/method.
+ */
+public final class CustomPropertyDefinition extends CustomDefinition {
+
+    /**
+     * Constructor for a custom property definition.
+     * <br>
+     * This is equivalent to calling {@code new CustomPropertyDefinition(value, CustomDefinition.AttributeInclusion.YES)}
+     *
+     * @param value generated custom definition
+     */
+    public CustomPropertyDefinition(ObjectNode value) {
+        this(value, CustomDefinition.AttributeInclusion.YES);
+    }
+
+    /**
+     * Constructor for a custom property definition.
+     *
+     * @param value generated custom definition
+     * @param attributeInclusion whether additional attributes should be applied on top of this custom definition
+     */
+    public CustomPropertyDefinition(ObjectNode value, CustomDefinition.AttributeInclusion attributeInclusion) {
+        super(value, DefinitionType.INLINE, attributeInclusion);
+    }
+}

--- a/src/main/java/com/github/victools/jsonschema/generator/CustomPropertyDefinitionProvider.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/CustomPropertyDefinitionProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.generator;
+
+/**
+ * Provider of non-standard JSON schema definitions.
+ *
+ * @param <M> either field or method for which a custom definition may be provided
+ */
+public interface CustomPropertyDefinitionProvider<M extends MemberScope<?, ?>> {
+
+    /**
+     * Look-up the non-standard JSON schema definition for a given property. If it returns null, the next definition provider is applied.
+     *
+     * @param scope targeted scope to provide custom definition for
+     * @param context generation context allowing to let the standard generation take over nested parts of the custom definition
+     * @return non-standard JSON schema definition (may be null)
+     */
+    CustomPropertyDefinition provideCustomSchemaDefinition(M scope, SchemaGenerationContext context);
+}

--- a/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerationContext.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerationContext.java
@@ -17,6 +17,8 @@
 package com.github.victools.jsonschema.generator;
 
 import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
@@ -100,6 +102,38 @@ public interface SchemaGenerationContext {
      * @see #createStandardDefinition(ResolvedType, CustomDefinitionProviderV2)
      */
     ObjectNode createStandardDefinitionReference(ResolvedType targetType, CustomDefinitionProviderV2 ignoredDefinitionProvider);
+
+    /**
+     * Create a standard definition for the given property. Ignoring custom definitions up to the given one, but respecting others.
+     * <br>
+     * If a specific custom definition for this field is being applied, it will be inlined and fully populated; that may be further manipulated.
+     * Otherwise, the returned node will be empty and is populated only later, i.e. it should not be changed in that case!
+     *
+     * @param targetScope property to create definition (reference) node for
+     * @param ignoredDefinitionProvider custom definition provider to ignore
+     * @return either custom inline definition for this field or a (temporarily) empty reference node for the targetType that will only be populated
+     *         at the very end of the schema generation
+     *
+     * @see #createDefinitionReference(ResolvedType)
+     */
+    ObjectNode createStandardDefinitionReference(FieldScope targetScope, CustomPropertyDefinitionProvider<FieldScope> ignoredDefinitionProvider);
+
+    /**
+     * Create a standard definition for the given property. Ignoring custom definitions up to the given one, but respecting others.
+     * <br>
+     * If a specific custom definition for this method is being applied, it will be inlined and fully populated; that may be further manipulated.
+     * Otherwise, the returned node will be empty and is populated only later, i.e. it should not be changed in that case!
+     * <br>
+     * The returned type is always an {@link ObjectNode} unless the given method is {@code void}, which will result in a {@link BooleanNode#FALSE}.
+     *
+     * @param targetScope property to create definition (reference) node for
+     * @param ignoredDefinitionProvider custom definition provider to ignore
+     * @return either custom inline definition for this method or a (temporarily) empty reference node for the targetType that will only be populated
+     *         at the very end of the schema generation
+     *
+     * @see #createDefinitionReference(ResolvedType)
+     */
+    JsonNode createStandardDefinitionReference(MethodScope targetScope, CustomPropertyDefinitionProvider<MethodScope> ignoredDefinitionProvider);
 
     /**
      * Ensure that the JSON schema represented by the given node allows for it to be of "type" "null".

--- a/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
@@ -110,6 +110,19 @@ public interface SchemaGeneratorConfig {
     ArrayNode createArrayNode();
 
     /**
+     * Look-up the non-standard JSON schema definition for a given property. Falling-back on the per-type custom definitions.
+     *
+     * @param <M> type of targeted property
+     * @param scope targeted scope for which to provide a custom definition
+     * @param context generation context allowing to let the standard generation take over nested parts of the custom definition
+     * @param ignoredDefinitionProvider custom definition provider to ignore
+     * @return non-standard JSON schema definition for the given field/method (may be null)
+     * @see #getCustomDefinition(ResolvedType, SchemaGenerationContext, CustomDefinitionProviderV2)
+     */
+    <M extends MemberScope<?, ?>> CustomDefinition getCustomDefinition(M scope, SchemaGenerationContext context,
+            CustomPropertyDefinitionProvider<M> ignoredDefinitionProvider);
+
+    /**
      * Look-up the non-standard JSON schema definition for a given type. If this returns null, the standard behaviour is expected to be applied.
      *
      * @param javaType generic type to provide custom definition for

--- a/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigPart.java
+++ b/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigPart.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
  */
 public class SchemaGeneratorConfigPart<M extends MemberScope<?, ?>> extends SchemaGeneratorTypeConfigPart<M> {
 
+    private final List<CustomPropertyDefinitionProvider<M>> customDefinitionProviders = new ArrayList<>();
     private final List<InstanceAttributeOverride<M>> instanceAttributeOverrides = new ArrayList<>();
 
     /*
@@ -52,6 +53,28 @@ public class SchemaGeneratorConfigPart<M extends MemberScope<?, ?>> extends Sche
      */
     private final List<ConfigFunction<M, List<ResolvedType>>> targetTypeOverridesResolvers = new ArrayList<>();
     private final List<ConfigFunction<M, String>> propertyNameOverrideResolvers = new ArrayList<>();
+
+    /**
+     * Adding a custom schema provider – if it returns null for a given type, the next definition provider will be applied.
+     * <br>
+     * If all custom property schema providers return null (or there is none), then the general type custom schema providers apply.
+     *
+     * @param definitionProvider provider of a custom property definition to register, which may return null
+     * @return this builder instance (for chaining)
+     */
+    public SchemaGeneratorConfigPart<M> withCustomDefinitionProvider(CustomPropertyDefinitionProvider<M> definitionProvider) {
+        this.customDefinitionProviders.add(definitionProvider);
+        return this;
+    }
+
+    /**
+     * Getter for the applicable custom property definition provider.
+     *
+     * @return providers for certain custom definitions by-passing the default schema generation to some extent
+     */
+    public List<CustomPropertyDefinitionProvider<M>> getCustomDefinitionProviders() {
+        return Collections.unmodifiableList(this.customDefinitionProviders);
+    }
 
     /**
      * Setter for override of attributes on a given JSON Schema node in the respective member.


### PR DESCRIPTION
In some circumstances, there may be the need to assign custom definitions in the scope of a particular property, e.g. when considering per-property annotations that override the per-type behavior.