### PR TITLE
Basic Container Item Annotation Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### `jsonschema-generator`
+#### Added
+- Convenience methods on `FieldScope`/`MethodScope` for accessing (first level) container item annotations: `getContainerItemAnnotation()` and `getContainerItemAnnotationConsideringFieldAndGetter()`
+
+#### Changed
+- `MethodScope.getAnnotation()` now also considers annotations directly on return type (when no matching annotation was found on the method itself)
+
+### `jsonschema-module-javax-validation`
+#### Changed
+- Consider (first level) container item annotations (e.g. List<@Size(min = 3) String>`)
+
 ## [4.8.1] - 2020-03-31
 ### All
 #### Fixed
@@ -297,6 +309,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Indicate a number's "exclusiveMaximum" according to `@DecimalMax` or `@Negative`
 
 
+[Unreleased]: https://github.com/victools/jsonschema-generator/compare/v4.8.1...HEAD
+[4.8.1]: https://github.com/victools/jsonschema-generator/compare/v4.8.0...v4.8.2
 [4.8.0]: https://github.com/victools/jsonschema-generator/compare/v4.7.0...v4.8.0
 [4.7.0]: https://github.com/victools/jsonschema-generator/compare/v4.6.0...v4.7.0
 [4.6.0]: https://github.com/victools/jsonschema-generator/compare/v4.5.0...v4.6.0

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/MemberScope.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/MemberScope.java
@@ -264,6 +264,16 @@ public abstract class MemberScope<M extends ResolvedMember<T>, T extends Member>
     }
 
     /**
+     * Return the annotation of the given type on the member's container item (i.e. first type parameter if there is one), if such an annotation is
+     * present on either the field or its getter.
+     *
+     * @param <A> type of annotation
+     * @param annotationClass type of annotation
+     * @return annotation instance (or {@code null} if no annotation of the given type is present)
+     */
+    public abstract <A extends Annotation> A getContainerItemAnnotation(Class<A> annotationClass);
+
+    /**
      * Return the annotation of the given type on the member, if such an annotation is present on either the field or its getter.
      *
      * @param <A> type of annotation
@@ -271,6 +281,16 @@ public abstract class MemberScope<M extends ResolvedMember<T>, T extends Member>
      * @return annotation instance (or {@code null} if no annotation of the given type is present)
      */
     public abstract <A extends Annotation> A getAnnotationConsideringFieldAndGetter(Class<A> annotationClass);
+
+    /**
+     * Return the annotation of the given type on the member's container item (i.e. first type parameter if there is one), if such an annotation is
+     * present on either the field or its getter.
+     *
+     * @param <A> type of annotation
+     * @param annotationClass type of annotation
+     * @return annotation instance (or {@code null} if no annotation of the given type is present)
+     */
+    public abstract <A extends Annotation> A getContainerItemAnnotationConsideringFieldAndGetter(Class<A> annotationClass);
 
     /**
      * Returns the name to be used to reference this member in its parent's "properties".

--- a/jsonschema-module-javax-validation/src/test/java/com/github/victools/jsonschema/module/javax/validation/IntegrationTest.java
+++ b/jsonschema-module-javax-validation/src/test/java/com/github/victools/jsonschema/module/javax/validation/IntegrationTest.java
@@ -90,11 +90,11 @@ public class IntegrationTest {
         public Object nullObject;
 
         @NotNull
-        public List<String> notNullList;
+        public List<@Min(2) @Max(2048) Integer> notNullList;
         @NotEmpty
-        public List<String> notEmptyList;
+        public List<@DecimalMin(value = "0", inclusive = false) @DecimalMax(value = "1", inclusive = false) Double> notEmptyList;
         @Size(min = 3, max = 25)
-        public List<String> sizeRangeList;
+        public List<@NotEmpty @Size(max = 100) String> sizeRangeList;
 
         @NotNull
         @Email(regexp = ".+@.+\\..+")

--- a/jsonschema-module-javax-validation/src/test/resources/com/github/victools/jsonschema/module/javax/validation/integration-test-result.json
+++ b/jsonschema-module-javax-validation/src/test/resources/com/github/victools/jsonschema/module/javax/validation/integration-test-result.json
@@ -19,7 +19,9 @@
             "minItems": 1,
             "type": "array",
             "items": {
-                "type": "string"
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "exclusiveMaximum": 1
             }
         },
         "notEmptyPatternText": {
@@ -35,7 +37,9 @@
         "notNullList": {
             "type": "array",
             "items": {
-                "type": "string"
+                "type": "integer",
+                "minimum": 2,
+                "maximum": 2048
             }
         },
         "nullObject": {},
@@ -44,7 +48,9 @@
             "maxItems": 25,
             "type": ["array", "null"],
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
             }
         },
         "sizeRangeText": {

--- a/jsonschema-module-swagger-1.5/src/test/java/com/github/victools/jsonschema/module/swagger15/IntegrationTest.java
+++ b/jsonschema-module-swagger-1.5/src/test/java/com/github/victools/jsonschema/module/swagger15/IntegrationTest.java
@@ -27,6 +27,7 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Scanner;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -80,7 +81,7 @@ public class IntegrationTest {
         public Object hiddenField;
 
         @ApiModelProperty(name = "fieldWithOverriddenName")
-        public boolean originalFieldName;
+        public List<Boolean> originalFieldName;
 
         @ApiModelProperty(value = "field description", allowableValues = "A, B,    C, D")
         public String fieldWithDescriptionAndAllowableValues;

--- a/jsonschema-module-swagger-1.5/src/test/java/com/github/victools/jsonschema/module/swagger15/SwaggerModuleTest.java
+++ b/jsonschema-module-swagger-1.5/src/test/java/com/github/victools/jsonschema/module/swagger15/SwaggerModuleTest.java
@@ -27,6 +27,7 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.List;
 import java.util.function.Predicate;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -219,19 +220,24 @@ public class SwaggerModuleTest {
 
     Object parametersForTestTitleResolver() {
         return new Object[][]{
-            {"unannotatedField", null},
-            {"exampleWithEmptyApiModel", null},
-            {"exampleWithApiModelTitle", "example title"}
+            {"unannotatedField", false, null},
+            {"exampleWithEmptyApiModel", false, null},
+            {"exampleWithApiModelTitle", false, "example title"},
+            {"listExampleWithApiModelTitle", false, null},
+            {"listExampleWithApiModelTitle", true, "example title"}
         };
     }
 
     @Test
     @Parameters
-    public void testTitleResolver(String fieldName, String expectedTitle) {
+    public void testTitleResolver(String fieldName, boolean asContainerItem, String expectedTitle) {
         new SwaggerModule().applyToConfigBuilder(this.configBuilder);
 
         TestType testType = new TestType(TestClassForDescription.class);
         FieldScope field = testType.getMemberField(fieldName);
+        if (asContainerItem) {
+            field = field.asFakeContainerItemScope();
+        }
 
         ArgumentCaptor<ConfigFunction<TypeScope, String>> captor = ArgumentCaptor.forClass(ConfigFunction.class);
         Mockito.verify(this.typesInGeneralConfigPart).withTitleResolver(captor.capture());
@@ -241,25 +247,30 @@ public class SwaggerModuleTest {
 
     Object parametersForTestDescriptionResolver() {
         return new Object[][]{
-            {"unannotatedField", null, null},
-            {"annotatedWithoutValueField", null, null},
-            {"annotatedWithoutValueGetterField", null, null},
-            {"annotatedField", "annotation value 1", null},
-            {"annotatedGetterField", "annotation value 2", null},
-            {"exampleWithEmptyApiModel", null, null},
-            {"exampleWithApiModelDescription", null, "type description"},
-            {"exampleWithTwoDescriptions", "property description", "type description"},
-            {"exampleWithApiModelTitle", null, null}
+            {"unannotatedField", false, null, null},
+            {"annotatedWithoutValueField", false, null, null},
+            {"annotatedWithoutValueGetterField", false, null, null},
+            {"annotatedField", false, "annotation value 1", null},
+            {"annotatedGetterField", false, "annotation value 2", null},
+            {"exampleWithEmptyApiModel", false, null, null},
+            {"exampleWithApiModelDescription", false, null, "type description"},
+            {"arrayExampleWithApiModelDescription", false, null, null},
+            {"arrayExampleWithApiModelDescription", true, null, "type description"},
+            {"exampleWithTwoDescriptions", false, "property description", "type description"},
+            {"exampleWithApiModelTitle", false, null, null}
         };
     }
 
     @Test
     @Parameters
-    public void testDescriptionResolver(String fieldName, String expectedMemberDescription, String expectedTypeDescription) {
+    public void testDescriptionResolver(String fieldName, boolean asContainerItem, String expectedMemberDescription, String expectedTypeDescription) {
         new SwaggerModule().applyToConfigBuilder(this.configBuilder);
 
         TestType testType = new TestType(TestClassForDescription.class);
         FieldScope field = testType.getMemberField(fieldName);
+        if (asContainerItem) {
+            field = field.asFakeContainerItemScope();
+        }
 
         ArgumentCaptor<ConfigFunction<FieldScope, String>> memberCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
         Mockito.verify(this.fieldConfigPart).withDescriptionResolver(memberCaptor.capture());
@@ -307,34 +318,39 @@ public class SwaggerModuleTest {
 
     Object parametersForTestNumberMinMaxResolvers() {
         return new Object[][]{
-            {"unannotatedInt", null, null, null, null},
-            {"minMinusHundredLong", "-100", null, null, null},
-            {"minMinusHundredOnGetterLong", "-100", null, null, null},
-            {"maxFiftyShort", null, null, "50", null},
-            {"maxFiftyOnGetterShort", null, null, "50", null},
-            {"tenToTwentyInclusiveDouble", "10.1", null, "20.2", null},
-            {"tenToTwentyInclusiveOnGetterDouble", "10.1", null, "20.2", null},
-            {"tenToTwentyExclusiveDecimal", null, "10.1", null, "20.2"},
-            {"tenToTwentyExclusiveOnGetterDecimal", null, "10.1", null, "20.2"},
-            {"positiveByte", null, BigDecimal.ZERO, null, null},
-            {"positiveOnGetterByte", null, BigDecimal.ZERO, null, null},
-            {"positiveOrZeroBigInteger", BigDecimal.ZERO, null, null, null},
-            {"positiveOrZeroOnGetterBigInteger", BigDecimal.ZERO, null, null, null},
-            {"negativeDecimal", null, null, null, BigDecimal.ZERO},
-            {"negativeOnGetterDecimal", null, null, null, BigDecimal.ZERO},
-            {"negativeOrZeroLong", null, null, BigDecimal.ZERO, null},
-            {"negativeOrZeroOnGetterLong", null, null, BigDecimal.ZERO, null}
+            {"unannotatedInt", false, null, null, null, null},
+            {"unannotatedIntArray", false, null, null, null, null},
+            {"unannotatedIntArray", true, null, null, null, null},
+            {"minMinusHundredLong", false, "-100", null, null, null},
+            {"minMinusHundredOnGetterLong", false, "-100", null, null, null},
+            {"maxFiftyShort", false, null, null, "50", null},
+            {"maxFiftyOnGetterShort", false, null, null, "50", null},
+            {"tenToTwentyInclusiveDouble", false, "10.1", null, "20.2", null},
+            {"tenToTwentyInclusiveOnGetterDouble", false, "10.1", null, "20.2", null},
+            {"tenToTwentyExclusiveDecimal", false, null, "10.1", null, "20.2"},
+            {"tenToTwentyExclusiveOnGetterDecimal", false, null, "10.1", null, "20.2"},
+            {"positiveByte", false, null, BigDecimal.ZERO, null, null},
+            {"positiveOnGetterByte", false, null, BigDecimal.ZERO, null, null},
+            {"positiveOrZeroBigInteger", false, BigDecimal.ZERO, null, null, null},
+            {"positiveOrZeroOnGetterBigInteger", false, BigDecimal.ZERO, null, null, null},
+            {"negativeDecimal", false, null, null, null, BigDecimal.ZERO},
+            {"negativeOnGetterDecimal", false, null, null, null, BigDecimal.ZERO},
+            {"negativeOrZeroLong", false, null, null, BigDecimal.ZERO, null},
+            {"negativeOrZeroOnGetterLong", false, null, null, BigDecimal.ZERO, null}
         };
     }
 
     @Test
     @Parameters
-    public void testNumberMinMaxResolvers(String fieldName, BigDecimal expectedMinInclusive, BigDecimal expectedMinExclusive,
+    public void testNumberMinMaxResolvers(String fieldName, boolean asContainerItem, BigDecimal expectedMinInclusive, BigDecimal expectedMinExclusive,
             BigDecimal expectedMaxInclusive, BigDecimal expectedMaxExclusive) throws Exception {
         new SwaggerModule().applyToConfigBuilder(this.configBuilder);
 
         TestType testType = new TestType(TestClassForNumberMinMax.class);
         FieldScope field = testType.getMemberField(fieldName);
+        if (asContainerItem) {
+            field = field.asFakeContainerItemScope();
+        }
 
         ArgumentCaptor<ConfigFunction<FieldScope, BigDecimal>> minInclusiveCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
         Mockito.verify(this.fieldConfigPart).withNumberInclusiveMinimumResolver(minInclusiveCaptor.capture());
@@ -409,14 +425,16 @@ public class SwaggerModuleTest {
         int annotatedWithoutValueField;
         double annotatedWithoutValueGetterField;
         @ApiModelProperty(value = "annotation value 1")
-        Object annotatedField;
+        List<Object> annotatedField;
         boolean annotatedGetterField;
 
         ExampleWithEmptyApiModel exampleWithEmptyApiModel;
         ExampleWithApiModelDescription exampleWithApiModelDescription;
+        ExampleWithApiModelDescription[] arrayExampleWithApiModelDescription;
         @ApiModelProperty(value = "property description")
         ExampleWithApiModelDescription exampleWithTwoDescriptions;
         ExampleWithApiModelTitle exampleWithApiModelTitle;
+        List<ExampleWithApiModelTitle> listExampleWithApiModelTitle;
 
         public String getUnannotatedField() {
             return this.unannotatedField;
@@ -431,7 +449,7 @@ public class SwaggerModuleTest {
             return this.annotatedWithoutValueGetterField;
         }
 
-        public Object getAnnotatedField() {
+        public List<Object> getAnnotatedField() {
             return this.annotatedField;
         }
 
@@ -489,6 +507,7 @@ public class SwaggerModuleTest {
     private static class TestClassForNumberMinMax {
 
         int unannotatedInt;
+        int[] unannotatedIntArray;
         @ApiModelProperty(allowableValues = "range[-100, infinity)")
         long minMinusHundredLong;
         long minMinusHundredOnGetterLong;

--- a/jsonschema-module-swagger-1.5/src/test/resources/com/github/victools/jsonschema/module/swagger15/integration-test-result.json
+++ b/jsonschema-module-swagger-1.5/src/test/resources/com/github/victools/jsonschema/module/swagger15/integration-test-result.json
@@ -17,7 +17,10 @@
             "maximum": 20
         },
         "fieldWithOverriddenName": {
-            "type": "boolean"
+            "type": ["array", "null"],
+            "items": {
+                "type": "boolean"
+            }
         }
     },
     "title": "test title",


### PR DESCRIPTION
These changes should cover the majority of use-cases as per #60 for container items.

This is explicitly _not_ covering other generics such as `Optional<@NotBlank String>`.

Since the `classmate` library used for type resolution currently does not include the `AnnotatedType` (introduced in Java 8), some additional changes will be required to make this work for more than the first level of container items.
At that time, a more generic approach can be taken to support other parameterized types besides collections.

----

### `jsonschema-generator`
#### Added
- Convenience methods on `FieldScope`/`MethodScope` for accessing (first level) container item annotations: `getContainerItemAnnotation()` and `getContainerItemAnnotationConsideringFieldAndGetter()`

#### Changed
- `MethodScope.getAnnotation()` now also considers annotations directly on return type (when no matching annotation was found on the method itself)

### `jsonschema-module-javax-validation`
#### Changed
- Consider (first level) container item annotations (e.g. List<@Size(min = 3) String>`)