### PR TITLE
Inline all the things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-generator`
+#### Changed
+- Enhance `Option.ALLOF_CLEANUP_AT_THE_END` to also reduce `allOf` if multiple parts have the same attributes but with equal values
+
 ### `jsonschema-module-jackson`
 #### Added
 - New `JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY` to allow enum serialization based on each constant's `@JsonProperty` value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### `jsonschema-generator`
+#### Added
+- New `Option.INLINE_ALL_SCHEMAS` to enforce no `definitions`/`$defs` to be produced (throwing exception if there is at least one circular reference)
+
 #### Changed
 - Enhance `Option.ALLOF_CLEANUP_AT_THE_END` to also reduce `allOf` if multiple parts have the same attributes but with equal values
 

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/Option.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/Option.java
@@ -21,6 +21,7 @@ import com.github.victools.jsonschema.generator.impl.module.ConstantValueModule;
 import com.github.victools.jsonschema.generator.impl.module.EnumModule;
 import com.github.victools.jsonschema.generator.impl.module.FieldExclusionModule;
 import com.github.victools.jsonschema.generator.impl.module.FlattenedOptionalModule;
+import com.github.victools.jsonschema.generator.impl.module.InlineSchemaModule;
 import com.github.victools.jsonschema.generator.impl.module.MethodExclusionModule;
 import com.github.victools.jsonschema.generator.impl.module.SimpleTypeModule;
 import com.github.victools.jsonschema.generator.impl.module.SimplifiedOptionalModule;
@@ -206,6 +207,15 @@ public enum Option {
      * Default: false (disabled)
      */
     DEFINITIONS_FOR_ALL_OBJECTS(null, null),
+    /**
+     * Whether all sub-schemas should be defined in-line, i.e. including no "definitions"/"$defs". This takes precedence over
+     * {@link #DEFINITIONS_FOR_ALL_OBJECTS}.
+     * <br>
+     * Beware: This will result in an exception being thrown if a single circular reference is being encountered!
+     * <br>
+     * Default: false (disabled)
+     */
+    INLINE_ALL_SCHEMAS(InlineSchemaModule::new, null, Option.DEFINITIONS_FOR_ALL_OBJECTS),
     /**
      * Whether as the last step of the schema generation, unnecessary "allOf" elements (i.e. where there are no conflicts/overlaps between the
      * contained sub-schemas) should be merged into one, in order to make the generated schema more readable. This also applies to manually added

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
@@ -119,7 +119,8 @@ public class SchemaGenerator {
                     && !mainSchemaKey.equals(definitionKey);
             if (referenceInline) {
                 // it is a simple type, just in-line the sub-schema everywhere
-                references.forEach(node -> node.setAll(generationContext.getDefinition(definitionKey)));
+                ObjectNode definition = generationContext.getDefinition(definitionKey);
+                references.forEach(node -> AttributeCollector.mergeMissingAttributes(node, definition));
                 referenceKey = null;
             } else {
                 // the same sub-schema is referenced in multiple places
@@ -146,7 +147,7 @@ public class SchemaGenerator {
                     nullableReferences.forEach(node -> node.put(this.config.getKeyword(SchemaKeyword.TAG_REF),
                             this.config.getKeyword(SchemaKeyword.TAG_REF_PREFIX) + nullableDefinitionName));
                 } else {
-                    nullableReferences.forEach(node -> node.setAll(definition));
+                    nullableReferences.forEach(node -> AttributeCollector.mergeMissingAttributes(node, definition));
                 }
             }
         }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
@@ -49,11 +49,18 @@ public interface SchemaGeneratorConfig {
     String getKeyword(SchemaKeyword keyword);
 
     /**
-     * Determine whether all referenced objects should be listed in the schema's "definitions", even if they only occur once.
+     * Determine whether all referenced objects should be listed in the schema's "definitions"/"$defs", even if they only occur once.
      *
      * @return whether to add a definition even for objects occurring only once
      */
     boolean shouldCreateDefinitionsForAllObjects();
+
+    /**
+     * Determine whether all sub-schemas should be included in-line, even if they occur multiple times, and not in the schema's "definitions"/"$defs".
+     *
+     * @return whether to include all sub-schemas in-line
+     */
+    boolean shouldInlineAllSchemas();
 
     /**
      * Determine whether the {@link SchemaKeyword#TAG_SCHEMA} attribute with {@link SchemaKeyword#TAG_SCHEMA_VALUE} should be added.

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/AttributeCollector.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/AttributeCollector.java
@@ -18,6 +18,7 @@ package com.github.victools.jsonschema.generator.impl;
 
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -32,6 +33,7 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -168,6 +170,25 @@ public class AttributeCollector {
             collector.setArrayUniqueItems(node, config.resolveArrayUniqueItemsForType(scope), generationContext);
         }
         return node;
+    }
+
+    /**
+     * Merge the second node's attributes into the first, skipping those attributes that are already contained in the first node.
+     *
+     * @param targetNode node to add non-existent attributes to
+     * @param attributeContainer container holding attributes to add to the first node
+     */
+    public static void mergeMissingAttributes(ObjectNode targetNode, ObjectNode attributeContainer) {
+        if (attributeContainer == null) {
+            return;
+        }
+        Iterator<Map.Entry<String, JsonNode>> attributeIterator = attributeContainer.fields();
+        while (attributeIterator.hasNext()) {
+            Map.Entry<String, JsonNode> attribute = attributeIterator.next();
+            if (!targetNode.has(attribute.getKey())) {
+                targetNode.set(attribute.getKey(), attribute.getValue());
+            }
+        }
     }
 
     /**

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
@@ -109,6 +109,11 @@ public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
     }
 
     @Override
+    public boolean shouldInlineAllSchemas() {
+        return this.isOptionEnabled(Option.INLINE_ALL_SCHEMAS);
+    }
+
+    @Override
     public boolean shouldCleanupUnnecessaryAllOfElements() {
         return this.isOptionEnabled(Option.ALLOF_CLEANUP_AT_THE_END);
     }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/InlineSchemaModule.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/InlineSchemaModule.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.generator.impl.module;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.CustomDefinition;
+import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2;
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.SchemaGenerationContext;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import java.util.Deque;
+import java.util.LinkedList;
+
+/**
+ * Default module being included if {@code Option.INLINE_ALL_SCHEMAS} is enabled.
+ */
+public class InlineSchemaModule implements Module, CustomDefinitionProviderV2 {
+
+    private final Deque<ResolvedType> declaringTypes = new LinkedList<>();
+
+    @Override
+    public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+        builder.forTypesInGeneral().withCustomDefinitionProvider(this);
+    }
+
+    @Override
+    public CustomDefinition provideCustomSchemaDefinition(ResolvedType javaType, SchemaGenerationContext context) {
+        if (this.declaringTypes.contains(javaType)) {
+            throw new IllegalArgumentException("Option.INLINE_ALL_SCHEMAS cannot be fulfilled due to a circular reference to "
+                    + context.getTypeContext().getFullTypeDescription(javaType));
+        }
+        if (context.getTypeContext().isContainerType(javaType)) {
+            // container types are being in-lined by default and only handle container-item-scope if the container itself is not a custom definition
+            return null;
+        }
+        this.declaringTypes.addLast(javaType);
+        ObjectNode definition = context.createStandardDefinition(javaType, this);
+        this.declaringTypes.removeLast();
+        return new CustomDefinition(definition, true);
+    }
+}

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-fieldattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-fieldattributes.json
@@ -1,127 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "definitions": {
-        "TestClass1": {
-            "type": "object",
-            "properties": {
-                "genericArray": {
-                    "title": "String[]<String>",
-                    "description": "looked-up from field: String[]<String>",
-                    "minItems": 2,
-                    "maxItems": 100,
-                    "uniqueItems": false,
-                    "type": ["array", "null"],
-                    "items": {
-                        "type": "string",
-                        "title": "String",
-                        "description": "looked-up from field: String",
-                        "const": "constant string value",
-                        "minLength": 1,
-                        "maxLength": 256,
-                        "format": "date",
-                        "pattern": "^.{1,256}$"
-                    }
-                },
-                "genericValue": {
-                    "type": ["string", "null"],
-                    "title": "String",
-                    "description": "looked-up from field: String",
-                    "const": "constant string value",
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
-                },
-                "ignoredInternalValue": {
-                    "type": ["integer", "null"],
-                    "title": "Integer",
-                    "description": "looked-up from field: Integer",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
-                },
-                "primitiveValue": {
-                    "type": ["integer", "null"],
-                    "title": "int",
-                    "description": "looked-up from field: int"
-                }
-            }
-        },
-        "TestClass2(Long)": {
-            "type": "object",
-            "properties": {
-                "genericArray": {
-                    "title": "Long[]<Long>",
-                    "description": "looked-up from field: Long[]<Long>",
-                    "minItems": 2,
-                    "maxItems": 100,
-                    "uniqueItems": false,
-                    "type": ["array", "null"],
-                    "items": {
-                        "type": "integer",
-                        "title": "Long",
-                        "description": "looked-up from field: Long",
-                        "default": 1,
-                        "enum": [1, 2, 3, 4, 5],
-                        "minimum": 1,
-                        "exclusiveMinimum": 0,
-                        "maximum": 1E+1,
-                        "exclusiveMaximum": 11,
-                        "multipleOf": 1
-                    }
-                },
-                "genericValue": {
-                    "type": ["integer", "null"],
-                    "title": "Long",
-                    "description": "looked-up from field: Long",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
-                }
-            }
-        },
-        "TestClass2(String)": {
-            "type": "object",
-            "properties": {
-                "genericArray": {
-                    "title": "String[]<String>",
-                    "description": "looked-up from field: String[]<String>",
-                    "minItems": 2,
-                    "maxItems": 100,
-                    "uniqueItems": false,
-                    "type": ["array", "null"],
-                    "items": {
-                        "type": "string",
-                        "title": "String",
-                        "description": "looked-up from field: String",
-                        "const": "constant string value",
-                        "minLength": 1,
-                        "maxLength": 256,
-                        "format": "date",
-                        "pattern": "^.{1,256}$"
-                    }
-                },
-                "genericValue": {
-                    "type": ["string", "null"],
-                    "title": "String",
-                    "description": "looked-up from field: String",
-                    "const": "constant string value",
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
-                }
-            }
-        }
-    },
     "type": "object",
     "properties": {
         "class4": {
@@ -138,26 +16,79 @@
                             "uniqueItems": false,
                             "type": ["array", "null"],
                             "items": {
-                                "allOf": [{
-                                        "$ref": "#/definitions/TestClass2(String)"
-                                    }, {
-                                        "title": "TestClass2<String>",
-                                        "description": "looked-up from field: TestClass2<String>",
-                                        "additionalProperties": false,
-                                        "patternProperties": {
-                                            "^generic.+$": {
-                                                "type": "string"
-                                            }
+                                "type": "object",
+                                "properties": {
+                                    "genericArray": {
+                                        "title": "String[]<String>",
+                                        "description": "looked-up from field: String[]<String>",
+                                        "minItems": 2,
+                                        "maxItems": 100,
+                                        "uniqueItems": false,
+                                        "type": ["array", "null"],
+                                        "items": {
+                                            "type": "string",
+                                            "title": "String",
+                                            "description": "looked-up from field: String",
+                                            "const": "constant string value",
+                                            "minLength": 1,
+                                            "maxLength": 256,
+                                            "format": "date",
+                                            "pattern": "^.{1,256}$"
                                         }
-                                    }]
+                                    },
+                                    "genericValue": {
+                                        "type": ["string", "null"],
+                                        "title": "String",
+                                        "description": "looked-up from field: String",
+                                        "const": "constant string value",
+                                        "minLength": 1,
+                                        "maxLength": 256,
+                                        "format": "date",
+                                        "pattern": "^.{1,256}$"
+                                    }
+                                },
+                                "title": "TestClass2<String>",
+                                "description": "looked-up from field: TestClass2<String>",
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                    "^generic.+$": {
+                                        "type": "string"
+                                    }
+                                }
                             }
                         },
                         "genericValue": {
-                            "anyOf": [{
-                                    "type": "null"
-                                }, {
-                                    "$ref": "#/definitions/TestClass2(String)"
-                                }],
+                            "type": ["object", "null"],
+                            "properties": {
+                                "genericArray": {
+                                    "title": "String[]<String>",
+                                    "description": "looked-up from field: String[]<String>",
+                                    "minItems": 2,
+                                    "maxItems": 100,
+                                    "uniqueItems": false,
+                                    "type": ["array", "null"],
+                                    "items": {
+                                        "type": "string",
+                                        "title": "String",
+                                        "description": "looked-up from field: String",
+                                        "const": "constant string value",
+                                        "minLength": 1,
+                                        "maxLength": 256,
+                                        "format": "date",
+                                        "pattern": "^.{1,256}$"
+                                    }
+                                },
+                                "genericValue": {
+                                    "type": ["string", "null"],
+                                    "title": "String",
+                                    "description": "looked-up from field: String",
+                                    "const": "constant string value",
+                                    "minLength": 1,
+                                    "maxLength": 256,
+                                    "format": "date",
+                                    "pattern": "^.{1,256}$"
+                                }
+                            },
                             "title": "TestClass2<String>",
                             "description": "looked-up from field: TestClass2<String>",
                             "additionalProperties": false,
@@ -173,7 +104,37 @@
                     "additionalProperties": false,
                     "patternProperties": {
                         "^generic.+$": {
-                            "$ref": "#/definitions/TestClass2(String)"
+                            "type": "object",
+                            "properties": {
+                                "genericArray": {
+                                    "title": "String[]<String>",
+                                    "description": "looked-up from field: String[]<String>",
+                                    "minItems": 2,
+                                    "maxItems": 100,
+                                    "uniqueItems": false,
+                                    "type": ["array", "null"],
+                                    "items": {
+                                        "type": "string",
+                                        "title": "String",
+                                        "description": "looked-up from field: String",
+                                        "const": "constant string value",
+                                        "minLength": 1,
+                                        "maxLength": 256,
+                                        "format": "date",
+                                        "pattern": "^.{1,256}$"
+                                    }
+                                },
+                                "genericValue": {
+                                    "type": ["string", "null"],
+                                    "title": "String",
+                                    "description": "looked-up from field: String",
+                                    "const": "constant string value",
+                                    "minLength": 1,
+                                    "maxLength": 256,
+                                    "format": "date",
+                                    "pattern": "^.{1,256}$"
+                                }
+                            }
                         }
                     }
                 },
@@ -214,7 +175,54 @@
                         "uniqueItems": false,
                         "type": "array",
                         "items": {
-                            "$ref": "#/definitions/TestClass1"
+                            "type": "object",
+                            "properties": {
+                                "genericArray": {
+                                    "title": "String[]<String>",
+                                    "description": "looked-up from field: String[]<String>",
+                                    "minItems": 2,
+                                    "maxItems": 100,
+                                    "uniqueItems": false,
+                                    "type": ["array", "null"],
+                                    "items": {
+                                        "type": "string",
+                                        "title": "String",
+                                        "description": "looked-up from field: String",
+                                        "const": "constant string value",
+                                        "minLength": 1,
+                                        "maxLength": 256,
+                                        "format": "date",
+                                        "pattern": "^.{1,256}$"
+                                    }
+                                },
+                                "genericValue": {
+                                    "type": ["string", "null"],
+                                    "title": "String",
+                                    "description": "looked-up from field: String",
+                                    "const": "constant string value",
+                                    "minLength": 1,
+                                    "maxLength": 256,
+                                    "format": "date",
+                                    "pattern": "^.{1,256}$"
+                                },
+                                "ignoredInternalValue": {
+                                    "type": ["integer", "null"],
+                                    "title": "Integer",
+                                    "description": "looked-up from field: Integer",
+                                    "default": 1,
+                                    "enum": [1, 2, 3, 4, 5],
+                                    "minimum": 1,
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 1E+1,
+                                    "exclusiveMaximum": 11,
+                                    "multipleOf": 1
+                                },
+                                "primitiveValue": {
+                                    "type": ["integer", "null"],
+                                    "title": "int",
+                                    "description": "looked-up from field: int"
+                                }
+                            }
                         }
                     }
                 },
@@ -226,18 +234,62 @@
                     "uniqueItems": false,
                     "type": ["array", "null"],
                     "items": {
-                        "allOf": [{
-                                "$ref": "#/definitions/TestClass1"
-                            }, {
-                                "title": "TestClass1",
-                                "description": "looked-up from field: TestClass1",
-                                "additionalProperties": false,
-                                "patternProperties": {
-                                    "^generic.+$": {
-                                        "type": "string"
-                                    }
+                        "type": "object",
+                        "properties": {
+                            "genericArray": {
+                                "title": "String[]<String>",
+                                "description": "looked-up from field: String[]<String>",
+                                "minItems": 2,
+                                "maxItems": 100,
+                                "uniqueItems": false,
+                                "type": ["array", "null"],
+                                "items": {
+                                    "type": "string",
+                                    "title": "String",
+                                    "description": "looked-up from field: String",
+                                    "const": "constant string value",
+                                    "minLength": 1,
+                                    "maxLength": 256,
+                                    "format": "date",
+                                    "pattern": "^.{1,256}$"
                                 }
-                            }]
+                            },
+                            "genericValue": {
+                                "type": ["string", "null"],
+                                "title": "String",
+                                "description": "looked-up from field: String",
+                                "const": "constant string value",
+                                "minLength": 1,
+                                "maxLength": 256,
+                                "format": "date",
+                                "pattern": "^.{1,256}$"
+                            },
+                            "ignoredInternalValue": {
+                                "type": ["integer", "null"],
+                                "title": "Integer",
+                                "description": "looked-up from field: Integer",
+                                "default": 1,
+                                "enum": [1, 2, 3, 4, 5],
+                                "minimum": 1,
+                                "exclusiveMinimum": 0,
+                                "maximum": 1E+1,
+                                "exclusiveMaximum": 11,
+                                "multipleOf": 1
+                            },
+                            "primitiveValue": {
+                                "type": ["integer", "null"],
+                                "title": "int",
+                                "description": "looked-up from field: int"
+                            }
+                        },
+                        "title": "TestClass1",
+                        "description": "looked-up from field: TestClass1",
+                        "additionalProperties": false,
+                        "patternProperties": {
+                            "^generic.+$": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             },
@@ -248,24 +300,102 @@
                 "^generic.+$": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/TestClass1"
+                        "type": "object",
+                        "properties": {
+                            "genericArray": {
+                                "title": "String[]<String>",
+                                "description": "looked-up from field: String[]<String>",
+                                "minItems": 2,
+                                "maxItems": 100,
+                                "uniqueItems": false,
+                                "type": ["array", "null"],
+                                "items": {
+                                    "type": "string",
+                                    "title": "String",
+                                    "description": "looked-up from field: String",
+                                    "const": "constant string value",
+                                    "minLength": 1,
+                                    "maxLength": 256,
+                                    "format": "date",
+                                    "pattern": "^.{1,256}$"
+                                }
+                            },
+                            "genericValue": {
+                                "type": ["string", "null"],
+                                "title": "String",
+                                "description": "looked-up from field: String",
+                                "const": "constant string value",
+                                "minLength": 1,
+                                "maxLength": 256,
+                                "format": "date",
+                                "pattern": "^.{1,256}$"
+                            },
+                            "ignoredInternalValue": {
+                                "type": ["integer", "null"],
+                                "title": "Integer",
+                                "description": "looked-up from field: Integer",
+                                "default": 1,
+                                "enum": [1, 2, 3, 4, 5],
+                                "minimum": 1,
+                                "exclusiveMinimum": 0,
+                                "maximum": 1E+1,
+                                "exclusiveMaximum": 11,
+                                "multipleOf": 1
+                            },
+                            "primitiveValue": {
+                                "type": ["integer", "null"],
+                                "title": "int",
+                                "description": "looked-up from field: int"
+                            }
+                        }
                     }
                 }
             }
         },
         "nestedLong": {
-            "allOf": [{
-                    "$ref": "#/definitions/TestClass2(Long)"
-                }, {
-                    "title": "TestClass2<Long>",
-                    "description": "looked-up from field: TestClass2<Long>",
-                    "additionalProperties": false,
-                    "patternProperties": {
-                        "^generic.+$": {
-                            "type": "integer"
-                        }
+            "type": "object",
+            "properties": {
+                "genericArray": {
+                    "title": "Long[]<Long>",
+                    "description": "looked-up from field: Long[]<Long>",
+                    "minItems": 2,
+                    "maxItems": 100,
+                    "uniqueItems": false,
+                    "type": ["array", "null"],
+                    "items": {
+                        "type": "integer",
+                        "title": "Long",
+                        "description": "looked-up from field: Long",
+                        "default": 1,
+                        "enum": [1, 2, 3, 4, 5],
+                        "minimum": 1,
+                        "exclusiveMinimum": 0,
+                        "maximum": 1E+1,
+                        "exclusiveMaximum": 11,
+                        "multipleOf": 1
                     }
-                }]
+                },
+                "genericValue": {
+                    "type": ["integer", "null"],
+                    "title": "Long",
+                    "description": "looked-up from field: Long",
+                    "default": 1,
+                    "enum": [1, 2, 3, 4, 5],
+                    "minimum": 1,
+                    "exclusiveMinimum": 0,
+                    "maximum": 1E+1,
+                    "exclusiveMaximum": 11,
+                    "multipleOf": 1
+                }
+            },
+            "title": "TestClass2<Long>",
+            "description": "looked-up from field: TestClass2<Long>",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^generic.+$": {
+                    "type": "integer"
+                }
+            }
         },
         "nestedLongList": {
             "title": "List<TestClass2<Long>>",
@@ -275,18 +405,49 @@
             "uniqueItems": false,
             "type": "array",
             "items": {
-                "allOf": [{
-                        "$ref": "#/definitions/TestClass2(Long)"
-                    }, {
-                        "title": "TestClass2<Long>",
-                        "description": "looked-up from field: TestClass2<Long>",
-                        "additionalProperties": false,
-                        "patternProperties": {
-                            "^generic.+$": {
-                                "type": "integer"
-                            }
+                "type": "object",
+                "properties": {
+                    "genericArray": {
+                        "title": "Long[]<Long>",
+                        "description": "looked-up from field: Long[]<Long>",
+                        "minItems": 2,
+                        "maxItems": 100,
+                        "uniqueItems": false,
+                        "type": ["array", "null"],
+                        "items": {
+                            "type": "integer",
+                            "title": "Long",
+                            "description": "looked-up from field: Long",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
                         }
-                    }]
+                    },
+                    "genericValue": {
+                        "type": ["integer", "null"],
+                        "title": "Long",
+                        "description": "looked-up from field: Long",
+                        "default": 1,
+                        "enum": [1, 2, 3, 4, 5],
+                        "minimum": 1,
+                        "exclusiveMinimum": 0,
+                        "maximum": 1E+1,
+                        "exclusiveMaximum": 11,
+                        "multipleOf": 1
+                    }
+                },
+                "title": "TestClass2<Long>",
+                "description": "looked-up from field: TestClass2<Long>",
+                "additionalProperties": false,
+                "patternProperties": {
+                    "^generic.+$": {
+                        "type": "integer"
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
Introducing new `Option.INLINE_ALL_SCHEMAS`. This resolves #59 and follows the approach presented by @opbokel on that issue.

Throws an `IllegalArgumentException` when encountering a circular reference (instead of running into endless loops).