### PR TITLE
Maven Plugin cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project consists of:
     - [victools/jsonschema-module-jackson](jsonschema-module-jackson) – deriving JSON Schema attributes from `jackson` annotations (e.g. "description", property name overrides, what properties to ignore) as well as looking up appropriate (annotated) subtypes
     - [victools/jsonschema-module-javax-validation](jsonschema-module-javax-validation) – deriving JSON Schema attributes from `javax.validation` annotations (e.g. which properties are nullable or not, their "minimum"/"maximum", "minItems"/"maxItems", "minLength"/"maxLength")
     - [victools/jsonschema-module-swagger-1.5](jsonschema-module-swagger-1.5) – deriving JSON Schema attributes from `swagger` (1.5.x) annotations (e.g. "description", property name overrides, what properties to ignore, their "minimum"/"maximum", "const"/"enum")
+- the [victools/jsonschema-maven-plugin](jsonschema-maven-plugin) – allowing you to generate JSON Schemas as part of your Maven build
 
 Another example for such a module is:
 - [imIfOu/jsonschema-module-addon](https://github.com/imIfOu/jsonschema-module-addon) – deriving JSON Schema attributes from a custom annotation with various parameters, which is part of the module.

--- a/jsonschema-maven-plugin/README.md
+++ b/jsonschema-maven-plugin/README.md
@@ -5,9 +5,10 @@ Maven plugin for the [jsonschema-generator](../jsonschema-generator) – Integra
 
 ## Features
 1. Generate the JSON schema for a Java class.
-2. Configure the generator by selecting the modules to be used.
-3. Configure the options of the modules used in the generation.
-4. Configure the use of custom modules.
+2. Configure the designated JSON Schema Draft version.
+3. Configure the `OptionPreset` and individual `Option`s to be considered during schema generation.
+4. Configure the standard modules and their respective options to be applied.
+5. Configure any custom modules to be applied.
 
 ## Usage
 ### Plugin definition
@@ -18,21 +19,21 @@ Maven plugin for the [jsonschema-generator](../jsonschema-generator) – Integra
     <executions>
         <execution>
             <goals>
-                <goal>generate-schema</goal>
+                <goal>generate</goal>
             </goals>
         </execution>
     </executions>
     <configuration>
-        <className>com.myOrg.myApp.myclass</className>
+        <className>com.myOrg.myApp.MyClass</className>
     </configuration>
 </plugin>
 ```
-This will use the default configuration of the generator. 
+This will use the default configuration of the generator.
 
 ### Configuring file locations
 ```xml
 <configuration>
-    <className>com.myOrg.myApp.Myclass</className>
+    <className>com.myOrg.myApp.MyClass</className>
     <schemaFileName>mySchema.json</schemaFileName>
     <schemaFilePath>src/main/resources/schemas</schemaFilePath>
 </configuration>
@@ -48,7 +49,7 @@ The version of JSON Schema that is to be used can be configured with the `<schem
     <schemaVersion>DRAFT_2019_09</schemaVersion>
 </configuration>
 ```
-Allowed values are:
+Allowed values are (as per `com.github.victools.jsonschema.generator.SchemaVersion`):
 - `DRAFT_2019_09`
 - `DRAFT_7`
 - `DRAFT_6`
@@ -56,7 +57,7 @@ Allowed values are:
 `DRAFT_7` is the default, if not specified.
 
 ### Configuring the generator
-The JSON schema generator can be configured with the options as they are defined in `com.github.victools.jsonschema.generator.Option` 
+The JSON schema generator can be configured with individual options as they are defined in `com.github.victools.jsonschema.generator.Option`
 The following example shows the possible elements:
 ```xml
 <configuration>
@@ -67,21 +68,21 @@ The following example shows the possible elements:
             <option>DEFINITIONS_FOR_ALL_OBJECTS</option>
             <option>FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT</option>
         </enabled>
-        <disabled>SIMPLIFIED_ENUMS</disabled>
+        <disabled>SCHEMA_VERSION_INDICATOR</disabled>
     </options>
 </configuration>
 ```
-The `preset` element can select one of the values from `com.github.victools.jsonschema.generator.Option`.
+The `preset` element can select one of the constant values from `com.github.victools.jsonschema.generator.OptionPreset`.
 In case no `preset` is specified, `PLAIN_JSON` is taken as default value.
 
-Additional to the `preset` a number of options can be either enabled and/or disabled.
+Additional to the `preset` a number of individual `Option`s can be either enabled and/or disabled.
 The syntax supports a single value as well as multiple values as nested elements.
 
 ### Configuring modules
-When you want to have more control over the modules that are to be used during generation, the `<module>` element can be used to define them. 
+When you want to have more control over the modules that are to be used during generation, the `<modules>` element can be used to define them.
 ```xml
 <configuration>
-    <className>com.myOrg.myApp.myclass</className>
+    <className>com.myOrg.myApp.MyClass</className>
     <modules>
         <module>
             <name>Jackson</name>
@@ -99,7 +100,7 @@ There are three standard modules that can be used:
 ### Defining options for a module
 ```xml
 <configuration>
-    <className>com.myOrg.myApp.myclass</className>
+    <className>com.myOrg.myApp.MyClass</className>
     <modules>
         <module>
             <name>Jackson</name>
@@ -116,33 +117,42 @@ in this way the options as supported by the module can be specified.
 To enable a custom module in the generation the following construct can be used:
 ```xml
 <configuration>
-    <className>com.myOrg.myApp.myclass</className>
+    <className>com.myOrg.myApp.MyClass</className>
     <modules>
         <module>
-            <className>com.myOrg.myApp.MyAddonModule</className>
+            <className>com.myOrg.myApp.CustomModule</className>
         </module>
     </modules>
-</configuration>  
+</configuration>
 ```
 Make sure your custom module is on the classpath and has a default constructor.
 It is not possible to configure options for custom modules.
 
-### Full example
+### Complete Example
 ```xml
 <build>
     <plugins>
         <plugin>
             <groupId>com.github.victools</groupId>
             <artifactId>jsonschema-maven-plugin</artifactId>
-            <version>4.8.0</version>
+            <version>4.11.0</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>generate</goal>
+                    </goals>
+                </execution>
+            </executions>
             <configuration>
-                <className>com.github.victools.jsonschema.plugin.maven.TestClass</className>
+                <className>com.myOrg.myApp.MyClass</className>
                 <schemaVersion>DRAFT_2019_09</schemaVersion>
                 <schemaFileName>testclass.json</schemaFileName>
                 <schemaFilePath>result/schemas</schemaFilePath>
                 <options>
-                    <option>DEFINITIONS_FOR_ALL_OBJECTS</option>
-                    <option>NULLABLE_FIELDS_BY_DEFAULT</option>
+                    <enabled>
+                        <option>DEFINITIONS_FOR_ALL_OBJECTS</option>
+                        <option>NULLABLE_FIELDS_BY_DEFAULT</option>
+                    </enabled>
                 </options>
                 <modules>
                     <module>
@@ -152,7 +162,6 @@ It is not possible to configure options for custom modules.
                         </options>
                     </module>
                     <module>
-                        <name>MyModule</name>
                         <className>com.github.imifou.jsonschema.module.addon.AddonModule</className>
                     </module>
                 </modules>

--- a/jsonschema-maven-plugin/pom.xml
+++ b/jsonschema-maven-plugin/pom.xml
@@ -13,73 +13,66 @@
     <packaging>maven-plugin</packaging>
 
     <name>Java JSON Schema Generator Maven Plugin</name>
-    <url>https://github.com/victools/jsonschema-maven-plugin</url>
-    <organization>
-        <name>VicTools</name>
-        <url>https://www.github.com/victools</url>
-    </organization>
+    <inceptionYear>2020</inceptionYear>
+
+    <prerequisites>
+        <maven>3.0</maven>
+    </prerequisites>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.core.version>3.6.3</maven.core.version>
+        <maven.testing.version>3.3.0</maven.testing.version>
+        <maven.tools.version>3.6.0</maven.tools.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.0</version>
+            <version>${maven.tools.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.6.3</version>
+            <version>${maven.core.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.6.3</version>
+            <version>${maven.core.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.6.3</version>
+            <version>${maven.core.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-compat</artifactId>
-            <version>3.6.3</version>
+            <version>${maven.core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>3.3.0</version>
+            <version>${maven.testing.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.10.3</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.10.3</version>
         </dependency>
         <dependency>
             <groupId>com.github.victools</groupId>
             <artifactId>jsonschema-generator</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.victools</groupId>
@@ -115,137 +108,16 @@
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
-            <plugin>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
-                    <configuration>
-                        <source>${maven.compiler.source}</source>
-                        <target>${maven.compiler.target}</target>
-                        <showDeprecation>true</showDeprecation>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.0.0</version>
-                    <executions>
-                        <execution>
-                            <configuration>
-                                <configLocation>checkstyle.xml</configLocation>
-                                <sourceDirectories>${project.build.sourceDirectory}</sourceDirectories>
-                                <encoding>UTF-8</encoding>
-                                <consoleOutput>true</consoleOutput>
-                                <logViolationsToConsole>true</logViolationsToConsole>
-                            </configuration>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                            <phase>prepare-package</phase>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.3</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>report</id>
-                            <phase>test</phase>
-                            <goals>
-                                <goal>report</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                    <dependencies>
-                        <dependency>
-                            <groupId>commons-collections</groupId>
-                            <artifactId>commons-collections</artifactId>
-                            <version>3.2.2</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
-                    <executions>
-                        <execution>
-                            <id>attach-sources</id>
-                            <goals>
-                                <goal>jar-no-fork</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.0</version>
-                    <configuration>
-                        <source>${maven.compiler.source}</source>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>attach-javadocs</id>
-                            <goals>
-                                <goal>jar</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
-                    <executions>
-                        <execution>
-                            <id>sign-artifacts</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>sign</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.8</version>
-                    <extensions>true</extensions>
-                    <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
                     <version>3.6.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.8.2</version>
+                    <version>3.9.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -254,9 +126,7 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.0</version>
                 <reportSets>
                     <reportSet>
                         <reports>

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/GeneratorOptions.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/GeneratorOptions.java
@@ -24,7 +24,7 @@ import com.github.victools.jsonschema.generator.Option;
 public class GeneratorOptions {
 
     // The preset options
-    public String preset;
+    public StandardOptionPreset preset;
 
     // The options of the generator that should be enabled
     public Option[] enabled;

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
@@ -16,9 +16,7 @@
 
 package com.github.victools.jsonschema.plugin.maven;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.victools.jsonschema.generator.Module;
 import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.OptionPreset;
@@ -32,7 +30,15 @@ import com.github.victools.jsonschema.module.javax.validation.JavaxValidationMod
 import com.github.victools.jsonschema.module.javax.validation.JavaxValidationOption;
 import com.github.victools.jsonschema.module.swagger15.SwaggerModule;
 import com.github.victools.jsonschema.module.swagger15.SwaggerOption;
-import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.text.MessageFormat;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -41,25 +47,13 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.Writer;
-import java.lang.reflect.InvocationTargetException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-
 /**
  * Maven plugin for the victools/jsonschema-generator.
  */
-@Mojo(name = "generate-schema",
+@Mojo(name = "generate",
         defaultPhase = LifecyclePhase.COMPILE,
-        requiresDependencyResolution = ResolutionScope.RUNTIME)
+        requiresDependencyResolution = ResolutionScope.COMPILE,
+        requiresDependencyCollection = ResolutionScope.COMPILE)
 public class SchemaGeneratorMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", required = true, readonly = true)
@@ -72,34 +66,40 @@ public class SchemaGeneratorMojo extends AbstractMojo {
     private String className;
 
     /**
-     * The directory path where the schema files is generated.
-     * By default this is in the resources directory.
+     * The directory path where the schema files are generated.
+     * <br>
+     * By default, this is: {@code src/main/resources}
      */
     @Parameter(property = "schemaFilePath")
-    private String schemaFilePath;
+    private File schemaFilePath;
 
     /**
-     * The name of the file in which the generate schema is written.
+     * The name of the file in which the generated schema is written. Allowing for two placeholders:
+     * <ul>
+     * <li><code>{0}</code> - containing the simple class name (last part of the {@link #className} parameter)</li>
+     * <li><code>{1}</code> - containing the package path (first part of the {@link #className} parameter)</li>
+     * </ul>
+     * The default name is: <code>{0}-schema.json</code>
      */
-    @Parameter(property = "schemaFileName")
+    @Parameter(property = "schemaFileName", defaultValue = "{0}-schema.json")
     private String schemaFileName;
 
     /**
      * The schema version to be used: DRAFT_6, DRAFT_7 or DRAFT_2019_09.
      */
     @Parameter(property = "schemaVersion", defaultValue = "DRAFT_7")
-    private String schemaVersion;
+    private SchemaVersion schemaVersion;
 
     /**
      * The options for the generator.
      */
-    @Parameter(property = "options")
+    @Parameter
     private GeneratorOptions options;
 
     /**
      * Selection of Modules that need to be activated during generation.
      */
-    @Parameter(property = "modules")
+    @Parameter
     private GeneratorModule[] modules;
 
     /**
@@ -107,110 +107,83 @@ public class SchemaGeneratorMojo extends AbstractMojo {
      *
      * @throws MojoExecutionException An exception in case of errors and unexpected behavior
      */
+    @Override
     public void execute() throws MojoExecutionException {
-        getLog().info("Generating JSON Schema for class " + className);
+        this.getLog().debug("Initializing Schema Generator");
+        final SchemaGenerator generator = this.createGenerator();
 
+        this.getLog().info("Generating JSON Schema for class: " + this.className);
         // Load the class for which the schema will be generated
         Class<?> schemaClass;
         try {
-            schemaClass = getClassLoader().loadClass(className);
+            schemaClass = Class.forName(this.className);
         } catch (ClassNotFoundException e) {
-            throw new MojoExecutionException("Error loading class " + className, e);
+            throw new MojoExecutionException("Error loading class " + this.className, e);
         }
-
-        // Generate the schema
-        ObjectMapper mapper = new ObjectMapper();
-        SchemaGenerator generator = createGenerator(mapper);
         JsonNode jsonSchema = generator.generateSchema(schemaClass);
-
-        // Write the result
-        File schemaFile = getSchemaFile();
-        try {
-            String schema = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonSchema);
-            writeToFile(schema, schemaFile);
-        } catch (JsonProcessingException e) {
-            throw new MojoExecutionException("Error writing schema file at " + schemaFile, e);
-        }
-    }
-
-    private static URLClassLoader classLoader = null;
-
-    /**
-     * Construct the classloader based on the project classpath.
-     *
-     * @return The classloader
-     * @throws MojoExecutionException in case of problems
-     */
-    private URLClassLoader getClassLoader() throws MojoExecutionException {
-        if (classLoader == null) {
-            List<String> runtimeClasspathElements;
-            try {
-                runtimeClasspathElements = project.getRuntimeClasspathElements();
-            } catch (DependencyResolutionRequiredException e) {
-                throw new MojoExecutionException("Error: Class path construction problem.", e);
-            }
-
-            if (runtimeClasspathElements != null) {
-                URL[] runtimeUrls = new URL[runtimeClasspathElements.size()];
-                for (int i = 0; i < runtimeClasspathElements.size(); i++) {
-                    String element = runtimeClasspathElements.get(i);
-                    try {
-                        runtimeUrls[i] = new File(element).toURI().toURL();
-                    } catch (MalformedURLException e) {
-                        throw new MojoExecutionException("Error: Class path construction problem.", e);
-                    }
-                }
-                classLoader = new URLClassLoader(runtimeUrls,
-                        Thread.currentThread().getContextClassLoader());
-            }
-        }
-
-        return classLoader;
+        File file = getSchemaFile(schemaClass);
+        this.getLog().info("- Writing schema to file: " + file);
+        this.writeToFile(jsonSchema, file);
     }
 
     /**
-     * Return the name of the file in which the schema has to be written.
-     * The default path is: src/main/resources
-     * The default file name is: name of the class + ".schema.json"
+     * Return the file in which the schema has to be written.
      *
+     * <p>The path is determined based on the {@link #schemaFilePath} parameter.
+     * <br>
+     * The name of the file is determined based on the {@link #schemaFileName} parameter, which allows for two placeholders:
+     * <ul>
+     * <li><code>{0}</code> - containing the simple class name (last part of the {@link #className} parameter)</li>
+     * <li><code>{1}</code> - containing the package path (first part of the {@link #className} parameter)</li>
+     * </ul>
+     * </p>
+     * The default path is: {@code src/main/resources}
+     * <br>
+     * The default name is: <code>{0}-schema.json</code>
+     *
+     * @param mainType targeted class for which the schema is being generated
      * @return The full path name of the schema file
      */
-    private File getSchemaFile() {
-        File filePath;
-        if (schemaFilePath == null || schemaFilePath.isEmpty()) {
-            filePath = new File("src" + File.separator + "main" + File.separator + "resources");
+    private File getSchemaFile(Class<?> mainType) {
+        File directory;
+        if (this.schemaFilePath == null) {
+            directory = new File("src" + File.separator + "main" + File.separator + "resources");
+            this.getLog().debug("- No 'schemaFilePath' configured. Applying default: " + directory);
         } else {
-            filePath = new File(schemaFilePath);
+            directory = this.schemaFilePath;
+        }
+        try {
+            Files.createDirectories(directory.toPath());
+        } catch (IOException e) {
+            this.getLog().warn("Failed to ensure existence of 'schemaFilePath' " + directory, e);
         }
 
-        String fileName;
-        if (schemaFileName == null || schemaFileName.isEmpty()) {
-            fileName = className + ".schema.json";
-        } else {
-            fileName = schemaFileName;
-        }
+        String fileName = MessageFormat.format(this.schemaFileName,
+                // placeholder {0}
+                mainType.getSimpleName(),
+                // placeholder {1}
+                mainType.getPackage().getName());
 
-        return new File(filePath, fileName);
+        return new File(directory, fileName);
     }
 
     /**
      * Create the JSON Schema generator.
-     * Configuring it the specified options and add the required modules
+     * <br>
+     * Configuring it the specified options and adding the required modules.
      *
-     * @param mapper The mapper that is to be used
      * @return The configured generator
      * @throws MojoExecutionException Error exception
      */
-    private SchemaGenerator createGenerator(ObjectMapper mapper) throws MojoExecutionException {
+    private SchemaGenerator createGenerator() throws MojoExecutionException {
         // Start with the generator builder
-        SchemaGeneratorConfigBuilder configBuilder =
-                new SchemaGeneratorConfigBuilder(mapper, getSchemaVersion(), getOptionPreset());
+        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(this.schemaVersion, this.getOptionPreset());
 
         // Add options when required
-        setOptions(configBuilder, options);
+        this.setOptions(configBuilder);
 
         // Register the modules when specified
-        setModules(configBuilder, modules);
+        this.setModules(configBuilder);
 
         // And construct the generator
         SchemaGeneratorConfig config = configBuilder.build();
@@ -218,42 +191,16 @@ public class SchemaGeneratorMojo extends AbstractMojo {
     }
 
     /**
-     * Get the schema version to be used from the configuration.
-     *
-     * @return The schema version
-     * @throws MojoExecutionException Exception in case of an unknown value
-     */
-    private SchemaVersion getSchemaVersion() throws MojoExecutionException {
-        try {
-            return SchemaVersion.valueOf(schemaVersion);
-        } catch (IllegalArgumentException e) {
-            throw new MojoExecutionException("Error: Unknown schema version " + schemaVersion, e);
-        }
-    }
-
-    /**
-     * Determine the standard option preset of the generator. Take it from the configuration or set the default.
-     * The default is: PLAIN_JSON
+     * Determine the standard option preset of the generator. Take it from the configuration or set the default. The default is: PLAIN_JSON
      *
      * @return The OptionPreset
      * @throws MojoExecutionException In case an unknown preset was used.
      */
     private OptionPreset getOptionPreset() throws MojoExecutionException {
-        // Unfortunately OptionPreset is not an Enum. So have to do some hardcoding now.
-        if (options.preset != null && !options.preset.isEmpty()) {
-            switch (options.preset) {
-            case "FULL_DOCUMENTATION":
-                return OptionPreset.FULL_DOCUMENTATION;
-            case "PLAIN_JSON":
-                return OptionPreset.PLAIN_JSON;
-            case "JAVA_OBJECT":
-                return OptionPreset.JAVA_OBJECT;
-            default:
-                throw new MojoExecutionException("Error: Option preset is not one of "
-                        + "['FULL_DOCUMENTATION', 'PLAIN_JSON', 'JAVA_OBJECT']");
-            }
+        if (this.options != null && this.options.preset != null) {
+            return this.options.preset.getPreset();
         }
-
+        this.getLog().debug("- No 'options/preset' configured. Applying default: PLAIN_JSON");
         return OptionPreset.PLAIN_JSON;
     }
 
@@ -261,19 +208,21 @@ public class SchemaGeneratorMojo extends AbstractMojo {
      * Set the generator options form the configuration.
      *
      * @param configBuilder The configbuilder on which the options are set
-     * @param options       The options from the pom file
      */
-    private void setOptions(SchemaGeneratorConfigBuilder configBuilder, GeneratorOptions options) {
+    private void setOptions(SchemaGeneratorConfigBuilder configBuilder) {
+        if (this.options == null) {
+            return;
+        }
         // Enable all the configured options
-        if (options.enabled != null) {
-            for (Option option : options.enabled) {
+        if (this.options.enabled != null) {
+            for (Option option : this.options.enabled) {
                 configBuilder.with(option);
             }
         }
 
         // Disable all the configured options
-        if (options.disabled != null) {
-            for (Option option : options.disabled) {
+        if (this.options.disabled != null) {
+            for (Option option : this.options.disabled) {
                 configBuilder.without(option);
             }
         }
@@ -283,35 +232,37 @@ public class SchemaGeneratorMojo extends AbstractMojo {
      * Configure all the modules on the generator.
      *
      * @param configBuilder The builder on which the modules are added.
-     * @param modules       The modules configuration part from the the pom.xml
-     * @throws MojoExecutionException Error exception
+     * @throws MojoExecutionException Invalid module name or className configured
      */
-    private void setModules(SchemaGeneratorConfigBuilder configBuilder, GeneratorModule[] modules) throws MojoExecutionException {
-        for (GeneratorModule module : modules) {
+    @SuppressWarnings("unchecked")
+    private void setModules(SchemaGeneratorConfigBuilder configBuilder) throws MojoExecutionException {
+        if (this.modules == null) {
+            return;
+        }
+        for (GeneratorModule module : this.modules) {
             if (module.className != null && !module.className.isEmpty()) {
                 try {
-                    getLog().info("- Adding CustomModule " + module.className);
-                    Class<? extends Module> moduleClass =
-                            (Class<? extends Module>) getClassLoader().loadClass(module.className);
+                    this.getLog().debug("- Adding custom Module " + module.className);
+                    Class<? extends Module> moduleClass = (Class<? extends Module>) Class.forName(module.className);
                     Module moduleInstance = moduleClass.getConstructor().newInstance();
                     configBuilder.with(moduleInstance);
                 } catch (ClassCastException | InstantiationException
                         | IllegalAccessException | NoSuchMethodException
                         | InvocationTargetException | ClassNotFoundException e) {
-                    throw new MojoExecutionException("Error: Can not create custom module" + module.className, e);
+                    throw new MojoExecutionException("Error: Can not instantiate custom module" + module.className, e);
                 }
             } else if (module.name != null) {
                 switch (module.name) {
                 case "Jackson":
-                    getLog().info("- Adding Jackson Module");
+                    this.getLog().debug("- Adding Jackson Module");
                     addJacksonModule(configBuilder, module);
                     break;
                 case "JavaxValidation":
-                    getLog().info("- Adding Javax Validation Module");
+                    this.getLog().debug("- Adding Javax Validation Module");
                     addJavaxValidationModule(configBuilder, module);
                     break;
                 case "Swagger15":
-                    getLog().info("- Adding Swagger 1.5 Module");
+                    this.getLog().debug("- Adding Swagger 1.5 Module");
                     addSwagger15Module(configBuilder, module);
                     break;
                 default:
@@ -338,7 +289,7 @@ public class SchemaGeneratorMojo extends AbstractMojo {
                 try {
                     swaggerOptions[i] = SwaggerOption.valueOf(module.options[i]);
                 } catch (IllegalArgumentException e) {
-                    throw new MojoExecutionException("Error: Unknown Swagger option " + swaggerOptions[i], e);
+                    throw new MojoExecutionException("Error: Unknown Swagger option " + module.options[i], e);
                 }
             }
             configBuilder.with(new SwaggerModule(swaggerOptions));
@@ -361,7 +312,7 @@ public class SchemaGeneratorMojo extends AbstractMojo {
                 try {
                     javaxValidationOptions[i] = JavaxValidationOption.valueOf(module.options[i]);
                 } catch (IllegalArgumentException e) {
-                    throw new MojoExecutionException("Error: Unknown JavaxValidation option " + javaxValidationOptions[i], e);
+                    throw new MojoExecutionException("Error: Unknown JavaxValidation option " + module.options[i], e);
                 }
             }
             configBuilder.with(new JavaxValidationModule(javaxValidationOptions));
@@ -384,7 +335,7 @@ public class SchemaGeneratorMojo extends AbstractMojo {
                 try {
                     jacksonOptions[i] = JacksonOption.valueOf(module.options[i]);
                 } catch (IllegalArgumentException e) {
-                    throw new MojoExecutionException("Error: Unknown Jackson option " + jacksonOptions[i], e);
+                    throw new MojoExecutionException("Error: Unknown Jackson option " + module.options[i], e);
                 }
             }
             configBuilder.with(new JacksonModule(jacksonOptions));
@@ -392,22 +343,18 @@ public class SchemaGeneratorMojo extends AbstractMojo {
     }
 
     /**
-     * Write content to a file.
+     * Write generated schema to a file.
      *
-     * @param content Content to be written
-     * @param file    The file to write to
-     * @throws MojoExecutionException In case of problems
+     * @param jsonSchema Generated schema to be written
+     * @param file       The file to write to
+     * @throws MojoExecutionException In case of problems when writing the targeted file
      */
-    private void writeToFile(String content, File file) throws MojoExecutionException {
-        try {
-            Writer writer = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8);
-            PrintWriter pw = new PrintWriter(writer);
-            pw.print(content);
-            pw.close();
-        } catch (FileNotFoundException e) {
+    private void writeToFile(JsonNode jsonSchema, File file) throws MojoExecutionException {
+        try (FileOutputStream outputStream = new FileOutputStream(file);
+                PrintWriter writer = new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
+            writer.print(jsonSchema.toPrettyString());
+        } catch (IOException e) {
             throw new MojoExecutionException("Error: Can not write to file " + file, e);
         }
     }
 }
-
-

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/StandardOptionPreset.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/StandardOptionPreset.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.plugin.maven;
+
+import com.github.victools.jsonschema.generator.OptionPreset;
+
+/**
+ * Enum of supported standard {@link OptionPreset}s that can be configured.
+ */
+public enum StandardOptionPreset {
+    FULL_DOCUMENTATION(OptionPreset.FULL_DOCUMENTATION),
+    PLAIN_JSON(OptionPreset.PLAIN_JSON),
+    JAVA_OBJECT(OptionPreset.JAVA_OBJECT),
+    NONE(new OptionPreset());
+
+    private final OptionPreset preset;
+
+    private StandardOptionPreset(OptionPreset preset) {
+        this.preset = preset;
+    }
+
+    /**
+     * Getter for the corresponding {@link OptionPreset} instance.
+     *
+     * @return {@link OptionPreset} instance
+     */
+    public OptionPreset getPreset() {
+        return this.preset;
+    }
+}

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
@@ -16,23 +16,22 @@
 
 package com.github.victools.jsonschema.plugin.maven;
 
+import java.io.File;
+import java.io.FileReader;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.MojoRule;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.component.configurator.ComponentConfigurationException;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.io.File;
-import java.io.FileReader;
-
-import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnitParamsRunner.class)
 public class SchemaGeneratorMojoTest {
@@ -65,32 +64,51 @@ public class SchemaGeneratorMojoTest {
 
         // Validate that the schema files is created.
         File resultFile = new File(generationLocation,testCaseName + ".json");
-        assertTrue(resultFile.exists());
+        Assert.assertTrue(resultFile.exists());
 
         // Validate that is the same as the reference
         File referenceFile = new File(testCaseLocation + "/" + testCaseName + "-reference.json");
-        assertTrue(referenceFile.exists());
-        assertTrue("Generated schema for " + testCaseName + " is not equal to the expected reference.",
+        Assert.assertTrue(referenceFile.exists());
+        Assert.assertTrue("Generated schema for " + testCaseName + " is not equal to the expected reference.",
                 FileUtils.contentEquals(resultFile, referenceFile));
     }
 
     public Object[] parametersForTestPomErrors() {
         return new Object[][]{
                 {"ClassNotFound"},
-                {"UnknownModule"},
+                {"UnknownModule"}
+        };
+    }
+
+    /**
+     * Unit test that will generate from a maven pom file fragment and expect a MojoExecutionException.
+     *
+     * @param testCaseName Name of the test case and file name prefix of the example {@code pom.xml}
+     * @throws Exception In case something goes wrong
+     */
+    @Test(expected = MojoExecutionException.class)
+    @Parameters
+    public void testPomErrors(String testCaseName) throws Exception {
+        File testCaseLocation = new File("src/test/resources/error-test-cases");
+        executePom(new File(testCaseLocation, testCaseName + "-pom.xml"));
+    }
+
+    public Object[] parametersForTestPomConfigurationErrors() {
+        return new Object[][]{
                 {"UnknownSchemaVersion"},
                 {"UnknownGeneratorPreset"}
         };
     }
 
     /**
-     * Unit test that will generate from a maven pom file fragment and expect an MojoExecutionException
+     * Unit test that will generate from a maven pom file fragment and expect a ComponentConfigurationException.
      *
+     * @param testCaseName Name of the test case and file name prefix of the example {@code pom.xml}
      * @throws Exception In case something goes wrong
      */
-    @Test(expected = MojoExecutionException.class)
+    @Test(expected = ComponentConfigurationException.class)
     @Parameters
-    public void testPomErrors(String testCaseName) throws Exception {
+    public void testPomConfigurationErrors(String testCaseName) throws Exception {
         File testCaseLocation = new File("src/test/resources/error-test-cases");
         executePom(new File(testCaseLocation, testCaseName + "-pom.xml"));
     }
@@ -107,7 +125,7 @@ public class SchemaGeneratorMojoTest {
         PlexusConfiguration configuration = rule.extractPluginConfiguration("jsonschema-maven-plugin", pomDom);
 
         // Configure the Mojo
-        SchemaGeneratorMojo myMojo = (SchemaGeneratorMojo) rule.lookupConfiguredMojo(new MavenProject(), "generate-schema");
+        SchemaGeneratorMojo myMojo = (SchemaGeneratorMojo) rule.lookupConfiguredMojo(new MavenProject(), "generate");
         myMojo = (SchemaGeneratorMojo) rule.configureMojo(myMojo, configuration);
 
         // And execute

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,23 @@
         </developer>
     </developers>
 
+    <contributors>
+        <contributor>
+            <name>Florian Didier</name>
+            <url>https://github.com/imIfOu</url>
+            <roles>
+                <role>Provided PR #5 (support for "required" and "default" properties)</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Jan Labrie</name>
+            <url>https://github.com/JanLabrie</url>
+            <roles>
+                <role>Provided PR #78 and various follow-ups (creation of maven plugin)</role>
+            </roles>
+        </contributor>
+    </contributors>
+
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>


### PR DESCRIPTION
@JanLabrie I've made a couple small changes to the pending Maven Plugin.

Since it is your creation, I'd appreciate if you could have a look – I don't want to "just merge" it without asking.

 1. renamed goal to `generate` to make the command-line call nicer. that is now `jsonschema:generate` (unless you think `jsonschema:generate-schema` is better?)
 2. update pom to avoid unnecessary plugin management (that is being taken care of by the parent pom already)
 3. some small fixes in README
 4. align maven plugin code with existing codebase (import order + using `this.` prefix)
 5. getting rid of the explicit `ClassLoader` code by adding dependency scope on `@Mojo` annotation
 6. stricter configuration of `SchemaVersion` and `OptionPreset` through enums (therefore no need to specifically map values anymore)
 7. better error messages for invalid module options (it was returning `null` instead of the configured name)
 8. create schema parent directories if necessary (mostly relevant for first-time executions, but I liked the convenience)
 9. close `FileOutputStream` after writing schema to file (using `try-with-resources` which calls `close()` on IO resources automatically)
 10. Changing the log messages regarding the configuration parameters to `debug` level.

----

The schema generation for multiple types is still outstanding though. I didn't touch that area since you were planning to tackle that yourself.