### PR TITLE
Configuration of Property Order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### `jsonschema-generator`
+#### Added
+- New `SchemaGeneratorGeneralConfigPart.withPropertySorter()` exposing the sorting logic of an object schema's properties
+
 ## [4.11.1] - 2020-04-30
 ### `jsonschema-maven-plugin`
 #### Fixed

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
@@ -133,6 +133,16 @@ public interface SchemaGeneratorConfig {
     ArrayNode createArrayNode();
 
     /**
+     * Implementation of the {@link java.util.Comparator#compare(Object, Object)} interface method to determine the order of fields and methods in an
+     * object's {@code "properties"}.
+     *
+     * @param first first field/method to compare to {@code second}
+     * @param second second field/method to compare to {@code first}
+     * @return a negative/positive integer as the first field/method should be positioned before/after the second respectively
+     */
+    int sortProperties(MemberScope<?, ?> first, MemberScope<?, ?> second);
+
+    /**
      * Look-up the non-standard JSON schema definition for a given property. Falling-back on the per-type custom definitions.
      *
      * @param <M> type of targeted property

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorGeneralConfigPart.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorGeneralConfigPart.java
@@ -16,11 +16,13 @@
 
 package com.github.victools.jsonschema.generator;
 
+import com.github.victools.jsonschema.generator.impl.PropertySortUtils;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -29,12 +31,34 @@ import java.util.Map;
  */
 public class SchemaGeneratorGeneralConfigPart extends SchemaGeneratorTypeConfigPart<TypeScope> {
 
+    private Comparator<MemberScope<?, ?>> propertySorter = PropertySortUtils.DEFAULT_PROPERTY_ORDER;
+
     private final List<CustomDefinitionProviderV2> customDefinitionProviders = new ArrayList<>();
     private final List<SubtypeResolver> subtypeResolvers = new ArrayList<>();
     private final List<TypeAttributeOverrideV2> typeAttributeOverrides = new ArrayList<>();
 
     private final List<ConfigFunction<TypeScope, String>> idResolvers = new ArrayList<>();
     private final List<ConfigFunction<TypeScope, String>> anchorResolvers = new ArrayList<>();
+
+    /**
+     * Replacing the current sorting algorithm of properties (fields and methods).
+     *
+     * @param propertySorter sorting algorithm for an object's properties
+     * @return this builder instance (for chaining)
+     */
+    public SchemaGeneratorGeneralConfigPart withPropertySorter(Comparator<MemberScope<?, ?>> propertySorter) {
+        this.propertySorter = propertySorter;
+        return this;
+    }
+
+    /**
+     * Getter for the sorting algorithm for an object's properties (fields and methods).
+     *
+     * @return applicable {@link Comparator} for an object's properties
+     */
+    public Comparator<MemberScope<?, ?>> getPropertySorter() {
+        return this.propertySorter;
+    }
 
     /**
      * Adding a custom schema provider – if it returns null for a given type, the next definition provider will be applied.

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/PropertySortUtils.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/PropertySortUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.generator.impl;
+
+import com.github.victools.jsonschema.generator.MemberScope;
+import com.github.victools.jsonschema.generator.MethodScope;
+import java.util.Comparator;
+
+/**
+ * Utility class containing the declaration of the default property sort algorithm and its components.
+ */
+public class PropertySortUtils {
+
+    /**
+     * {@link Comparator} sorting properties: with fields before methods.
+     */
+    public static final Comparator<MemberScope<?, ?>> SORT_PROPERTIES_FIELDS_BEFORE_METHODS
+            = (first, second) -> Boolean.compare(first instanceof MethodScope, second instanceof MethodScope);
+
+    /**
+     * {@link Comparator} sorting properties: alphabetically by their name.
+     *
+     * @see MemberScope#getSchemaPropertyName()
+     */
+    public static final Comparator<MemberScope<?, ?>> SORT_PROPERTIES_BY_NAME_ALPHABETICALLY
+            = (first, second) -> first.getSchemaPropertyName().compareTo(second.getSchemaPropertyName());
+
+    /**
+     * {@link Comparator} sorting properties into the following groups and within each group alphabetically by their name.
+     * <ol>
+     * <li>instance fields</li>
+     * <li>instance methods</li>
+     * <li>static fields</li>
+     * <li>static methods</li>
+     * </ol>
+     *
+     * @see MemberScope#getSchemaPropertyName()
+     */
+    public static final Comparator<MemberScope<?, ?>> DEFAULT_PROPERTY_ORDER
+            = SORT_PROPERTIES_FIELDS_BEFORE_METHODS.thenComparing(SORT_PROPERTIES_BY_NAME_ALPHABETICALLY);
+}

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
@@ -159,6 +159,11 @@ public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
     }
 
     @Override
+    public int sortProperties(MemberScope<?, ?> first, MemberScope<?, ?> second) {
+        return this.typesInGeneralConfigPart.getPropertySorter().compare(first, second);
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <M extends MemberScope<?, ?>> CustomDefinition getCustomDefinition(M scope, SchemaGenerationContext context,
             CustomPropertyDefinitionProvider<M> ignoredDefinitionProvider) {

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorComplexTypesTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorComplexTypesTest.java
@@ -110,7 +110,8 @@ public class SchemaGeneratorComplexTypesTest {
         Module typeInGeneralModule = configBuilder -> populateTypeConfigPart(
                 configBuilder.with(Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT).forTypesInGeneral()
                         .withIdResolver(scope -> scope.getType().getTypeName().contains("$Test") ? "id-" + scope.getSimpleTypeDescription() : null)
-                        .withAnchorResolver(scope -> scope.isContainerType() ? null : "#anchor"),
+                        .withAnchorResolver(scope -> scope.isContainerType() ? null : "#anchor")
+                        .withPropertySorter((_prop1, _prop2) -> 0),
                 "for type in general: ");
         Module methodModule = configBuilder -> populateConfigPart(configBuilder.forMethods(), "looked-up from method: ");
         Module fieldModule = configBuilder -> populateConfigPart(configBuilder.with(Option.INLINE_ALL_SCHEMAS).forFields(), "looked-up from field: ");

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/impl/PropertySortUtilsTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/impl/PropertySortUtilsTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.generator.impl;
+
+import com.github.victools.jsonschema.generator.FieldScope;
+import com.github.victools.jsonschema.generator.MemberScope;
+import com.github.victools.jsonschema.generator.MethodScope;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test for the {@link PropertySortUtils} class.
+ */
+public class PropertySortUtilsTest {
+
+    private FieldScope instanceFieldA;
+    private FieldScope instanceFieldC;
+    private MethodScope instanceMethodB;
+    private FieldScope staticFieldE;
+    private MethodScope staticMethodD;
+    private MethodScope staticMethodF;
+    private List<MemberScope<?, ?>> memberList;
+
+    @Before
+    public void setUp() {
+        this.instanceFieldA = this.createMemberMock(FieldScope.class, false, "a");
+        this.instanceFieldC = this.createMemberMock(FieldScope.class, false, "c");
+        this.staticFieldE = this.createMemberMock(FieldScope.class, true, "e");
+        this.instanceMethodB = this.createMemberMock(MethodScope.class, false, "b()");
+        this.staticMethodD = this.createMemberMock(MethodScope.class, true, "d()");
+        this.staticMethodF = this.createMemberMock(MethodScope.class, true, "f()");
+
+        this.memberList = Arrays.asList(
+                this.instanceFieldC, this.staticMethodF, this.staticFieldE, this.instanceFieldA, this.instanceMethodB, this.staticMethodD);
+    }
+
+    private <S extends MemberScope<?, ?>> S createMemberMock(Class<S> scopeType, boolean isStatic, String name) {
+        S mock = Mockito.mock(scopeType);
+        Mockito.when(mock.isStatic()).thenReturn(isStatic);
+        Mockito.when(mock.getSchemaPropertyName()).thenReturn(name);
+        return mock;
+    }
+
+    /**
+     * Test the correct sorting based on the {@link PropertySortUtils#SORT_PROPERTIES_FIELDS_BEFORE_METHODS} {@code Comparator}.
+     */
+    @Test
+    public void testSortPropertiesFieldsBeforeMethods() {
+        String sortingResult = this.memberList.stream()
+                .sorted(PropertySortUtils.SORT_PROPERTIES_FIELDS_BEFORE_METHODS)
+                .map(MemberScope::getSchemaPropertyName)
+                .collect(Collectors.joining(" "));
+        Assert.assertEquals("c e a f() b() d()", sortingResult);
+    }
+
+    /**
+     * Test the correct sorting based on the {@link PropertySortUtils#SORT_PROPERTIES_BY_NAME_ALPHABETICALLY} {@code Comparator}.
+     */
+    @Test
+    public void testSortPropertiesByNameAlphabetically() {
+        String sortingResult = this.memberList.stream()
+                .sorted(PropertySortUtils.SORT_PROPERTIES_BY_NAME_ALPHABETICALLY)
+                .map(MemberScope::getSchemaPropertyName)
+                .collect(Collectors.joining(" "));
+        Assert.assertEquals("a b() c d() e f()", sortingResult);
+    }
+
+    /**
+     * Test the correct sorting based on the {@link PropertySortUtils#DEFAULT_PROPERTY_ORDER} {@code Comparator}.
+     */
+    @Test
+    public void testDefaultPropertyOrder() {
+        String sortingResult = this.memberList.stream()
+                .sorted(PropertySortUtils.DEFAULT_PROPERTY_ORDER)
+                .map(MemberScope::getSchemaPropertyName)
+                .collect(Collectors.joining(" "));
+        Assert.assertEquals("a c e b() d() f()", sortingResult);
+    }
+}

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-FULL_DOCUMENTATION-typeattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-FULL_DOCUMENTATION-typeattributes.json
@@ -1,19 +1,16 @@
 {
     "type": "object",
     "properties": {
-        "CONSTANT": {
-            "type": "integer",
-            "const": 5,
+        "genericValue": {
+            "type": ["string", "null"],
             "$anchor": "#anchor",
-            "title": "Long",
-            "description": "for type in general: Long",
-            "default": 1,
-            "enum": [1, 2, 3, 4, 5],
-            "minimum": 1,
-            "exclusiveMinimum": 0,
-            "maximum": 1E+1,
-            "exclusiveMaximum": 11,
-            "multipleOf": 1
+            "title": "String",
+            "description": "for type in general: String",
+            "const": "constant string value",
+            "minLength": 1,
+            "maxLength": 256,
+            "format": "date",
+            "pattern": "^.{1,256}$"
         },
         "genericArray": {
             "type": ["array", "null"],
@@ -34,16 +31,11 @@
             "maxItems": 100,
             "uniqueItems": false
         },
-        "genericValue": {
-            "type": ["string", "null"],
+        "primitiveValue": {
+            "type": "integer",
             "$anchor": "#anchor",
-            "title": "String",
-            "description": "for type in general: String",
-            "const": "constant string value",
-            "minLength": 1,
-            "maxLength": 256,
-            "format": "date",
-            "pattern": "^.{1,256}$"
+            "title": "int",
+            "description": "for type in general: int"
         },
         "ignoredInternalValue": {
             "type": ["integer", "null"],
@@ -58,7 +50,13 @@
             "exclusiveMaximum": 11,
             "multipleOf": 1
         },
-        "primitiveValue": {
+        "isSimpleTestClass()": {
+            "type": "boolean",
+            "$anchor": "#anchor",
+            "title": "boolean",
+            "description": "for type in general: boolean"
+        },
+        "getPrimitiveValue()": {
             "type": "integer",
             "$anchor": "#anchor",
             "title": "int",
@@ -76,17 +74,19 @@
             "format": "date",
             "pattern": "^.{1,256}$"
         },
-        "getPrimitiveValue()": {
+        "CONSTANT": {
             "type": "integer",
+            "const": 5,
             "$anchor": "#anchor",
-            "title": "int",
-            "description": "for type in general: int"
-        },
-        "isSimpleTestClass()": {
-            "type": "boolean",
-            "$anchor": "#anchor",
-            "title": "boolean",
-            "description": "for type in general: boolean"
+            "title": "Long",
+            "description": "for type in general: Long",
+            "default": 1,
+            "enum": [1, 2, 3, 4, 5],
+            "minimum": 1,
+            "exclusiveMinimum": 0,
+            "maximum": 1E+1,
+            "exclusiveMaximum": 11,
+            "multipleOf": 1
         }
     },
     "$id": "id-TestClass1",

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION-typeattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION-typeattributes.json
@@ -16,12 +16,6 @@
                     "exclusiveMaximum": 11,
                     "multipleOf": 1
                 },
-                "isPresent()": {
-                    "type": "boolean",
-                    "$anchor": "#anchor",
-                    "title": "boolean",
-                    "description": "for type in general: boolean"
-                },
                 "orElse(Integer)": {
                     "type": ["integer", "null"],
                     "$anchor": "#anchor",
@@ -34,6 +28,12 @@
                     "maximum": 1E+1,
                     "exclusiveMaximum": 11,
                     "multipleOf": 1
+                },
+                "isPresent()": {
+                    "type": "boolean",
+                    "$anchor": "#anchor",
+                    "title": "boolean",
+                    "description": "for type in general: boolean"
                 }
             },
             "$anchor": "#anchor",
@@ -55,19 +55,13 @@
                     "format": "date",
                     "pattern": "^.{1,256}$"
                 },
-                "oldMode": {
-                    "type": "integer",
-                    "$anchor": "#anchor",
-                    "title": "int",
-                    "description": "for type in general: int"
-                },
                 "ordinal": {
                     "type": "integer",
                     "$anchor": "#anchor",
                     "title": "int",
                     "description": "for type in general: int"
                 },
-                "compareTo(RoundingMode)": {
+                "oldMode": {
                     "type": "integer",
                     "$anchor": "#anchor",
                     "title": "int",
@@ -85,11 +79,11 @@
                     "format": "date",
                     "pattern": "^.{1,256}$"
                 },
-                "valueOf(String)": {
-                    "$ref": "#/definitions/RoundingMode-nullable"
-                },
-                "valueOf(int)": {
-                    "$ref": "#/definitions/RoundingMode-nullable"
+                "compareTo(RoundingMode)": {
+                    "type": "integer",
+                    "$anchor": "#anchor",
+                    "title": "int",
+                    "description": "for type in general: int"
                 },
                 "values()": {
                     "type": ["array", "null"],
@@ -101,6 +95,12 @@
                     "minItems": 2,
                     "maxItems": 100,
                     "uniqueItems": false
+                },
+                "valueOf(int)": {
+                    "$ref": "#/definitions/RoundingMode-nullable"
+                },
+                "valueOf(String)": {
+                    "$ref": "#/definitions/RoundingMode-nullable"
                 }
             },
             "$anchor": "#anchor",
@@ -118,19 +118,16 @@
         "TestClass1": {
             "type": "object",
             "properties": {
-                "CONSTANT": {
-                    "type": "integer",
-                    "const": 5,
+                "genericValue": {
+                    "type": ["string", "null"],
                     "$anchor": "#anchor",
-                    "title": "Long",
-                    "description": "for type in general: Long",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
+                    "title": "String",
+                    "description": "for type in general: String",
+                    "const": "constant string value",
+                    "minLength": 1,
+                    "maxLength": 256,
+                    "format": "date",
+                    "pattern": "^.{1,256}$"
                 },
                 "genericArray": {
                     "type": ["array", "null"],
@@ -151,16 +148,11 @@
                     "maxItems": 100,
                     "uniqueItems": false
                 },
-                "genericValue": {
-                    "type": ["string", "null"],
+                "primitiveValue": {
+                    "type": "integer",
                     "$anchor": "#anchor",
-                    "title": "String",
-                    "description": "for type in general: String",
-                    "const": "constant string value",
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
+                    "title": "int",
+                    "description": "for type in general: int"
                 },
                 "ignoredInternalValue": {
                     "type": ["integer", "null"],
@@ -175,7 +167,13 @@
                     "exclusiveMaximum": 11,
                     "multipleOf": 1
                 },
-                "primitiveValue": {
+                "isSimpleTestClass()": {
+                    "type": "boolean",
+                    "$anchor": "#anchor",
+                    "title": "boolean",
+                    "description": "for type in general: boolean"
+                },
+                "getPrimitiveValue()": {
                     "type": "integer",
                     "$anchor": "#anchor",
                     "title": "int",
@@ -193,17 +191,19 @@
                     "format": "date",
                     "pattern": "^.{1,256}$"
                 },
-                "getPrimitiveValue()": {
+                "CONSTANT": {
                     "type": "integer",
+                    "const": 5,
                     "$anchor": "#anchor",
-                    "title": "int",
-                    "description": "for type in general: int"
-                },
-                "isSimpleTestClass()": {
-                    "type": "boolean",
-                    "$anchor": "#anchor",
-                    "title": "boolean",
-                    "description": "for type in general: boolean"
+                    "title": "Long",
+                    "description": "for type in general: Long",
+                    "default": 1,
+                    "enum": [1, 2, 3, 4, 5],
+                    "minimum": 1,
+                    "exclusiveMinimum": 0,
+                    "maximum": 1E+1,
+                    "exclusiveMaximum": 11,
+                    "multipleOf": 1
                 }
             },
             "$id": "id-TestClass1",
@@ -228,6 +228,19 @@
         "TestClass2(Long)": {
             "type": "object",
             "properties": {
+                "genericValue": {
+                    "type": ["integer", "null"],
+                    "$anchor": "#anchor",
+                    "title": "Long",
+                    "description": "for type in general: Long",
+                    "default": 1,
+                    "enum": [1, 2, 3, 4, 5],
+                    "minimum": 1,
+                    "exclusiveMinimum": 0,
+                    "maximum": 1E+1,
+                    "exclusiveMaximum": 11,
+                    "multipleOf": 1
+                },
                 "genericArray": {
                     "type": ["array", "null"],
                     "items": {
@@ -248,19 +261,6 @@
                     "minItems": 2,
                     "maxItems": 100,
                     "uniqueItems": false
-                },
-                "genericValue": {
-                    "type": ["integer", "null"],
-                    "$anchor": "#anchor",
-                    "title": "Long",
-                    "description": "for type in general: Long",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
                 },
                 "getGenericValue()": {
                     "type": ["integer", "null"],
@@ -307,6 +307,17 @@
         "TestClass2(String)": {
             "type": "object",
             "properties": {
+                "genericValue": {
+                    "type": ["string", "null"],
+                    "$anchor": "#anchor",
+                    "title": "String",
+                    "description": "for type in general: String",
+                    "const": "constant string value",
+                    "minLength": 1,
+                    "maxLength": 256,
+                    "format": "date",
+                    "pattern": "^.{1,256}$"
+                },
                 "genericArray": {
                     "type": ["array", "null"],
                     "items": {
@@ -325,17 +336,6 @@
                     "minItems": 2,
                     "maxItems": 100,
                     "uniqueItems": false
-                },
-                "genericValue": {
-                    "type": ["string", "null"],
-                    "$anchor": "#anchor",
-                    "title": "String",
-                    "description": "for type in general: String",
-                    "const": "constant string value",
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
                 },
                 "getGenericValue()": {
                     "type": ["string", "null"],
@@ -378,6 +378,18 @@
         "TestClass2(TestClass1*)-nullable": {
             "type": ["object", "null"],
             "properties": {
+                "genericValue": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "#/definitions/TestClass1"
+                    },
+                    "$id": "id-TestClass1[]",
+                    "title": "TestClass1[]",
+                    "description": "for type in general: TestClass1[]",
+                    "minItems": 2,
+                    "maxItems": 100,
+                    "uniqueItems": false
+                },
                 "genericArray": {
                     "type": ["array", "null"],
                     "items": {
@@ -395,18 +407,6 @@
                     "$id": "id-TestClass1[][]<TestClass1[]>",
                     "title": "TestClass1[][]<TestClass1[]>",
                     "description": "for type in general: TestClass1[][]<TestClass1[]>",
-                    "minItems": 2,
-                    "maxItems": 100,
-                    "uniqueItems": false
-                },
-                "genericValue": {
-                    "type": ["array", "null"],
-                    "items": {
-                        "$ref": "#/definitions/TestClass1"
-                    },
-                    "$id": "id-TestClass1[]",
-                    "title": "TestClass1[]",
-                    "description": "for type in general: TestClass1[]",
                     "minItems": 2,
                     "maxItems": 100,
                     "uniqueItems": false
@@ -447,6 +447,9 @@
         "TestClass2(TestClass2(String))-nullable": {
             "type": ["object", "null"],
             "properties": {
+                "genericValue": {
+                    "$ref": "#/definitions/TestClass2(String)-nullable"
+                },
                 "genericArray": {
                     "type": ["array", "null"],
                     "items": {
@@ -458,9 +461,6 @@
                     "minItems": 2,
                     "maxItems": 100,
                     "uniqueItems": false
-                },
-                "genericValue": {
-                    "$ref": "#/definitions/TestClass2(String)-nullable"
                 },
                 "getGenericValue()": {
                     "$ref": "#/definitions/TestClass2(String)-nullable"
@@ -480,13 +480,6 @@
         "TestClass4(Integer,String)-nullable": {
             "type": ["object", "null"],
             "properties": {
-                "DEFAULT_ROUNDING_MODE": {
-                    "allOf": [{
-                            "$ref": "#/definitions/RoundingMode"
-                        }, {
-                            "const": "HALF_UP"
-                        }]
-                },
                 "class2OfClass2OfT": {
                     "$ref": "#/definitions/TestClass2(TestClass2(String))-nullable"
                 },
@@ -495,6 +488,13 @@
                 },
                 "getClass2OfClass2OfT()": {
                     "$ref": "#/definitions/TestClass2(TestClass2(String))-nullable"
+                },
+                "DEFAULT_ROUNDING_MODE": {
+                    "allOf": [{
+                            "$ref": "#/definitions/RoundingMode"
+                        }, {
+                            "const": "HALF_UP"
+                        }]
                 }
             },
             "$id": "id-TestClass4<Integer, String>",
@@ -516,16 +516,28 @@
     },
     "type": "object",
     "properties": {
-        "class4": {
-            "$ref": "#/definitions/TestClass4(Integer,String)-nullable"
+        "nestedLong": {
+            "$ref": "#/definitions/TestClass2(Long)-nullable"
         },
         "nestedClass1Array": {
             "$ref": "#/definitions/TestClass2(TestClass1*)-nullable"
         },
-        "nestedLong": {
-            "$ref": "#/definitions/TestClass2(Long)-nullable"
-        },
         "nestedLongList": {
+            "type": ["array", "null"],
+            "items": {
+                "$ref": "#/definitions/TestClass2(Long)"
+            },
+            "$id": "id-List<TestClass2<Long>>",
+            "title": "List<TestClass2<Long>>",
+            "description": "for type in general: List<TestClass2<Long>>",
+            "minItems": 2,
+            "maxItems": 100,
+            "uniqueItems": false
+        },
+        "class4": {
+            "$ref": "#/definitions/TestClass4(Integer,String)-nullable"
+        },
+        "getNestedLongList()": {
             "type": ["array", "null"],
             "items": {
                 "$ref": "#/definitions/TestClass2(Long)"
@@ -540,23 +552,11 @@
         "getClass4()": {
             "$ref": "#/definitions/TestClass4(Integer,String)-nullable"
         },
-        "getNestedClass1Array()": {
-            "$ref": "#/definitions/TestClass2(TestClass1*)-nullable"
-        },
         "getNestedLong()": {
             "$ref": "#/definitions/TestClass2(Long)-nullable"
         },
-        "getNestedLongList()": {
-            "type": ["array", "null"],
-            "items": {
-                "$ref": "#/definitions/TestClass2(Long)"
-            },
-            "$id": "id-List<TestClass2<Long>>",
-            "title": "List<TestClass2<Long>>",
-            "description": "for type in general: List<TestClass2<Long>>",
-            "minItems": 2,
-            "maxItems": 100,
-            "uniqueItems": false
+        "getNestedClass1Array()": {
+            "$ref": "#/definitions/TestClass2(TestClass1*)-nullable"
         }
     },
     "$id": "id-TestClass3",

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-fieldattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-fieldattributes.json
@@ -451,5 +451,5 @@
             }
         }
     },
-    "required": ["nestedLongList", "nestedLong", "nestedClass1Array"]
+    "required": ["nestedClass1Array", "nestedLong", "nestedLongList"]
 }

--- a/jsonschema-module-javax-validation/src/test/resources/com/github/victools/jsonschema/module/javax/validation/integration-test-result.json
+++ b/jsonschema-module-javax-validation/src/test/resources/com/github/victools/jsonschema/module/javax/validation/integration-test-result.json
@@ -59,5 +59,5 @@
             "maxLength": 12
         }
     },
-    "required": ["notNullEmail", "notEmptyPatternText", "notBlankText", "notEmptyList", "notNullList"]
+    "required": ["notBlankText", "notEmptyList", "notEmptyPatternText", "notNullEmail", "notNullList"]
 }


### PR DESCRIPTION
By default, an object's properties are being sorted alphabetically by their names – with fields being listed first followed by the methods (depending on what is being included).

With this change, it is possible to alter the sorting algorithm.

Unfortunately, the possibility to preserve the declaration order requested in GH-92 depends on the specific compiler being used – but at least, this way you can apply any sorting you want, e.g. based on the Jackson `@JsonPropertyOrder` or similar annotations if you so chose.