### PR TITLE
feat: cache looked up getter and field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-generator`
+#### Changed
+- Cache looked-up getter in `FieldScope.findGetter()`
+- Cache looked-up field in `MethodScope.findGetterField()`
+
+### `jsonschema-maven-plugin`
+#### Fixed
+- Clearer error message in case of package resolution finding no types to produce schemas for
 
 ## [4.12.1] - 2020-05-28
 ### `jsonschema-maven-plugin`

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/MethodScope.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/MethodScope.java
@@ -19,6 +19,7 @@ package com.github.victools.jsonschema.generator;
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.ResolvedTypeWithMembers;
 import com.fasterxml.classmate.members.ResolvedMethod;
+import com.github.victools.jsonschema.generator.impl.LazyValue;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.AnnotatedType;
@@ -32,6 +33,8 @@ import java.util.stream.Stream;
  * Representation of a single introspected method.
  */
 public class MethodScope extends MemberScope<ResolvedMethod, Method> {
+
+    private final LazyValue<FieldScope> getterField = new LazyValue<>(this::doFindGetterField);
 
     /**
      * Constructor.
@@ -111,6 +114,15 @@ public class MethodScope extends MemberScope<ResolvedMethod, Method> {
      * @return associated field
      */
     public FieldScope findGetterField() {
+        return this.getterField.get();
+    }
+
+    /**
+     * Look-up the field associated with this method if it is deemed to be a getter by convention.
+     *
+     * @return associated field
+     */
+    private FieldScope doFindGetterField() {
         if (this.getType() == null || !this.isPublic() || this.getArgumentCount() > 0) {
             // void and non-public methods or those with arguments are not deemed to be getters
             return null;

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/LazyValue.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/LazyValue.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.generator.impl;
+
+import java.util.function.Supplier;
+
+/**
+ * Wrapper for a value that should only be lazily initialised when being accessed for the first time.
+ *
+ * @param <T> type of wrapped value
+ */
+public class LazyValue<T> {
+
+    private final Supplier<? extends T> supplier;
+    private boolean initPending;
+    private T value;
+
+    /**
+     * Constructor, not yet invoking the given {@link Supplier}.
+     *
+     * @param supplier value look-up to be performed the first time {@link #get()} is being called
+     */
+    public LazyValue(Supplier<? extends T> supplier) {
+        this.supplier = supplier;
+        this.initPending = true;
+    }
+
+    /**
+     * Look-up the wrapped value, loading it on first invocation.
+     *
+     * @return wrapped value
+     */
+    public T get() {
+        if (this.initPending) {
+            // explicitly NOT thread-safe as it seems unnecessary here to add that overhead
+            this.value = this.supplier.get();
+            this.initPending = false;
+        }
+        return this.value;
+    }
+}


### PR DESCRIPTION
Slight performance improvement:
- Cache looked-up getter in `FieldScope.findGetter()`
- Cache looked-up field in `MethodScope.findGetterField()`