### PR TITLE
feat: extend keyword enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-generator`
+#### Added
+- Entries in `SchemaKeyword` enum for `"not"`, `"minProperties"`, `"maxProperties"` (without further handling)
+
+### `jsonschema-module-swagger-2`
+#### Changed
+- Make use of new `SchemaKeyword` enum entries instead of hard-coded strings (no change in behaviour)
 
 ## [4.13.0] - 2020-06-27
 ### `jsonschema-generator`

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
@@ -57,10 +57,13 @@ public enum SchemaKeyword {
     TAG_REQUIRED("required"),
     TAG_ADDITIONAL_PROPERTIES("additionalProperties"),
     TAG_PATTERN_PROPERTIES("patternProperties"),
+    TAG_PROPERTIES_MIN("minProperties"),
+    TAG_PROPERTIES_MAX("maxProperties"),
 
     TAG_ALLOF("allOf"),
     TAG_ANYOF("anyOf"),
     TAG_ONEOF("oneOf"),
+    TAG_NOT("not"),
 
     TAG_TITLE("title"),
     TAG_DESCRIPTION("description"),

--- a/jsonschema-module-swagger-2/src/main/java/com/github/victools/jsonschema/module/swagger2/Swagger2Module.java
+++ b/jsonschema-module-swagger-2/src/main/java/com/github/victools/jsonschema/module/swagger2/Swagger2Module.java
@@ -404,7 +404,8 @@ public class Swagger2Module implements Module {
             return;
         }
         if (annotation.not() != Void.class) {
-            memberAttributes.set("not", context.createDefinitionReference(context.getTypeContext().resolve(annotation.not())));
+            memberAttributes.set(context.getKeyword(SchemaKeyword.TAG_NOT),
+                    context.createDefinitionReference(context.getTypeContext().resolve(annotation.not())));
         }
         if (annotation.allOf().length > 0) {
             Stream.of(annotation.allOf())
@@ -413,10 +414,10 @@ public class Swagger2Module implements Module {
                     .withArray(context.getKeyword(SchemaKeyword.TAG_ALLOF))::add);
         }
         if (annotation.minProperties() > 0) {
-            memberAttributes.put("minProperties", annotation.minProperties());
+            memberAttributes.put(context.getKeyword(SchemaKeyword.TAG_PROPERTIES_MIN), annotation.minProperties());
         }
         if (annotation.maxProperties() > 0) {
-            memberAttributes.put("maxProperties", annotation.maxProperties());
+            memberAttributes.put(context.getKeyword(SchemaKeyword.TAG_PROPERTIES_MAX), annotation.maxProperties());
         }
         if (annotation.requiredProperties().length > 0) {
             Set<String> alreadyMentionedRequiredFields = new HashSet<>();


### PR DESCRIPTION
As requested on GH-124 by @pahujatarun25, adding `"not"` to the `SchemaKeyword` enum even though no special handling of explicit configuration is supported at this stage.

So far, this keyword was only hard-coded in the new `jsonschema-module-swagger-2` where the `"minProperties"` and `"maxProperties"` keyword had also been hard-coded. To be consistent, those two are added to the central `SchemaKeyword` enum as well.

This is no behaviour change and purely convenience for users trying to avoid hard-coding on their side by using the `SchemaKeyword` enum (which is it's secondary purpose - the main purpose being the transparent support of keywords being renamed from one JSON Schema Draft to another, e.g `"id"` vs. `"$id"`).