### PR TITLE
feat: maven plugin supporting globs and exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 - Explicitly include dependencies of supported generator modules that they expect to be provided
+- Avoid generating the same schema multiple times if there are overlaps between entries in `<classNames>` and/or `<packageNames>`
 
 ## [4.13.0] - 2020-06-27
 ### `jsonschema-generator`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make use of new `SchemaKeyword` enum entries instead of hard-coded strings (no change in behaviour)
 
 ### `jsonschema-maven-plugin`
+#### Added
+- Support for including classes via glob patterns in `<classNames>` and `<packageNames>` (in addition to absolute paths)
+- Support for excluding classes via absolute paths or glob patterns in new `<excludeClassNames>`
+
 #### Fixed
 - Explicitly include dependencies of supported generator modules that they expect to be provided
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -198,6 +198,7 @@
         <module name="InnerAssignment" />
         <module name="CyclomaticComplexity">
             <property name="max" value="16"/>
+            <property name="switchBlockAsSingleDecisionPoint" value="true"/>
         </module>
     </module>
 </module>

--- a/jsonschema-maven-plugin/README.md
+++ b/jsonschema-maven-plugin/README.md
@@ -32,17 +32,31 @@ Maven plugin for the [jsonschema-generator](../jsonschema-generator) – Integra
 This will use the default configuration of the generator.
 
 ### Selecting the classes for generation
-The classes for which the JSON schema has to be generated are configured using the `<classNames>` and the `<packageNames>` elements.
-This can be either one element, or multiple by using nested elements.
+The classes for which a JSON schema should be generated are configured using the `<classNames>` and/or `<packageNames>` elements.
+Via `<excludeClassNames>` you can filter-out some classes again.
+These can be either a single element, or multiple by using nested elements.
 
 ```xml
-    <configuration>
-        <classNames>com.myOrg.myApp.MyClass</classNames>
-        <packageNames>
-            <packageName>com.myOrg.myApp.package1</packageName>
-            <packageName>com.myOrg.myApp.package2</packageName>
-        </packageNames>
-    </configuration>
+<configuration>
+    <classNames>com.myOrg.myApp.MyClass</classNames>
+    <packageNames>
+        <packageName>com.myOrg.myApp.package1</packageName>
+        <packageName>com.myOrg.myApp.package2</packageName>
+    </packageNames>
+    <excludeClassNames>com.myOrg.myApp.package2.HiddenClass</excludeClassNames>
+</configuration>
+```
+
+The content of each of these elements can be either:
+- an absolute path with dots (`.`) as package separators or
+- a glob pattern with slashes (`/`) as package separators and various types of placeholders (e.g. `?`, `*`, `**`).
+
+```xml
+<configuration>
+    <classNames>com/myOrg/myApp/My*</classNames>
+    <packageNames>com/myOrg/myApp/package?</packageNames>
+    <excludeClassNames>com/myOrg/myApp/**Hidden*</excludeClassNames>
+</configuration>
 ```
 
 ### Configuring generated file names and locations

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/GlobHandler.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/GlobHandler.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.plugin.maven;
+
+import java.util.regex.Pattern;
+
+/**
+ * Conversion logic from globs to regular expressions. Adapted from: https://stackoverflow.com/a/17369948
+ */
+public class GlobHandler {
+
+    /**
+     * Converts a standard POSIX Shell globbing pattern into a regular expression pattern. The result can be used with the standard
+     * {@link java.util.regex} API to recognize strings which match the glob pattern.
+     * <p>
+     * See also, the POSIX Shell language: http://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_13_01
+     * </p>
+     *
+     * @param pattern A glob pattern.
+     * @return A regex pattern to recognize the given glob pattern.
+     */
+    public static final String convertGlobToRegex(String pattern) {
+        StringBuilder sb = new StringBuilder(pattern.length());
+        int inGroup = 0;
+        int inClass = 0;
+        int firstIndexInClass = -1;
+        char[] arr = pattern.toCharArray();
+        for (int i = 0; i < arr.length; i++) {
+            char ch = arr[i];
+            switch (ch) {
+            case '\\':
+                if (++i >= arr.length) {
+                    sb.append('\\');
+                } else {
+                    char next = arr[i];
+                    switch (next) {
+                    case ',':
+                        // escape not needed
+                        break;
+                    case 'Q':
+                    case 'E':
+                        // extra escape needed
+                        sb.append("\\\\");
+                        break;
+                    default:
+                        sb.append('\\');
+                    }
+                    sb.append(next);
+                }
+                break;
+            case '*':
+                if (inClass != 0) {
+                    sb.append('*');
+                } else if ((i + 1) < arr.length && arr[i + 1] == '*') {
+                    i++;
+                    sb.append(".*");
+                } else {
+                    sb.append("[^/]*");
+                }
+                break;
+            case '?':
+                if (inClass == 0) {
+                    sb.append("[^/]");
+                } else {
+                    sb.append('?');
+                }
+                break;
+            case '[':
+                inClass++;
+                firstIndexInClass = i + 1;
+                sb.append('[');
+                break;
+            case ']':
+                inClass--;
+                sb.append(']');
+                break;
+            case '.':
+            case '(':
+            case ')':
+            case '+':
+            case '|':
+            case '^':
+            case '$':
+            case '@':
+            case '%':
+                if (inClass == 0 || (firstIndexInClass == i && ch == '^')) {
+                    sb.append('\\');
+                }
+                sb.append(ch);
+                break;
+            case '!':
+                if (firstIndexInClass == i) {
+                    sb.append('^');
+                } else {
+                    sb.append('!');
+                }
+                break;
+            case '{':
+                inGroup++;
+                sb.append('(');
+                break;
+            case '}':
+                inGroup--;
+                sb.append(')');
+                break;
+            case ',':
+                if (inGroup > 0) {
+                    sb.append('|');
+                } else {
+                    sb.append(',');
+                }
+                break;
+            default:
+                sb.append(ch);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Generate regular expression from the given input for filtering classes on the classpath.
+     *
+     * @param input either absolute value (with "." as package separator) or glob pattern (with "/" as package separator)
+     * @param forPackage whether the given input identifies a package
+     * @return regular expression to filter classes on classpath by
+     */
+    public static Pattern createClassOrPackageNameFilter(String input, boolean forPackage) {
+        String inputRegex;
+        if (input.chars().anyMatch(singleChar -> singleChar == '/' || singleChar == '*')) {
+            // convert glob pattern into regular expression
+            inputRegex = GlobHandler.convertGlobToRegex(input);
+        } else {
+            // backward compatible support for absolute paths with "." as separator
+            inputRegex = input.replace('.', '/');
+        }
+        if (forPackage) {
+            // cater for any classname and any subpackages in between
+            inputRegex += inputRegex.endsWith("/") ? ".+" : "/.+";
+        }
+        return Pattern.compile(inputRegex);
+    }
+}

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/PotentialSchemaClass.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/PotentialSchemaClass.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.plugin.maven;
+
+/**
+ * Wrapper for a class on the classpath for which a schema may be generated.
+ */
+public class PotentialSchemaClass implements Comparable<PotentialSchemaClass> {
+
+    private final String fullClassName;
+    private final String absolutePathToMatch;
+    private boolean alreadyGenerated;
+
+    /**
+     * Constructor expecting the full class name including its package path with "." as separators.
+     *
+     * @param fullClassName targeted class's full name
+     */
+    public PotentialSchemaClass(String fullClassName) {
+        this.fullClassName = fullClassName;
+        this.absolutePathToMatch = fullClassName.replace('.', '/');
+        this.alreadyGenerated = false;
+    }
+
+    @Override
+    public int compareTo(PotentialSchemaClass other) {
+        return this.getFullClassName().compareTo(other.getFullClassName());
+    }
+
+    public String getFullClassName() {
+        return this.fullClassName;
+    }
+
+    public String getAbsolutePathToMatch() {
+        return this.absolutePathToMatch;
+    }
+
+    public boolean isAlreadyGenerated() {
+        return alreadyGenerated;
+    }
+
+    public void setAlreadyGenerated() {
+        this.alreadyGenerated = true;
+    }
+}

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
@@ -226,7 +226,7 @@ public class SchemaGeneratorMojo extends AbstractMojo {
             Reflections reflections = new Reflections("", new SubTypesScanner(false), this.getClassLoader());
             Stream<PotentialSchemaClass> allTypesStream = reflections.getAllTypes().stream()
                     .map(PotentialSchemaClass::new);
-            if (this.excludeClassNames != null) {
+            if (this.excludeClassNames != null && this.excludeClassNames.length > 0) {
                 Set<Pattern> exclusions = Stream.of(this.excludeClassNames)
                         .map(excludeEntry -> GlobHandler.createClassOrPackageNameFilter(excludeEntry, false))
                         .collect(Collectors.toSet());

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
@@ -180,6 +180,7 @@ public class SchemaGeneratorMojo extends AbstractMojo {
         Pattern filter = GlobHandler.createClassOrPackageNameFilter(classOrPackageName, targetPackage);
         List<PotentialSchemaClass> matchingClasses = this.getAllClassNames().stream()
                 .filter(entry -> filter.matcher(entry.getAbsolutePathToMatch()).matches())
+                .sorted()
                 .collect(Collectors.toList());
         for (PotentialSchemaClass potentialTarget : matchingClasses) {
             if (potentialTarget.isAlreadyGenerated()) {
@@ -232,7 +233,7 @@ public class SchemaGeneratorMojo extends AbstractMojo {
                 allTypesStream = allTypesStream
                         .filter(typeEntry -> exclusions.stream().noneMatch(pattern -> pattern.matcher(typeEntry.getAbsolutePathToMatch()).matches()));
             }
-            this.allTypes = allTypesStream.sorted().collect(Collectors.toList());
+            this.allTypes = allTypesStream.collect(Collectors.toList());
         }
         return this.allTypes;
     }

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/GlobHandlerTest.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/GlobHandlerTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.plugin.maven;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for conversion logic from globs to regular expressions. Adapted from: https://stackoverflow.com/a/17369948
+ */
+@RunWith(JUnitParamsRunner.class)
+public class GlobHandlerTest {
+
+    public Object[] parametersForTestBasicPattern() {
+        return new Object[][]{
+            {"single star becomes all but shlash star", "gl*b", "gl[^/]*b"},
+            {"double star becomes dot star", "gl**b", "gl.*b"},
+            {"escaped star is unchanged", "gl\\*b", "gl\\*b"},
+            {"question mark becomes all but shlash", "gl?b", "gl[^/]b"},
+            {"escaped question mark is unchanged", "gl\\?b", "gl\\?b"},
+            {"character classes dont need conversion", "gl[-o]b", "gl[-o]b"},
+            {"escaped classes are unchanged", "gl\\[-o\\]b", "gl\\[-o\\]b"},
+            {"negation in character classes", "gl[!a-n!p-z]b", "gl[^a-n!p-z]b"},
+            {"nested negation in character classes", "gl[[!a-n]!p-z]b", "gl[[^a-n]!p-z]b"},
+            {"escape carat if it is the first char in a character class", "gl[^o]b", "gl[\\^o]b"},
+            {"metachars are escaped", "gl?*.()+|^$@%b", "gl[^/][^/]*\\.\\(\\)\\+\\|\\^\\$\\@\\%b"},
+            {"metachars in character classes dont need escaping", "gl[?*.()+|^$@%]b", "gl[?*.()+|^$@%]b"},
+            {"escaped backslash is unchanged", "gl\\\\b", "gl\\\\b"},
+            {"slash-Q and slash-E are escaped", "\\Qglob\\E", "\\\\Qglob\\\\E"},
+            {"braces are turned into groups", "{glob,regex}", "(glob|regex)"},
+            {"escaped braces are unchanged", "\\{glob\\}", "\\{glob\\}"},
+            {"commas dont need escaping", "{glob\\,regex},", "(glob,regex),"},
+        };
+    }
+
+    @Test
+    @TestCaseName("testBasicPattern: {0}")
+    @Parameters
+    public void testBasicPattern(String testCaseName, String globInput, String regexOutput) {
+        Assert.assertEquals(regexOutput, GlobHandler.convertGlobToRegex(globInput));
+    }
+
+    /*
+     * Additional tests for more realistic patterns for classnames.
+     */
+    @Test
+    @Parameters({
+        "com/**/testpackage/*, true, com/github/victools/jsonschema/plugin/maven/testpackage/TestClassA",
+        "com/**/testpackage/*, false, com/github/victools/jsonschema/plugin/maven/testpackage/subpackage/TestClassC",
+        "com/**/testpackage/**, true, com/github/victools/jsonschema/plugin/maven/testpackage/TestClassA",
+        "com/**/testpackage/**, true, com/github/victools/jsonschema/plugin/maven/testpackage/subpackage/TestClassC",
+        "com/**/testpackage, false, com/github/victools/jsonschema/plugin/maven/testpackage/TestClassA",
+        "com/**/testpackage, false, com/github/victools/jsonschema/plugin/maven/testpackage/subpackage/TestClassC",
+        "**/subpackage/**, false, com/github/victools/jsonschema/plugin/maven/testpackage/TestClassA",
+        "**/subpackage/**, true, com/github/victools/jsonschema/plugin/maven/testpackage/subpackage/TestClassC",
+        "**/subpackage, false, com/github/victools/jsonschema/plugin/maven/testpackage/subpackage/TestClassC",
+        "subpackage/**, false, com/github/victools/jsonschema/plugin/maven/testpackage/subpackage/TestClassC",
+        "com/*/victools/**, true, com/github/victools/jsonschema/plugin/maven/testpackage/TestClassA",
+        "com/*/jsonschema/**, false, com/github/victools/jsonschema/plugin/maven/testpackage/TestClassA",
+        "com/**/jsonschema/**, true, com/github/victools/jsonschema/plugin/maven/testpackage/TestClassA",
+    })
+    public void testClassNamePattern(String inputPattern, boolean matching, String classNamePath) {
+        String regex = GlobHandler.convertGlobToRegex(inputPattern);
+        Assert.assertSame(matching, classNamePath.matches(regex));
+    }
+}

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/SchemaFileName-pom.xml
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/SchemaFileName-pom.xml
@@ -7,7 +7,7 @@
                 <configuration>
                     <classNames>
                         <className>com.github.victools.jsonschema.plugin.maven.testpackage.TestClassA</className>
-                        <className>com.github.victools.jsonschema.plugin.maven.testpackage.TestClassB</className>
+                        <className>com/github/victools/**/testpackage/*</className>
                     </classNames>
                     <schemaFilePath>target/generated-test-sources/SchemaFileName</schemaFilePath>
                     <schemaFileName>schemas/{1}/{0}.schema</schemaFileName>

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/TwoClasses-pom.xml
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/TwoClasses-pom.xml
@@ -7,7 +7,7 @@
                 <configuration>
                     <classNames>
                         <className>com.github.victools.jsonschema.plugin.maven.testpackage.TestClassA</className>
-                        <className>com.github.victools.jsonschema.plugin.maven.testpackage.TestClassB</className>
+                        <className>com/github/victools/**/testpackage/TestClassB</className>
                     </classNames>
                     <schemaFilePath>target/generated-test-sources/TwoClasses</schemaFilePath>
                     <schemaFileName>{0}.schema</schemaFileName>


### PR DESCRIPTION
Implementing feature requested in GH-104:
- Adding support for including classes via glob patterns in `<classNames>` and `<packageNames>` (in addition to absolute paths)
- Adding support for excluding classes via absolute paths or glob patterns in new `<excludeClassNames>`
- Avoid generating the same schema multiple times if there are overlaps between entries in `<classNames>` and/or `<packageNames>`.

The logic around converting a glob into a regular expression is rather complicated, but the resulting configuration is quite straightforward.
It is backward compatible with regards to the absolute paths including dots (`.´) as package separators.
@JanLabrie what do you think?