### PR TITLE
feat: support extra OpenAPI format values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-generator`
+#### Added
+- New `Option.EXTRA_OPEN_API_FORMAT_VALUES` to support automatic inclusion of `"format"` values for certain simple/fixed types
 
 ## [4.14.0] - 2020-08-02
 ### `jsonschema-generator`

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/Option.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/Option.java
@@ -252,6 +252,15 @@ public enum Option {
      */
     PLAIN_DEFINITION_KEYS(null, null),
     /**
+     * For the "format" attribute, JSON Schema defines various supported values. The OpenAPI specification assigns a few more of those in order to
+     * differentiate between standard data types (e.g. float vs. double) and even some more fixed data types (e.g. LocalDate, LocalDateTime) if
+     * {@link #ADDITIONAL_FIXED_TYPES} is enabled. By enabling this option, these extra "format" values will be set for the respective
+     * primitive/standard data types automatically.
+     *
+     * @since 4.15.0
+     */
+    EXTRA_OPEN_API_FORMAT_VALUES(null, null),
+    /**
      * Whether as the last step of the schema generation, unnecessary "allOf" elements (i.e. where there are no conflicts/overlaps between the
      * contained sub-schemas) should be merged into one, in order to make the generated schema more readable. This also applies to manually added
      * "allOf" elements, e.g. through custom definitions or attribute overrides.

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
@@ -87,6 +87,13 @@ public interface SchemaGeneratorConfig {
     boolean shouldUsePlainDefinitionKeys();
 
     /**
+     * Determine whether extra {@link SchemaKeyword#TAG_FORMAT} values should be included for "simple types".
+     *
+     * @return whether to include extra {@link SchemaKeyword#TAG_FORMAT} values
+     */
+    boolean shouldIncludeExtraOpenApiFormatValues();
+
+    /**
      * Determine whether unnecessary {@link SchemaKeyword#TAG_ALLOF} elements should be removed and merged into their declaring schema when there are
      * no conflicts between the sub-schemas.
      *

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
@@ -125,6 +125,11 @@ public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
     }
 
     @Override
+    public boolean shouldIncludeExtraOpenApiFormatValues() {
+        return this.isOptionEnabled(Option.EXTRA_OPEN_API_FORMAT_VALUES);
+    }
+
+    @Override
     public boolean shouldCleanupUnnecessaryAllOfElements() {
         return this.isOptionEnabled(Option.ALLOF_CLEANUP_AT_THE_END);
     }

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSimpleTypesTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSimpleTypesTest.java
@@ -32,38 +32,65 @@ import org.junit.runner.RunWith;
 @RunWith(JUnitParamsRunner.class)
 public class SchemaGeneratorSimpleTypesTest {
 
-    Object parametersForTestGenerateSchema_SimpleType() {
-        Object[][] typeCombinations = new Object[][]{
-            {Object.class, null},
-            {String.class, SchemaKeyword.TAG_TYPE_STRING},
-            {Character.class, SchemaKeyword.TAG_TYPE_STRING},
-            {char.class, SchemaKeyword.TAG_TYPE_STRING},
-            {CharSequence.class, SchemaKeyword.TAG_TYPE_STRING},
-            {Byte.class, SchemaKeyword.TAG_TYPE_STRING},
-            {byte.class, SchemaKeyword.TAG_TYPE_STRING},
-            {Boolean.class, SchemaKeyword.TAG_TYPE_BOOLEAN},
-            {boolean.class, SchemaKeyword.TAG_TYPE_BOOLEAN},
-            {Integer.class, SchemaKeyword.TAG_TYPE_INTEGER},
-            {int.class, SchemaKeyword.TAG_TYPE_INTEGER},
-            {Long.class, SchemaKeyword.TAG_TYPE_INTEGER},
-            {long.class, SchemaKeyword.TAG_TYPE_INTEGER},
-            {Short.class, SchemaKeyword.TAG_TYPE_INTEGER},
-            {short.class, SchemaKeyword.TAG_TYPE_INTEGER},
-            {Double.class, SchemaKeyword.TAG_TYPE_NUMBER},
-            {double.class, SchemaKeyword.TAG_TYPE_NUMBER},
-            {Float.class, SchemaKeyword.TAG_TYPE_NUMBER},
-            {float.class, SchemaKeyword.TAG_TYPE_NUMBER}
+    private Object[][] getSimpleTypeCombinations() {
+        return new Object[][]{
+            {Object.class, null, null},
+            {String.class, SchemaKeyword.TAG_TYPE_STRING, null},
+            {Character.class, SchemaKeyword.TAG_TYPE_STRING, null},
+            {char.class, SchemaKeyword.TAG_TYPE_STRING, null},
+            {CharSequence.class, SchemaKeyword.TAG_TYPE_STRING, null},
+            {Byte.class, SchemaKeyword.TAG_TYPE_STRING, null},
+            {byte.class, SchemaKeyword.TAG_TYPE_STRING, null},
+            {Boolean.class, SchemaKeyword.TAG_TYPE_BOOLEAN, null},
+            {boolean.class, SchemaKeyword.TAG_TYPE_BOOLEAN, null},
+            {Integer.class, SchemaKeyword.TAG_TYPE_INTEGER, "int32"},
+            {int.class, SchemaKeyword.TAG_TYPE_INTEGER, "int32"},
+            {Long.class, SchemaKeyword.TAG_TYPE_INTEGER, "int64"},
+            {long.class, SchemaKeyword.TAG_TYPE_INTEGER, "int64"},
+            {Short.class, SchemaKeyword.TAG_TYPE_INTEGER, null},
+            {short.class, SchemaKeyword.TAG_TYPE_INTEGER, null},
+            {Double.class, SchemaKeyword.TAG_TYPE_NUMBER, "double"},
+            {double.class, SchemaKeyword.TAG_TYPE_NUMBER, "double"},
+            {Float.class, SchemaKeyword.TAG_TYPE_NUMBER, "float"},
+            {float.class, SchemaKeyword.TAG_TYPE_NUMBER, "float"},
+            {java.time.LocalDate.class, SchemaKeyword.TAG_TYPE_STRING, "date"},
+            {java.time.LocalDateTime.class, SchemaKeyword.TAG_TYPE_STRING, "date-time"},
+            {java.time.LocalTime.class, SchemaKeyword.TAG_TYPE_STRING, "date-time"},
+            {java.time.ZonedDateTime.class, SchemaKeyword.TAG_TYPE_STRING, "date-time"},
+            {java.time.OffsetDateTime.class, SchemaKeyword.TAG_TYPE_STRING, "date-time"},
+            {java.time.OffsetTime.class, SchemaKeyword.TAG_TYPE_STRING, "date-time"},
+            {java.time.Instant.class, SchemaKeyword.TAG_TYPE_STRING, "date-time"},
+            {java.util.Date.class, SchemaKeyword.TAG_TYPE_STRING, "date-time"},
+            {java.util.Calendar.class, SchemaKeyword.TAG_TYPE_STRING, "date-time"},
+            {java.util.UUID.class, SchemaKeyword.TAG_TYPE_STRING, "uuid"},
+            {java.time.ZoneId.class, SchemaKeyword.TAG_TYPE_STRING, null},
+            {java.math.BigInteger.class, SchemaKeyword.TAG_TYPE_INTEGER, null},
+            {java.math.BigDecimal.class, SchemaKeyword.TAG_TYPE_NUMBER, null},
+            {Number.class, SchemaKeyword.TAG_TYPE_NUMBER, null},
         };
+    }
+
+    Object[] parametersForTestGenerateSchema_SimpleTypeWithoutFormat() {
+        Object[][] typeCombinations = this.getSimpleTypeCombinations();
         return EnumSet.allOf(SchemaVersion.class).stream()
                 .flatMap(schemaVersion -> Arrays.stream(typeCombinations).map(entry -> new Object[]{entry[0], entry[1], schemaVersion}))
                 .toArray();
     }
 
+    Object[] parametersForTestGenerateSchema_SimpleTypeWithFormat() {
+        Object[][] typeCombinations = this.getSimpleTypeCombinations();
+        return EnumSet.allOf(SchemaVersion.class).stream()
+                .flatMap(schemaVersion -> Arrays.stream(typeCombinations).map(entry -> new Object[]{entry[0], entry[1], entry[2], schemaVersion}))
+                .toArray();
+    }
+
     @Test
     @Parameters
-    public void testGenerateSchema_SimpleType(Class<?> targetType, SchemaKeyword expectedJsonSchemaType, SchemaVersion schemaVersion)
+    public void testGenerateSchema_SimpleTypeWithoutFormat(Class<?> targetType, SchemaKeyword expectedJsonSchemaType, SchemaVersion schemaVersion)
             throws Exception {
-        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), schemaVersion).build();
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), schemaVersion)
+                .with(Option.ADDITIONAL_FIXED_TYPES)
+                .build();
         SchemaGenerator generator = new SchemaGenerator(config);
         JsonNode result = generator.generateSchema(targetType);
         if (expectedJsonSchemaType == null) {
@@ -76,11 +103,34 @@ public class SchemaGeneratorSimpleTypesTest {
     }
 
     @Test
-    @Parameters(method = "parametersForTestGenerateSchema_SimpleType")
+    @Parameters
+    public void testGenerateSchema_SimpleTypeWithFormat(Class<?> targetType, SchemaKeyword expectedJsonSchemaType, String expectedFormat,
+            SchemaVersion schemaVersion) throws Exception {
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), schemaVersion)
+                .with(Option.ADDITIONAL_FIXED_TYPES, Option.EXTRA_OPEN_API_FORMAT_VALUES)
+                .build();
+        SchemaGenerator generator = new SchemaGenerator(config);
+        JsonNode result = generator.generateSchema(targetType);
+        if (expectedJsonSchemaType == null) {
+            Assert.assertTrue(result.isEmpty());
+        } else if (expectedFormat == null) {
+            Assert.assertEquals(1, result.size());
+            Assert.assertEquals(expectedJsonSchemaType.forVersion(schemaVersion),
+                    result.get(SchemaKeyword.TAG_TYPE.forVersion(schemaVersion)).asText());
+        } else {
+            Assert.assertEquals(2, result.size());
+            Assert.assertEquals(expectedJsonSchemaType.forVersion(schemaVersion),
+                    result.get(SchemaKeyword.TAG_TYPE.forVersion(schemaVersion)).asText());
+            Assert.assertEquals(expectedFormat, result.get(SchemaKeyword.TAG_FORMAT.forVersion(schemaVersion)).asText());
+        }
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestGenerateSchema_SimpleTypeWithoutFormat")
     public void testGenerateSchema_SimpleType_withAdditionalPropertiesOption(Class<?> targetType, SchemaKeyword expectedJsonSchemaType,
             SchemaVersion schemaVersion) throws Exception {
         SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), schemaVersion)
-                .with(Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT)
+                .with(Option.ADDITIONAL_FIXED_TYPES, Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT)
                 .build();
         SchemaGenerator generator = new SchemaGenerator(config);
         JsonNode result = generator.generateSchema(targetType);


### PR DESCRIPTION
- Adding new `Option.EXTRA_OPEN_API_FORMAT_VALUES`
- When enabled, some extra `"format"` values are being included for certain fixed types
- Extending unit tests to cover the `Option.ADDITIONAL_FIXED_TYPES`