### PR TITLE
Support inline optional param annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - New `Option.EXTRA_OPEN_API_FORMAT_VALUES` to support automatic inclusion of `"format"` values for certain simple/fixed types
 
+### `jsonschema-module-javax-validation`
+#### Added
+- Support picking up annotations on a (top-level) generic `Optional` parameter (e.g. `Optional<@Size(min=2) String>`)
+
 ## [4.14.0] - 2020-08-02
 ### `jsonschema-generator`
 #### Added

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/FieldScope.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/FieldScope.java
@@ -140,7 +140,7 @@ public class FieldScope extends MemberScope<ResolvedField, Field> {
         AnnotatedType annotatedType = this.getRawMember().getAnnotatedType();
         if (annotatedType instanceof AnnotatedParameterizedType) {
             AnnotatedType[] typeArguments = ((AnnotatedParameterizedType) annotatedType).getAnnotatedActualTypeArguments();
-            if (typeArguments.length > 0) {
+            if (typeArguments.length == 1) {
                 return typeArguments[0].getAnnotation(annotationClass);
             }
         }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/MemberScope.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/MemberScope.java
@@ -285,7 +285,22 @@ public abstract class MemberScope<M extends ResolvedMember<T>, T extends Member>
     public abstract <A extends Annotation> A getAnnotationConsideringFieldAndGetter(Class<A> annotationClass);
 
     /**
-     * Return the annotation of the given type on the member's container item (i.e. first type parameter if there is one), if such an annotation is
+     * Return the annotation of the given type on the member, if such an annotation is present on either the field or its getter and this is not a
+     * {@link #isFakeContainerItemScope() fake container item scope}.
+     *
+     * @param <A> type of annotation
+     * @param annotationClass type of annotation
+     * @return annotation instance (or {@code null} if no annotation of the given type is present or the look-up is not supported by default)
+     */
+    public <A extends Annotation> A getAnnotationConsideringFieldAndGetterIfSupported(Class<A> annotationClass) {
+        if (this.isFakeContainerItemScope()) {
+            return null;
+        }
+        return this.getAnnotationConsideringFieldAndGetter(annotationClass);
+    }
+
+    /**
+     * Return the annotation of the given type on the member's container item (i.e. single type parameter if there is one), if such an annotation is
      * present on either the field or its getter.
      *
      * @param <A> type of annotation
@@ -293,6 +308,26 @@ public abstract class MemberScope<M extends ResolvedMember<T>, T extends Member>
      * @return annotation instance (or {@code null} if no annotation of the given type is present)
      */
     public abstract <A extends Annotation> A getContainerItemAnnotationConsideringFieldAndGetter(Class<A> annotationClass);
+
+    /**
+     * Return the annotation of the given type on the member's container item (i.e. single type parameter if there is one), if such an annotation is
+     * present on either the field or its getter and this particular member is either a collection or special generic type (e.g. {@link Optional}).
+     *
+     * @param <A> type of annotation
+     * @param annotationClass type of annotation
+     * @return annotation instance (or {@code null} if no annotation of the given type is present or this look-up is not supported by default )
+     */
+    public <A extends Annotation> A getContainerItemAnnotationConsideringFieldAndGetterIfSupported(Class<A> annotationClass) {
+        if (this.isFakeContainerItemScope()) {
+            return this.getContainerItemAnnotationConsideringFieldAndGetter(annotationClass);
+        }
+        if (this.getOverriddenType() != null
+                && this.getDeclaredType().getErasedType() == Optional.class
+                && this.getOverriddenType().getErasedType() == this.getDeclaredType().getTypeParameters().get(0).getErasedType()) {
+            return this.getContainerItemAnnotationConsideringFieldAndGetter(annotationClass);
+        }
+        return null;
+    }
 
     /**
      * Returns the name to be used to reference this member in its parent's "properties".

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/MethodScope.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/MethodScope.java
@@ -182,7 +182,7 @@ public class MethodScope extends MemberScope<ResolvedMethod, Method> {
         AnnotatedType annotatedReturnType = this.getRawMember().getAnnotatedReturnType();
         if (annotatedReturnType instanceof AnnotatedParameterizedType) {
             AnnotatedType[] typeArguments = ((AnnotatedParameterizedType) annotatedReturnType).getAnnotatedActualTypeArguments();
-            if (typeArguments.length > 0) {
+            if (typeArguments.length == 1) {
                 return typeArguments[0].getAnnotation(annotationClass);
             }
         }

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -127,11 +127,8 @@ public class JacksonModule implements Module {
      * @return successfully looked-up description (or {@code null})
      */
     protected String resolveDescription(FieldScope field) {
-        if (field.isFakeContainerItemScope()) {
-            return null;
-        }
         // look for property specific description
-        JsonPropertyDescription propertyAnnotation = field.getAnnotationConsideringFieldAndGetter(JsonPropertyDescription.class);
+        JsonPropertyDescription propertyAnnotation = field.getAnnotationConsideringFieldAndGetterIfSupported(JsonPropertyDescription.class);
         if (propertyAnnotation != null) {
             return propertyAnnotation.value();
         }
@@ -204,8 +201,8 @@ public class JacksonModule implements Module {
                 .map(JsonNaming::value)
                 .map(strategyType -> {
                     try {
-                        return strategyType.newInstance();
-                    } catch (InstantiationException | IllegalAccessException ex) {
+                        return strategyType.getConstructor().newInstance();
+                    } catch (ReflectiveOperationException | SecurityException ex) {
                         return null;
                     }
                 })

--- a/jsonschema-module-javax-validation/src/test/java/com/github/victools/jsonschema/module/javax/validation/IntegrationTest.java
+++ b/jsonschema-module-javax-validation/src/test/java/com/github/victools/jsonschema/module/javax/validation/IntegrationTest.java
@@ -17,7 +17,7 @@
 package com.github.victools.jsonschema.module.javax.validation;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Optional;
 import java.util.Scanner;
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
@@ -59,7 +60,7 @@ public class IntegrationTest {
                 JavaxValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED,
                 JavaxValidationOption.NOT_NULLABLE_METHOD_IS_REQUIRED,
                 JavaxValidationOption.INCLUDE_PATTERN_EXPRESSIONS);
-        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), SchemaVersion.DRAFT_2019_09)
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
                 .with(module)
                 .build();
         SchemaGenerator generator = new SchemaGenerator(config);
@@ -95,6 +96,17 @@ public class IntegrationTest {
         public List<@DecimalMin(value = "0", inclusive = false) @DecimalMax(value = "1", inclusive = false) Double> notEmptyList;
         @Size(min = 3, max = 25)
         public List<@NotEmpty @Size(max = 100) String> sizeRangeList;
+        @Size(min = 3, max = 25)
+        public List<String> sizeRangeListWithoutItemAnnotation;
+
+        @Size(min = 4, max = 18)
+        public Optional<Integer> optionalSizeRangeString1;
+        public Optional<@Size(min = 5, max = 10) Integer> optionalSizeRangeString2;
+
+        @Min(1)
+        @Max(8)
+        public Optional<Integer> optionalInclusiveRangeInt1;
+        public Optional<@Min(2) @Max(5) Integer> optionalInclusiveRangeInt2;
 
         @NotNull
         @Email(regexp = ".+@.+\\..+")

--- a/jsonschema-module-javax-validation/src/test/resources/com/github/victools/jsonschema/module/javax/validation/integration-test-result.json
+++ b/jsonschema-module-javax-validation/src/test/resources/com/github/victools/jsonschema/module/javax/validation/integration-test-result.json
@@ -1,4 +1,5 @@
 {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "object",
     "properties": {
         "exclusiveRangeDouble": {
@@ -43,18 +44,42 @@
             }
         },
         "nullObject": {},
+        "optionalInclusiveRangeInt1": {
+            "type": ["integer", "null"],
+            "minimum": 1,
+            "maximum": 8
+        },
+        "optionalInclusiveRangeInt2": {
+            "type": ["integer", "null"],
+            "minimum": 2,
+            "maximum": 5
+        },
+        "optionalSizeRangeString1": {
+            "type": ["integer", "null"]
+        },
+        "optionalSizeRangeString2": {
+            "type": ["integer", "null"]
+        },
         "sizeRangeList": {
             "minItems": 3,
             "maxItems": 25,
-            "type": ["array", "null"],
+            "type": "array",
             "items": {
                 "type": "string",
                 "minLength": 1,
                 "maxLength": 100
             }
         },
+        "sizeRangeListWithoutItemAnnotation": {
+            "minItems": 3,
+            "maxItems": 25,
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
         "sizeRangeText": {
-            "type": ["string", "null"],
+            "type": "string",
             "minLength": 5,
             "maxLength": 12
         }

--- a/jsonschema-module-swagger-1.5/src/main/java/com/github/victools/jsonschema/module/swagger15/SwaggerModule.java
+++ b/jsonschema-module-swagger-1.5/src/main/java/com/github/victools/jsonschema/module/swagger15/SwaggerModule.java
@@ -123,10 +123,7 @@ public class SwaggerModule implements Module {
      * @return description (or {@code null})
      */
     protected String resolveDescription(MemberScope<?, ?> member) {
-        if (member.isFakeContainerItemScope()) {
-            return null;
-        }
-        return Optional.ofNullable(member.getAnnotationConsideringFieldAndGetter(ApiModelProperty.class))
+        return Optional.ofNullable(member.getAnnotationConsideringFieldAndGetterIfSupported(ApiModelProperty.class))
                 .map(ApiModelProperty::value)
                 .filter(value -> !value.isEmpty())
                 .orElse(null);
@@ -167,10 +164,7 @@ public class SwaggerModule implements Module {
      * @return {@link ApiModelProperty} annotation's non-empty {@code allowableValues} (or {@code null})
      */
     private Optional<String> findModelPropertyAllowableValues(MemberScope<?, ?> member) {
-        if (member.isFakeContainerItemScope()) {
-            return Optional.empty();
-        }
-        return Optional.ofNullable(member.getAnnotationConsideringFieldAndGetter(ApiModelProperty.class))
+        return Optional.ofNullable(member.getAnnotationConsideringFieldAndGetterIfSupported(ApiModelProperty.class))
                 .map(ApiModelProperty::allowableValues)
                 .filter(allowableValues -> !allowableValues.isEmpty());
     }


### PR DESCRIPTION
Closing #138.

Similar to #60, this is limited to the top-level.
- `Optional<@Size(min = 5) String>` will be picked up
- `List<Optional<@Size(min = 5) String>>` will **not** be picked up

While this is added as a general feature, it only results in an actual feature change in the `jsonschema-module-javax-validation`.