### PR TITLE
Support for Jakarta Validation 3.0.0 added

### DIFF
--- a/jsonschema-maven-plugin/README.md
+++ b/jsonschema-maven-plugin/README.md
@@ -143,7 +143,7 @@ When you want to have more control over the modules that are to be used during g
 ```
 This configuration will generate the schema using the Jackson module.
 
-There are three standard modules that can be used:
+There are five standard modules that can be used:
 - `Jackson`
 - `JakartaValidation`
 - `JavaxValidation`

--- a/jsonschema-maven-plugin/README.md
+++ b/jsonschema-maven-plugin/README.md
@@ -145,6 +145,7 @@ This configuration will generate the schema using the Jackson module.
 
 There are three standard modules that can be used:
 - `Jackson`
+- `JakartaValidation`
 - `JavaxValidation`
 - `Swagger15` 
 - `Swagger2`

--- a/jsonschema-maven-plugin/pom.xml
+++ b/jsonschema-maven-plugin/pom.xml
@@ -88,6 +88,15 @@
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>
+        <!-- JakartaValidation Module dependencies -->
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-jakarta-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
         <!-- Swagger 1.5 Module dependencies -->
         <dependency>
             <groupId>com.github.victools</groupId>

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
@@ -26,6 +26,8 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import com.github.victools.jsonschema.module.jackson.JacksonModule;
 import com.github.victools.jsonschema.module.jackson.JacksonOption;
+import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationModule;
+import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationOption;
 import com.github.victools.jsonschema.module.javax.validation.JavaxValidationModule;
 import com.github.victools.jsonschema.module.javax.validation.JavaxValidationOption;
 import com.github.victools.jsonschema.module.swagger15.SwaggerModule;
@@ -380,6 +382,10 @@ public class SchemaGeneratorMojo extends AbstractMojo {
                     this.getLog().debug("- Adding Jackson Module");
                     addJacksonModule(configBuilder, module);
                     break;
+                case "JakartaValidation":
+                    this.getLog().debug("- Adding Jakarta Validation Module");
+                    addJakartaValidationModule(configBuilder, module);
+                    break;
                 case "JavaxValidation":
                     this.getLog().debug("- Adding Javax Validation Module");
                     addJavaxValidationModule(configBuilder, module);
@@ -394,7 +400,7 @@ public class SchemaGeneratorMojo extends AbstractMojo {
                     break;
                 default:
                     throw new MojoExecutionException("Error: Module does not have a name in "
-                            + "['Jackson', 'JavaxValidation', 'Swagger15', 'Swagger2'] or does not have a custom classname.");
+                            + "['Jackson', 'JakartaValidation', 'JavaxValidation', 'Swagger15', 'Swagger2'] or does not have a custom classname.");
                 }
             }
         }
@@ -501,6 +507,29 @@ public class SchemaGeneratorMojo extends AbstractMojo {
                 }
             }
             configBuilder.with(new JavaxValidationModule(javaxValidationOptions));
+        }
+    }
+
+    /**
+     * Add the Jakarta Validation module to the generator config.
+     *
+     * @param configBuilder The builder on which the config is added
+     * @param module The modules section form the pom
+     * @throws MojoExecutionException in case of problems
+     */
+    private void addJakartaValidationModule(SchemaGeneratorConfigBuilder configBuilder, GeneratorModule module) throws MojoExecutionException {
+        if (module.options == null || module.options.length == 0) {
+            configBuilder.with(new JakartaValidationModule());
+        } else {
+            JakartaValidationOption[] jakartaValidationOptions = new JakartaValidationOption[module.options.length];
+            for (int i = 0; i < module.options.length; i++) {
+                try {
+                    jakartaValidationOptions[i] = JakartaValidationOption.valueOf(module.options[i]);
+                } catch (IllegalArgumentException e) {
+                    throw new MojoExecutionException("Error: Unknown JakartaValidation option " + module.options[i], e);
+                }
+            }
+            configBuilder.with(new JakartaValidationModule(jakartaValidationOptions));
         }
     }
 

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
@@ -45,6 +45,7 @@ public class SchemaGeneratorMojoTest {
                 {"SchemaVersion"},
                 {"JacksonModule"},
                 {"JavaxValidationModule"},
+                {"JakartaValidationModule"},
                 {"Swagger15Module"},
                 {"Swagger2Module"},
                 {"Complete"}

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/JakartaValidationModule-pom.xml
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/JakartaValidationModule-pom.xml
@@ -1,0 +1,19 @@
+<project>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.victools</groupId>
+                <artifactId>jsonschema-maven-plugin</artifactId>
+                <configuration>
+                    <classNames>com.github.victools.jsonschema.plugin.maven.TestClass</classNames>
+                    <schemaFilePath>target/generated-test-sources/JakartaValidationModule</schemaFilePath>
+                    <modules>
+                        <module>
+                            <name>JakartaValidation</name>
+                        </module>
+                    </modules>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/JakartaValidationModule-reference.json
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/JakartaValidationModule-reference.json
@@ -1,0 +1,9 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "properties" : {
+    "anInt" : {
+      "type" : "integer"
+    }
+  }
+}

--- a/jsonschema-module-jakarta-validation/README.md
+++ b/jsonschema-module-jakarta-validation/README.md
@@ -1,0 +1,74 @@
+# Java JSON Schema Generator – Module javax.validation
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.victools/jsonschema-module-javax-validation/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.victools/jsonschema-module-jakarta-validation)
+
+Module for the [jsonschema-generator](../jsonschema-generator) – deriving JSON Schema attributes from `jakarta.validation.constraints` annotations.
+
+## Features
+1. Determine whether a member is not nullable, base assumption being that all fields and method return values are nullable if not annotated. Based on `@NotNull`/`@Null`/`@NotEmpty`/`@NotBlank`
+2. Populate list of "required" fields/methods for objects if `JakartaValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED` and/or `JakartaValidationOption.NOT_NULLABLE_METHOD_IS_REQUIRED` is/are being provided in constructor.
+3. Populate "minItems" and "maxItems" for containers (i.e. arrays and collections). Based on `@Size`/`@NotEmpty`
+4. Populate "minLength" and "maxLength" for strings. Based on `@Size`/`@NotEmpty`/`@NotBlank`
+5. Populate "format" for strings. Based on `@Email`, can be "email" or "idn-email" depending on whether `JakartaValidationOption.PREFER_IDN_EMAIL_FORMAT` is being provided in constructor.
+6. Populate "pattern" for strings. Based on `@Pattern`/`@Email`, when corresponding `JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS` is being provided in constructor.
+7. Populate "minimum"/"exclusiveMinimum" for numbers. Based on `@Min`/`@DecimalMin`/`@Positive`/`@PositiveOrZero`
+8. Populate "maximum"/"exclusiveMaximum" for numbers. Based on `@Max`/`@DecimalMax`/`@Negative`/`@NegativeOrZero`
+
+Schema attributes derived from validation annotations on fields are also applied to their respective getter methods.  
+Schema attributes derived from validation annotations on getter methods are also applied to their associated fields.
+
+----
+
+## Documentation
+JavaDoc is being used throughout the codebase, offering contextual information in your respective IDE or being available online through services like [javadoc.io](https://www.javadoc.io/doc/com.github.victools/jsonschema-module-jakarta-validation).
+
+Additional documentation can be found in the [Project Wiki](https://github.com/victools/jsonschema-generator/wiki).
+
+----
+
+## Usage
+### Dependency (Maven)
+```xml
+<dependency>
+    <groupId>com.github.victools</groupId>
+    <artifactId>jsonschema-module-jakarta-validation</artifactId>
+    <version>[4.16.0,5.0.0)</version>
+</dependency>
+```
+
+Since version `4.7`, the release versions of the main generator library and this module are aligned.
+It is recommended to use identical versions for both dependencies to ensure compatibility.
+
+### Code
+#### Passing into SchemaGeneratorConfigBuilder.with(Module)
+```java
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationModule;
+```
+```java
+JakartaValidationModule module = new JakartaValidationModule();
+SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09)
+    .with(module);
+```
+
+#### Complete Example
+```java
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationModule;
+import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationOption;
+```
+```java
+JakartaValidationModule module = new JakartaValidationModule(JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS);
+SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
+    .with(module);
+SchemaGeneratorConfig config = configBuilder.build();
+SchemaGenerator generator = new SchemaGenerator(config);
+JsonNode jsonSchema = generator.generateSchema(YourClass.class);
+
+System.out.println(jsonSchema.toString());
+```

--- a/jsonschema-module-jakarta-validation/README.md
+++ b/jsonschema-module-jakarta-validation/README.md
@@ -1,5 +1,5 @@
-# Java JSON Schema Generator – Module javax.validation
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.victools/jsonschema-module-javax-validation/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.victools/jsonschema-module-jakarta-validation)
+# Java JSON Schema Generator – Module jakarta.validation
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.victools/jsonschema-module-jakarta-validation/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.victools/jsonschema-module-jakarta-validation)
 
 Module for the [jsonschema-generator](../jsonschema-generator) – deriving JSON Schema attributes from `jakarta.validation.constraints` annotations.
 
@@ -31,7 +31,7 @@ Additional documentation can be found in the [Project Wiki](https://github.com/v
 <dependency>
     <groupId>com.github.victools</groupId>
     <artifactId>jsonschema-module-jakarta-validation</artifactId>
-    <version>[4.16.0,5.0.0)</version>
+    <version>[4.17.0,5.0.0)</version>
 </dependency>
 ```
 

--- a/jsonschema-module-jakarta-validation/pom.xml
+++ b/jsonschema-module-jakarta-validation/pom.xml
@@ -7,10 +7,10 @@
         <artifactId>jsonschema-generator-parent</artifactId>
         <version>4.17.0-SNAPSHOT</version>
     </parent>
-    <artifactId>jsonschema-module-javax-validation</artifactId>
+    <artifactId>jsonschema-module-jakarta-validation</artifactId>
 
-    <name>Java JSON Schema Generator Module – javax.validation</name>
-    <description>Module for the jsonschema-generator – deriving JSON Schema attributes from javax.validation annotations</description>
+    <name>Java JSON Schema Generator Module – jakarta.validation</name>
+    <description>Module for the jsonschema-generator – deriving JSON Schema attributes from jakarta.validation annotations</description>
 
     <dependencies>
         <dependency>
@@ -19,8 +19,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/jsonschema-module-jakarta-validation/src/main/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationModule.java
+++ b/jsonschema-module-jakarta-validation/src/main/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationModule.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright 2020 VicTools & Sascha Kohlmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.jakarta.validation;
+
+import com.github.victools.jsonschema.generator.FieldScope;
+import com.github.victools.jsonschema.generator.MemberScope;
+import com.github.victools.jsonschema.generator.MethodScope;
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigPart;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.lang.annotation.Annotation;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * JSON Schema Generation Module: based on annotations from the {@code jakarta.validation.constraints} package.
+ * <ul>
+ * <li>Determine whether a member is not nullable, base assumption being that all fields and method return values are nullable if not annotated.</li>
+ * <li>Optionally: also indicate all explicitly not nullable fields/methods to be required.</li>
+ * <li>Populate "minItems" and "maxItems" for containers (i.e. arrays and collections).</li>
+ * <li>Populate "minLength", "maxLength" and "format" for strings.</li>
+ * <li>Optionally: populate "pattern" for strings.</li>
+ * <li>Populate "minimum"/"exclusiveMinimum" and "maximum"/"exclusiveMaximum" for numbers.</li>
+ * </ul>
+ */
+public class JakartaValidationModule implements Module {
+
+    private final Set<JakartaValidationOption> options;
+    private Set<Class<?>> validationGroups;
+
+    /**
+     * Constructor.
+     *
+     * @param options features to enable
+     */
+    public JakartaValidationModule(JakartaValidationOption... options) {
+        this.options = options == null ? Collections.emptySet() : new HashSet<>(Arrays.asList(options));
+        // by default: ignore validation groups
+        this.validationGroups = null;
+    }
+
+    /**
+     * Add validation groups to be considered.
+     * <ul>
+     * <li>Never calling this method will result in all annotations to be picked-up.</li>
+     * <li>Calling this without parameters will only consider those annotations where no groups are defined.</li>
+     * <li>Calling this with not-null parameters will only consider those annotations without defined groups or where at least one matches.</li>
+     * </ul>
+     *
+     * @param validationGroups validation groups to consider
+     * @return this module instance (for chaining)
+     */
+    public JakartaValidationModule forValidationGroups(Class<?>... validationGroups) {
+        if (validationGroups == null) {
+            this.validationGroups = null;
+        } else {
+            this.validationGroups = new HashSet<>(Arrays.asList(validationGroups));
+        }
+        return this;
+    }
+
+    @Override
+    public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+        SchemaGeneratorConfigPart<FieldScope> fieldConfigPart = builder.forFields();
+        this.applyToConfigPart(fieldConfigPart);
+        if (this.options.contains(JakartaValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED)) {
+            fieldConfigPart.withRequiredCheck(this::isRequired);
+        }
+
+        SchemaGeneratorConfigPart<MethodScope> methodConfigPart = builder.forMethods();
+        this.applyToConfigPart(methodConfigPart);
+        if (this.options.contains(JakartaValidationOption.NOT_NULLABLE_METHOD_IS_REQUIRED)) {
+            methodConfigPart.withRequiredCheck(this::isRequired);
+        }
+    }
+
+    /**
+     * Apply the various annotation-based resolvers for the given configuration part (this is expected to be executed for both fields and methods).
+     *
+     * @param configPart config builder part to add configurations to
+     */
+    private void applyToConfigPart(SchemaGeneratorConfigPart<?> configPart) {
+        configPart.withNullableCheck(this::isNullable);
+        configPart.withArrayMinItemsResolver(this::resolveArrayMinItems);
+        configPart.withArrayMaxItemsResolver(this::resolveArrayMaxItems);
+        configPart.withStringMinLengthResolver(this::resolveStringMinLength);
+        configPart.withStringMaxLengthResolver(this::resolveStringMaxLength);
+        configPart.withStringFormatResolver(this::resolveStringFormat);
+        configPart.withNumberInclusiveMinimumResolver(this::resolveNumberInclusiveMinimum);
+        configPart.withNumberExclusiveMinimumResolver(this::resolveNumberExclusiveMinimum);
+        configPart.withNumberInclusiveMaximumResolver(this::resolveNumberInclusiveMaximum);
+        configPart.withNumberExclusiveMaximumResolver(this::resolveNumberExclusiveMaximum);
+
+        if (this.options.contains(JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS)) {
+            configPart.withStringPatternResolver(this::resolveStringPattern);
+        }
+    }
+
+    /**
+     * Retrieves the annotation instance of the given type, either from the field itself or (if not present) from its getter.
+     * <br>
+     * If the given field/method represents only a container item of the actual declared type, that container item's annotations are being checked.
+     *
+     * @param <A> type of annotation
+     * @param member field or method to retrieve annotation instance from (or from a field's getter or getter method's field)
+     * @param annotationClass type of annotation
+     * @param validationGroupsLookup how to look-up the associated validation groups of an annotation instance
+     * @return annotation instance (or {@code null})
+     * @see MemberScope#getAnnotationConsideringFieldAndGetterIfSupported(Class)
+     * @see MemberScope#getContainerItemAnnotationConsideringFieldAndGetterIfSupported(Class)
+     */
+    protected <A extends Annotation> A getAnnotationFromFieldOrGetter(MemberScope<?, ?> member, Class<A> annotationClass,
+            Function<A, Class<?>[]> validationGroupsLookup) {
+        A containerItemAnnotation = member.getContainerItemAnnotationConsideringFieldAndGetterIfSupported(annotationClass);
+        if (this.shouldConsiderAnnotation(containerItemAnnotation, validationGroupsLookup)) {
+            return containerItemAnnotation;
+        }
+        A annotation = member.getAnnotationConsideringFieldAndGetterIfSupported(annotationClass);
+        if (this.shouldConsiderAnnotation(annotation, validationGroupsLookup)) {
+            return annotation;
+        }
+        return null;
+    }
+
+    /**
+     * Check whether a given annotation is supposed to be considered in the schema generation. I.e. if specific validation groups are defined, it must
+     * belong to at least one of them.
+     *
+     * @param <A> type of annotation
+     * @param annotation annotation instance (may be {@code null}, which will result in {@code false} to be returned)
+     * @param validationGroupsLookup how to look-up the associated validation groups of an annotation instance
+     * @return whether the given annotation should be considered in the current schema generation
+     */
+    private <A extends Annotation> boolean shouldConsiderAnnotation(A annotation, Function<A, Class<?>[]> validationGroupsLookup) {
+        // avoid repeated null checks by doing it here
+        if (annotation == null) {
+            return false;
+        }
+        // no specific validation groups means: all annotations are fair game
+        if (this.validationGroups == null) {
+            return true;
+        }
+        // check that the annotation's validation groups have at least one common entry to the configured groups on this module
+        Class<?>[] associatedGroups = validationGroupsLookup.apply(annotation);
+        return associatedGroups.length == 0 || !Collections.disjoint(this.validationGroups, Arrays.asList(associatedGroups));
+    }
+
+    /**
+     * Determine whether a given field or method is annotated to be not nullable.
+     *
+     * @param member the field or method to check
+     * @return whether member is annotated as nullable or not (returns null if not specified: assumption it is nullable then)
+     */
+    protected Boolean isNullable(MemberScope<?, ?> member) {
+        Boolean result;
+        if (this.getAnnotationFromFieldOrGetter(member, NotNull.class, NotNull::groups) != null
+                || this.getAnnotationFromFieldOrGetter(member, NotBlank.class, NotBlank::groups) != null
+                || this.getAnnotationFromFieldOrGetter(member, NotEmpty.class, NotEmpty::groups) != null) {
+            // field is specifically NOT nullable
+            result = Boolean.FALSE;
+        } else if (this.getAnnotationFromFieldOrGetter(member, Null.class, Null::groups) != null) {
+            // field is specifically null (and thereby nullable)
+            result = Boolean.TRUE;
+        } else {
+            result = null;
+        }
+        return result;
+    }
+
+    /**
+     * Determine whether a given field or method is deemed to be required in its parent type.
+     *
+     * @param member the field or method to check
+     * @return whether member is deemed to be required or not
+     */
+    protected boolean isRequired(MemberScope<?, ?> member) {
+        Boolean nullableCheckResult = this.isNullable(member);
+        return Boolean.FALSE.equals(nullableCheckResult);
+    }
+
+    /**
+     * Determine a given array type's minimum number of items.
+     *
+     * @param member the field or method to check
+     * @return specified minimum number of array items (or null)
+     * @see Size
+     */
+    protected Integer resolveArrayMinItems(MemberScope<?, ?> member) {
+        if (member.isContainerType()) {
+            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class, Size::groups);
+            if (sizeAnnotation != null && sizeAnnotation.min() > 0) {
+                // minimum length greater than the default 0 was specified
+                return sizeAnnotation.min();
+            }
+            if (this.getAnnotationFromFieldOrGetter(member, NotEmpty.class, NotEmpty::groups) != null) {
+                return 1;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Determine a given array type's maximum number of items.
+     *
+     * @param member the field or method to check
+     * @return specified maximum number of array items (or null)
+     * @see Size
+     */
+    protected Integer resolveArrayMaxItems(MemberScope<?, ?> member) {
+        if (member.isContainerType()) {
+            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class, Size::groups);
+            if (sizeAnnotation != null && sizeAnnotation.max() < 2147483647) {
+                // maximum length below the default 2147483647 was specified
+                return sizeAnnotation.max();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Determine a given text type's minimum number of characters.
+     *
+     * @param member the field or method to check
+     * @return specified minimum number of characters (or null)
+     * @see Size
+     * @see NotEmpty
+     * @see NotBlank
+     */
+    protected Integer resolveStringMinLength(MemberScope<?, ?> member) {
+        if (member.getType().isInstanceOf(CharSequence.class)) {
+            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class, Size::groups);
+            if (sizeAnnotation != null && sizeAnnotation.min() > 0) {
+                // minimum length greater than the default 0 was specified
+                return sizeAnnotation.min();
+            }
+            if (this.getAnnotationFromFieldOrGetter(member, NotEmpty.class, NotEmpty::groups) != null
+                    || this.getAnnotationFromFieldOrGetter(member, NotBlank.class, NotBlank::groups) != null) {
+                return 1;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Determine a given text type's maximum number of characters.
+     *
+     * @param member the field or method to check
+     * @return specified minimum number of characters (or null)
+     * @see Size
+     */
+    protected Integer resolveStringMaxLength(MemberScope<?, ?> member) {
+        if (member.getType().isInstanceOf(CharSequence.class)) {
+            Size sizeAnnotation = this.getAnnotationFromFieldOrGetter(member, Size.class, Size::groups);
+            if (sizeAnnotation != null && sizeAnnotation.max() < 2147483647) {
+                // maximum length below the default 2147483647 was specified
+                return sizeAnnotation.max();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Determine a given text type's format.
+     *
+     * @param member the field or method to check
+     * @return specified format (or null)
+     * @see Email
+     */
+    protected String resolveStringFormat(MemberScope<?, ?> member) {
+        if (member.getType().isInstanceOf(CharSequence.class)) {
+            Email emailAnnotation = this.getAnnotationFromFieldOrGetter(member, Email.class, Email::groups);
+            if (emailAnnotation != null) {
+                // @Email annotation was found, indicate the respective format
+                if (this.options.contains(JakartaValidationOption.PREFER_IDN_EMAIL_FORMAT)) {
+                    // the option was set to rather return the value for the internationalised email format
+                    return "idn-email";
+                }
+                // indicate standard internet email address format
+                return "email";
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Determine a given text type's pattern.
+     *
+     * @param member the field or method to check
+     * @return specified pattern (or null)
+     * @see Pattern
+     */
+    protected String resolveStringPattern(MemberScope<?, ?> member) {
+        if (member.getType().isInstanceOf(CharSequence.class)) {
+            Pattern patternAnnotation = this.getAnnotationFromFieldOrGetter(member, Pattern.class, Pattern::groups);
+            if (patternAnnotation != null) {
+                // @Pattern annotation was found, return its (mandatory) regular expression
+                return patternAnnotation.regexp();
+            }
+            Email emailAnnotation = this.getAnnotationFromFieldOrGetter(member, Email.class, Email::groups);
+            if (emailAnnotation != null && !".*".equals(emailAnnotation.regexp())) {
+                // non-default regular expression on @Email annotation should also be considered
+                return emailAnnotation.regexp();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Determine a number type's minimum (inclusive) value.
+     *
+     * @param member the field or method to check
+     * @return specified inclusive minimum value (or null)
+     * @see Min
+     * @see DecimalMin
+     * @see PositiveOrZero
+     */
+    protected BigDecimal resolveNumberInclusiveMinimum(MemberScope<?, ?> member) {
+        Min minAnnotation = this.getAnnotationFromFieldOrGetter(member, Min.class, Min::groups);
+        if (minAnnotation != null) {
+            return new BigDecimal(minAnnotation.value());
+        }
+        DecimalMin decimalMinAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMin.class, DecimalMin::groups);
+        if (decimalMinAnnotation != null && decimalMinAnnotation.inclusive()) {
+            return new BigDecimal(decimalMinAnnotation.value());
+        }
+        PositiveOrZero positiveAnnotation = this.getAnnotationFromFieldOrGetter(member, PositiveOrZero.class, PositiveOrZero::groups);
+        if (positiveAnnotation != null) {
+            return BigDecimal.ZERO;
+        }
+        return null;
+    }
+
+    /**
+     * Determine a number type's minimum (exclusive) value.
+     *
+     * @param member the field or method to check
+     * @return specified exclusive minimum value (or null)
+     * @see DecimalMin
+     * @see Positive
+     */
+    protected BigDecimal resolveNumberExclusiveMinimum(MemberScope<?, ?> member) {
+        DecimalMin decimalMinAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMin.class, DecimalMin::groups);
+        if (decimalMinAnnotation != null && !decimalMinAnnotation.inclusive()) {
+            return new BigDecimal(decimalMinAnnotation.value());
+        }
+        Positive positiveAnnotation = this.getAnnotationFromFieldOrGetter(member, Positive.class, Positive::groups);
+        if (positiveAnnotation != null) {
+            return BigDecimal.ZERO;
+        }
+        return null;
+    }
+
+    /**
+     * Determine a number type's maximum (inclusive) value.
+     *
+     * @param member the field or method to check
+     * @return specified inclusive maximum value (or null)
+     * @see Max
+     * @see DecimalMax#inclusive()
+     * @see NegativeOrZero
+     */
+    protected BigDecimal resolveNumberInclusiveMaximum(MemberScope<?, ?> member) {
+        Max maxAnnotation = this.getAnnotationFromFieldOrGetter(member, Max.class, Max::groups);
+        if (maxAnnotation != null) {
+            return new BigDecimal(maxAnnotation.value());
+        }
+        DecimalMax decimalMaxAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMax.class, DecimalMax::groups);
+        if (decimalMaxAnnotation != null && decimalMaxAnnotation.inclusive()) {
+            return new BigDecimal(decimalMaxAnnotation.value());
+        }
+        NegativeOrZero negativeAnnotation = this.getAnnotationFromFieldOrGetter(member, NegativeOrZero.class, NegativeOrZero::groups);
+        if (negativeAnnotation != null) {
+            return BigDecimal.ZERO;
+        }
+        return null;
+    }
+
+    /**
+     * Determine a number type's maximum (exclusive) value.
+     *
+     * @param member the field or method to check
+     * @return specified exclusive maximum value (or null)
+     * @see DecimalMax#inclusive()
+     * @see Negative
+     */
+    protected BigDecimal resolveNumberExclusiveMaximum(MemberScope<?, ?> member) {
+        DecimalMax decimalMaxAnnotation = this.getAnnotationFromFieldOrGetter(member, DecimalMax.class, DecimalMax::groups);
+        if (decimalMaxAnnotation != null && !decimalMaxAnnotation.inclusive()) {
+            return new BigDecimal(decimalMaxAnnotation.value());
+        }
+        Negative negativeAnnotation = this.getAnnotationFromFieldOrGetter(member, Negative.class, Negative::groups);
+        if (negativeAnnotation != null) {
+            return BigDecimal.ZERO;
+        }
+        return null;
+    }
+}

--- a/jsonschema-module-jakarta-validation/src/main/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationOption.java
+++ b/jsonschema-module-jakarta-validation/src/main/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationOption.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 VicTools & Sascha Kohlmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.jakarta.validation;
+
+/**
+ * Flags to enable/disable certain aspects of the {@link JakartaValidationModule}'s processing.
+ */
+public enum JakartaValidationOption {
+    /**
+     * Use this option to add not-nullable fields to their parent's list of "required" properties.
+     */
+    NOT_NULLABLE_FIELD_IS_REQUIRED,
+    /**
+     * Use this option to add not-nullable methods to their parent's list of "required" properties.
+     */
+    NOT_NULLABLE_METHOD_IS_REQUIRED,
+    /**
+     * Use this option to indicate the "idn-email" format instead of "email" when an {@code @Email} annotation is being found.
+     * <br>
+     * Beware that this format was only introduced in {@code SchemaVersion.DRAFT_7}.
+     */
+    PREFER_IDN_EMAIL_FORMAT,
+    /**
+     * Use this option to include a string's "pattern" according to {@code @Pattern(regexp = "...")} or {@code @Email(regexp = "...")}.
+     */
+    INCLUDE_PATTERN_EXPRESSIONS;
+
+}

--- a/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/IntegrationTest.java
+++ b/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/IntegrationTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 VicTools & Sascha Kohlmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.jakarta.validation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.Scanner;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+/**
+ * Integration test of this module being used in a real SchemaGenerator instance.
+ */
+public class IntegrationTest {
+
+    /**
+     * Test
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testIntegration() throws Exception {
+        // active all optional modules
+        JakartaValidationModule module = new JakartaValidationModule(
+                JakartaValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED,
+                JakartaValidationOption.NOT_NULLABLE_METHOD_IS_REQUIRED,
+                JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS);
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
+                .with(module)
+                .build();
+        SchemaGenerator generator = new SchemaGenerator(config);
+        JsonNode result = generator.generateSchema(TestClass.class);
+
+        String rawJsonSchema = result.toString();
+        JSONAssert.assertEquals('\n' + rawJsonSchema + '\n',
+                loadResource("integration-test-result.json"), rawJsonSchema, JSONCompareMode.STRICT);
+    }
+
+    private static String loadResource(String resourcePath) throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+        try (InputStream inputStream = IntegrationTest.class
+                .getResourceAsStream(resourcePath);
+                Scanner scanner = new Scanner(inputStream, StandardCharsets.UTF_8.name())) {
+            while (scanner.hasNext()) {
+                stringBuilder.append(scanner.nextLine()).append('\n');
+            }
+        }
+        String fileAsString = stringBuilder.toString();
+        return fileAsString;
+
+    }
+
+    static class TestClass {
+
+        @Null
+        public Object nullObject;
+
+        @NotNull
+        public List<@Min(2) @Max(2048) Integer> notNullList;
+        @NotEmpty
+        public List<@DecimalMin(value = "0", inclusive = false) @DecimalMax(value = "1", inclusive = false) Double> notEmptyList;
+        @Size(min = 3, max = 25)
+        public List<@NotEmpty @Size(max = 100) String> sizeRangeList;
+        @Size(min = 3, max = 25)
+        public List<String> sizeRangeListWithoutItemAnnotation;
+
+        @Size(min = 4, max = 18)
+        public Optional<Integer> optionalSizeRangeString1;
+        public Optional<@Size(min = 5, max = 10) Integer> optionalSizeRangeString2;
+
+        @Min(1)
+        @Max(8)
+        public Optional<Integer> optionalInclusiveRangeInt1;
+        public Optional<@Min(2) @Max(5) Integer> optionalInclusiveRangeInt2;
+
+        @NotNull
+        @Email(regexp = ".+@.+\\..+")
+        public String notNullEmail;
+        @NotEmpty
+        @Pattern(regexp = "\\w+")
+        public String notEmptyPatternText;
+        @NotBlank
+        public String notBlankText;
+        @Size(min = 5, max = 12)
+        public String sizeRangeText;
+
+        @Min(7)
+        @Max(38)
+        public int inclusiveRangeInt;
+
+        @DecimalMin(value = "0", inclusive = false)
+        @DecimalMax(value = "1", inclusive = false)
+        public double exclusiveRangeDouble;
+    }
+}

--- a/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationModuleTest.java
+++ b/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationModuleTest.java
@@ -1,0 +1,828 @@
+/*
+ * Copyright 2020 VicTools & Sascha Kohlmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.jakarta.validation;
+
+import com.github.victools.jsonschema.generator.ConfigFunction;
+import com.github.victools.jsonschema.generator.FieldScope;
+import com.github.victools.jsonschema.generator.MethodScope;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigPart;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Negative;
+import jakarta.validation.constraints.NegativeOrZero;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Set;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * Test for the {@link JakartaValidationModule}.
+ */
+@RunWith(JUnitParamsRunner.class)
+public class JakartaValidationModuleTest {
+
+    private SchemaGeneratorConfigBuilder configBuilder;
+    private SchemaGeneratorConfigPart<FieldScope> fieldConfigPart;
+    private SchemaGeneratorConfigPart<MethodScope> methodConfigPart;
+
+    @Before
+    public void setUp() {
+        this.configBuilder = Mockito.mock(SchemaGeneratorConfigBuilder.class);
+        this.fieldConfigPart = Mockito.spy(new SchemaGeneratorConfigPart<>());
+        this.methodConfigPart = Mockito.spy(new SchemaGeneratorConfigPart<>());
+        Mockito.when(this.configBuilder.forFields()).thenReturn(this.fieldConfigPart);
+        Mockito.when(this.configBuilder.forMethods()).thenReturn(this.methodConfigPart);
+    }
+
+    @Test
+    public void testApplyToConfigBuilderWithDefaultOptions() {
+        new JakartaValidationModule().applyToConfigBuilder(this.configBuilder);
+
+        this.verifyCommonConfigurations();
+
+        Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart);
+    }
+
+    @Test
+    public void testApplyToConfigBuilderWithRequiredFieldsOption() {
+        new JakartaValidationModule(JakartaValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.verifyCommonConfigurations();
+
+        Mockito.verify(this.fieldConfigPart).withRequiredCheck(Mockito.any());
+
+        Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart);
+    }
+
+    @Test
+    public void testApplyToConfigBuilderWithRequiredMethodsOption() {
+        new JakartaValidationModule(JakartaValidationOption.NOT_NULLABLE_METHOD_IS_REQUIRED)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.verifyCommonConfigurations();
+
+        Mockito.verify(this.methodConfigPart).withRequiredCheck(Mockito.any());
+
+        Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart);
+    }
+
+    @Test
+    public void testApplyToConfigBuilderWithPatternOption() {
+        new JakartaValidationModule(JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.verifyCommonConfigurations();
+
+        Mockito.verify(this.fieldConfigPart).withStringPatternResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withStringPatternResolver(Mockito.any());
+
+        Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart);
+    }
+
+    @Test
+    public void testApplyToConfigBuilderWithAllOptions() {
+        new JakartaValidationModule(JakartaValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED, JakartaValidationOption.NOT_NULLABLE_METHOD_IS_REQUIRED,
+                JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.verifyCommonConfigurations();
+
+        Mockito.verify(this.fieldConfigPart).withRequiredCheck(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withRequiredCheck(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withStringPatternResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withStringPatternResolver(Mockito.any());
+
+        Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart);
+    }
+
+    private void verifyCommonConfigurations() {
+        Mockito.verify(this.configBuilder).forFields();
+        Mockito.verify(this.configBuilder).forMethods();
+
+        Mockito.verify(this.fieldConfigPart).withNullableCheck(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withArrayMinItemsResolver(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withArrayMaxItemsResolver(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withStringMinLengthResolver(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withStringMaxLengthResolver(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withStringFormatResolver(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withNumberInclusiveMinimumResolver(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withNumberExclusiveMinimumResolver(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withNumberInclusiveMaximumResolver(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withNumberExclusiveMaximumResolver(Mockito.any());
+
+        Mockito.verify(this.methodConfigPart).withNullableCheck(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withArrayMinItemsResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withArrayMaxItemsResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withStringMinLengthResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withStringMaxLengthResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withStringFormatResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withNumberInclusiveMinimumResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withNumberExclusiveMinimumResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withNumberInclusiveMaximumResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withNumberExclusiveMaximumResolver(Mockito.any());
+    }
+
+    Object parametersForTestNullableCheck() {
+        return new Object[][]{
+            {"unannotatedField", null},
+            {"notNullNumber", Boolean.FALSE},
+            {"notNullOnGetterNumber", Boolean.FALSE},
+            {"notEmptyList", Boolean.FALSE},
+            {"notEmptyOnGetterList", Boolean.FALSE},
+            {"notBlankString", Boolean.FALSE},
+            {"notBlankOnGetterString", Boolean.FALSE},
+            {"nullField", Boolean.TRUE},
+            {"nullGetter", Boolean.TRUE}
+        };
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNullableCheck")
+    public void testNullableCheckOnFieldNoValidationGroup(String fieldName, Boolean expectedResult) throws Exception {
+        new JakartaValidationModule().applyToConfigBuilder(this.configBuilder);
+
+        this.testNullableCheckOnField(fieldName, expectedResult);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNullableCheck")
+    public void testNullableCheckOnFieldMatchingValidationGroup(String fieldName, Boolean expectedResult) throws Exception {
+        new JakartaValidationModule()
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testNullableCheckOnField(fieldName, expectedResult);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNullableCheck")
+    @TestCaseName("{method}({0}) [{index}]")
+    public void testNullableCheckOnFieldDifferentValidationGroup(String fieldName, Boolean ignoredResult) throws Exception {
+        new JakartaValidationModule()
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testNullableCheckOnField(fieldName, null);
+    }
+
+    private void testNullableCheckOnField(String fieldName, Boolean expectedResult) throws Exception {
+        ArgumentCaptor<ConfigFunction<FieldScope, Boolean>> captor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withNullableCheck(captor.capture());
+        TestType testType = new TestType(TestClassForNullableCheck.class);
+        FieldScope field = testType.getMemberField(fieldName);
+
+        Boolean result = captor.getValue().apply(field);
+        Assert.assertEquals(expectedResult, result);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNullableCheck")
+    public void testNullableCheckOnMethodNoValidationGroup(String fieldName, Boolean expectedResult) throws Exception {
+        new JakartaValidationModule().applyToConfigBuilder(this.configBuilder);
+
+        this.testNullableCheckOnMethod(fieldName, expectedResult);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNullableCheck")
+    public void testNullableCheckOnMethodMatchingValidationGroup(String fieldName, Boolean expectedResult) throws Exception {
+        new JakartaValidationModule()
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testNullableCheckOnMethod(fieldName, expectedResult);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNullableCheck")
+    @TestCaseName("{method}({0}) [{index}]")
+    public void testNullableCheckOnMethodDifferentValidationGroup(String fieldName, Boolean ignoredResult) throws Exception {
+        new JakartaValidationModule()
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testNullableCheckOnMethod(fieldName, null);
+    }
+
+    private void testNullableCheckOnMethod(String fieldName, Boolean expectedResult) throws Exception {
+        ArgumentCaptor<ConfigFunction<MethodScope, Boolean>> captor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.methodConfigPart).withNullableCheck(captor.capture());
+        TestType testType = new TestType(TestClassForNullableCheck.class);
+        String methodName = "get" + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
+        MethodScope method = testType.getMemberMethod(methodName);
+
+        Boolean result = captor.getValue().apply(method);
+        Assert.assertEquals(expectedResult, result);
+    }
+
+    Object parametersForTestArrayItemCountResolvers() {
+        return new Object[][]{
+            {"unannotatedArray", null, null},
+            {"sizeTenToTwentyString", null, null},
+            {"sizeTenToTwentyOnGetterString", null, null},
+            {"minSizeFiveArray", 5, null},
+            {"minSizeFiveOnGetterArray", 5, null},
+            {"maxSizeFiftyArray", null, 50},
+            {"maxSizeFiftyOnGetterArray", null, 50},
+            {"sizeTenToTwentySet", 10, 20},
+            {"sizeTenToTwentyOnGetterSet", 10, 20},
+            {"nonEmptyMaxSizeHundredList", 1, 100},
+            {"nonEmptyMaxSizeHundredOnGetterList", 1, 100}
+        };
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestArrayItemCountResolvers")
+    public void testArrayItemCountResolversNoValidationGroup(String fieldName, Integer expectedMinItems, Integer expectedMaxItems) throws Exception {
+        new JakartaValidationModule().applyToConfigBuilder(this.configBuilder);
+
+        this.testArrayItemCountResolvers(fieldName, expectedMinItems, expectedMaxItems);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestArrayItemCountResolvers")
+    public void testArrayItemCountResolversMatchingValidationGroup(String fieldName, Integer expectedMinItems, Integer expectedMaxItems)
+            throws Exception {
+        new JakartaValidationModule()
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testArrayItemCountResolvers(fieldName, expectedMinItems, expectedMaxItems);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestArrayItemCountResolvers")
+    @TestCaseName("{method}({0}) [{index}]")
+    public void testArrayItemCountResolversDifferentValidationGroup(String fieldName, Integer ignoredMinItems, Integer ignoredMaxItems)
+            throws Exception {
+        new JakartaValidationModule()
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testArrayItemCountResolvers(fieldName, null, null);
+    }
+
+    private void testArrayItemCountResolvers(String fieldName, Integer expectedMinItems, Integer expectedMaxItems) throws Exception {
+        TestType testType = new TestType(TestClassForArrayItemCount.class);
+        FieldScope field = testType.getMemberField(fieldName);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, Integer>> minItemCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withArrayMinItemsResolver(minItemCaptor.capture());
+        Integer minItemCount = minItemCaptor.getValue().apply(field);
+        Assert.assertEquals(expectedMinItems, minItemCount);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, Integer>> maxItemCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withArrayMaxItemsResolver(maxItemCaptor.capture());
+        Integer maxItemCount = maxItemCaptor.getValue().apply(field);
+        Assert.assertEquals(expectedMaxItems, maxItemCount);
+    }
+
+    Object parametersForTestStringLengthResolvers() {
+        return new Object[][]{
+            {"unannotatedString", null, null},
+            {"sizeTenToTwentyArray", null, null},
+            {"sizeTenToTwentyOnGetterArray", null, null},
+            {"minSizeFiveSequence", 5, null},
+            {"minSizeFiveOnGetterSequence", 5, null},
+            {"maxSizeFiftyString", null, 50},
+            {"maxSizeFiftyOnGetterString", null, 50},
+            {"sizeTenToTwentyString", 10, 20},
+            {"sizeTenToTwentyOnGetterString", 10, 20},
+            {"nonEmptyMaxSizeHundredString", 1, 100},
+            {"nonEmptyMaxSizeHundredOnGetterString", 1, 100},
+            {"nonBlankString", 1, null},
+            {"nonBlankOnGetterString", 1, null}
+        };
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestStringLengthResolvers")
+    public void testStringLengthResolversNoValidationGroup(String fieldName, Integer expectedMinLength, Integer expectedMaxLength) throws Exception {
+        new JakartaValidationModule().applyToConfigBuilder(this.configBuilder);
+
+        this.testStringLengthResolvers(fieldName, expectedMinLength, expectedMaxLength);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestStringLengthResolvers")
+    public void testStringLengthResolversMatchingValidationGroup(String fieldName, Integer expectedMinLength, Integer expectedMaxLength)
+            throws Exception {
+        new JakartaValidationModule()
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testStringLengthResolvers(fieldName, expectedMinLength, expectedMaxLength);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestStringLengthResolvers")
+    @TestCaseName("{method}({0}) [{index}]")
+    public void testStringLengthResolversDifferentValidationGroup(String fieldName, Integer ignoredMinLength, Integer ignoredMaxLength)
+            throws Exception {
+        new JakartaValidationModule()
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testStringLengthResolvers(fieldName, null, null);
+    }
+
+    private void testStringLengthResolvers(String fieldName, Integer expectedMinLength, Integer expectedMaxLength) throws Exception {
+        TestType testType = new TestType(TestClassForStringProperties.class);
+        FieldScope field = testType.getMemberField(fieldName);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, Integer>> minLengthCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withStringMinLengthResolver(minLengthCaptor.capture());
+        Integer minLength = minLengthCaptor.getValue().apply(field);
+        Assert.assertEquals(expectedMinLength, minLength);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, Integer>> maxLengthCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withStringMaxLengthResolver(maxLengthCaptor.capture());
+        Integer maxLength = maxLengthCaptor.getValue().apply(field);
+        Assert.assertEquals(expectedMaxLength, maxLength);
+    }
+
+    Object parametersForTestStringFormatAndPatternResolvers() {
+        JakartaValidationOption[] onlyPatternOption = new JakartaValidationOption[]{
+            JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS
+        };
+        JakartaValidationOption[] patternAndIdnEmailOptions = new JakartaValidationOption[]{
+            JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS, JakartaValidationOption.PREFER_IDN_EMAIL_FORMAT
+        };
+        return new Object[][]{
+            {"unannotatedString", onlyPatternOption, null, null},
+            {"sizeTenToTwentyArray", onlyPatternOption, null, null},
+            {"sizeTenToTwentyOnGetterArray", onlyPatternOption, null, null},
+            {"minSizeFiveSequence", onlyPatternOption, null, "^\\d+$"},
+            {"minSizeFiveOnGetterSequence", onlyPatternOption, null, "^\\d+$"},
+            {"nonEmptyMaxSizeHundredString", onlyPatternOption, "email", null},
+            {"nonEmptyMaxSizeHundredString", patternAndIdnEmailOptions, "idn-email", null},
+            {"nonEmptyMaxSizeHundredOnGetterString", onlyPatternOption, "email", null},
+            {"nonEmptyMaxSizeHundredOnGetterString", patternAndIdnEmailOptions, "idn-email", null},
+            {"nonBlankString", onlyPatternOption, "email", "^.+your-company\\.com$"},
+            {"nonBlankOnGetterString", onlyPatternOption, "email", "^.+your-company\\.com$"}
+        };
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestStringFormatAndPatternResolvers")
+    public void testStringFormatAndPatternResolversNoValidationGroup(String fieldName, JakartaValidationOption[] options,
+            String expectedFormat, String expectedPattern) throws Exception {
+        new JakartaValidationModule(options).applyToConfigBuilder(this.configBuilder);
+
+        this.testStringFormatAndPatternResolvers(fieldName, expectedFormat, expectedPattern);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestStringFormatAndPatternResolvers")
+    public void testStringFormatAndPatternResolversMatchingValidationGroup(String fieldName, JakartaValidationOption[] options,
+            String expectedFormat, String expectedPattern) throws Exception {
+        new JakartaValidationModule(options)
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testStringFormatAndPatternResolvers(fieldName, expectedFormat, expectedPattern);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestStringFormatAndPatternResolvers")
+    @TestCaseName("{method}({0}, {1}) [{index}]")
+    public void testStringFormatAndPatternResolversDifferentValidationGroup(String fieldName, JakartaValidationOption[] options,
+            String ignoredFormat, String ignoredPattern) throws Exception {
+        new JakartaValidationModule(options)
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testStringFormatAndPatternResolvers(fieldName, null, null);
+    }
+
+    private void testStringFormatAndPatternResolvers(String fieldName, String expectedFormat, String expectedPattern)
+            throws Exception {
+        TestType testType = new TestType(TestClassForStringProperties.class);
+        FieldScope field = testType.getMemberField(fieldName);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, String>> formatCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withStringFormatResolver(formatCaptor.capture());
+        String formatValue = formatCaptor.getValue().apply(field);
+        Assert.assertEquals(expectedFormat, formatValue);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, String>> patternCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withStringPatternResolver(patternCaptor.capture());
+        String patternValue = patternCaptor.getValue().apply(field);
+        Assert.assertEquals(expectedPattern, patternValue);
+    }
+
+    Object parametersForTestNumberMinMaxResolvers() {
+        return new Object[][]{
+            {"unannotatedInt", null, null, null, null},
+            {"minMinusHundredLong", "-100", null, null, null},
+            {"minMinusHundredOnGetterLong", "-100", null, null, null},
+            {"maxFiftyShort", null, null, "50", null},
+            {"maxFiftyOnGetterShort", null, null, "50", null},
+            {"tenToTwentyInclusiveInteger", "10.1", null, "20.2", null},
+            {"tenToTwentyInclusiveOnGetterInteger", "10.1", null, "20.2", null},
+            {"tenToTwentyExclusiveInteger", null, "10.1", null, "20.2"},
+            {"tenToTwentyExclusiveOnGetterInteger", null, "10.1", null, "20.2"},
+            {"positiveByte", null, BigDecimal.ZERO, null, null},
+            {"positiveOnGetterByte", null, BigDecimal.ZERO, null, null},
+            {"positiveOrZeroBigInteger", BigDecimal.ZERO, null, null, null},
+            {"positiveOrZeroOnGetterBigInteger", BigDecimal.ZERO, null, null, null},
+            {"negativeDecimal", null, null, null, BigDecimal.ZERO},
+            {"negativeOnGetterDecimal", null, null, null, BigDecimal.ZERO},
+            {"negativeOrZeroLong", null, null, BigDecimal.ZERO, null},
+            {"negativeOrZeroOnGetterLong", null, null, BigDecimal.ZERO, null}
+        };
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNumberMinMaxResolvers")
+    public void testNumberMinMaxResolversNoValidationGroup(String fieldName, BigDecimal expectedMinInclusive, BigDecimal expectedMinExclusive,
+            BigDecimal expectedMaxInclusive, BigDecimal expectedMaxExclusive) throws Exception {
+        new JakartaValidationModule().applyToConfigBuilder(this.configBuilder);
+
+        this.testNumberMinMaxResolvers(fieldName, expectedMinInclusive, expectedMinExclusive, expectedMaxInclusive, expectedMaxExclusive);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNumberMinMaxResolvers")
+    public void testNumberMinMaxResolversMatchingValidationGroup(String fieldName, BigDecimal expectedMinInclusive, BigDecimal expectedMinExclusive,
+            BigDecimal expectedMaxInclusive, BigDecimal expectedMaxExclusive) throws Exception {
+        new JakartaValidationModule()
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testNumberMinMaxResolvers(fieldName, expectedMinInclusive, expectedMinExclusive, expectedMaxInclusive, expectedMaxExclusive);
+    }
+
+    @Test
+    @Parameters(method = "parametersForTestNumberMinMaxResolvers")
+    @TestCaseName("{method}({0}) [{index}]")
+    public void testNumberMinMaxResolversDifferentValidationGroup(String fieldName, BigDecimal ignoredMinInclusive, BigDecimal ignoredMinExclusive,
+            BigDecimal ignoredMaxInclusive, BigDecimal ignoredMaxExclusive) throws Exception {
+        new JakartaValidationModule()
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testNumberMinMaxResolvers(fieldName, null, null, null, null);
+    }
+
+    private void testNumberMinMaxResolvers(String fieldName, BigDecimal expectedMinInclusive, BigDecimal expectedMinExclusive,
+            BigDecimal expectedMaxInclusive, BigDecimal expectedMaxExclusive) {
+        TestType testType = new TestType(TestClassForNumberMinMax.class);
+        FieldScope field = testType.getMemberField(fieldName);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, BigDecimal>> minInclusiveCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withNumberInclusiveMinimumResolver(minInclusiveCaptor.capture());
+        BigDecimal minInclusive = minInclusiveCaptor.getValue().apply(field);
+        Assert.assertEquals(expectedMinInclusive, minInclusive);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, BigDecimal>> minExclusiveCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withNumberExclusiveMinimumResolver(minExclusiveCaptor.capture());
+        BigDecimal minExclusive = minExclusiveCaptor.getValue().apply(field);
+        Assert.assertEquals(expectedMinExclusive, minExclusive);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, BigDecimal>> maxInclusiveCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withNumberInclusiveMaximumResolver(maxInclusiveCaptor.capture());
+        BigDecimal maxInclusive = maxInclusiveCaptor.getValue().apply(field);
+        Assert.assertEquals(expectedMaxInclusive, maxInclusive);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, BigDecimal>> maxExclusiveCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withNumberExclusiveMaximumResolver(maxExclusiveCaptor.capture());
+        BigDecimal maxExclusive = maxExclusiveCaptor.getValue().apply(field);
+        Assert.assertEquals(expectedMaxExclusive, maxExclusive);
+    }
+
+    public Object[] parametersForTestValidationGroupSetting() {
+        return new Object[][]{
+            {"skippedConfiguringGroups", "fieldWithoutValidationGroup", Boolean.TRUE, null},
+            {"skippedConfiguringGroups", "fieldWithSingleValidationGroup", Boolean.TRUE, null},
+            {"skippedConfiguringGroups", "fieldWithMultipleValidationGroups", Boolean.TRUE, null},
+            {"noConfiguredGroups", "fieldWithoutValidationGroup", Boolean.TRUE, new Class<?>[0]},
+            {"noConfiguredGroups", "fieldWithSingleValidationGroup", null, new Class<?>[0]},
+            {"noConfiguredGroups", "fieldWithMultipleValidationGroups", null, new Class<?>[0]},
+            {"singleConfiguredGroup", "fieldWithoutValidationGroup", Boolean.TRUE, new Class<?>[]{Test.class}},
+            {"singleConfiguredMatchingGroup", "fieldWithSingleValidationGroup", Boolean.TRUE, new Class<?>[]{Test.class}},
+            {"singleConfiguredMatchingGroup", "fieldWithMultipleValidationGroups", Boolean.TRUE, new Class<?>[]{Test.class}},
+            {"singleConfiguredDifferentGroup", "fieldWithSingleValidationGroup", null, new Class<?>[]{Object.class}},
+            {"singleConfiguredDifferentGroup", "fieldWithMultipleValidationGroups", null, new Class<?>[]{Object.class}},
+            {"multipleConfiguredGroups", "fieldWithoutValidationGroup", Boolean.TRUE, new Class<?>[]{Test.class, Object.class}},
+            {"multipleConfiguredGroupsSingleMatch", "fieldWithSingleValidationGroup", Boolean.TRUE, new Class<?>[]{Test.class, Object.class}},
+            {"multipleConfiguredGroupsSingleMatch", "fieldWithMultipleValidationGroups", Boolean.TRUE, new Class<?>[]{Test.class, Object.class}},
+            {"multipleConfiguredGroupsMultipleMatches", "fieldWithMultipleValidationGroups", Boolean.TRUE, new Class<?>[]{Test.class, Assert.class}},
+            {"multipleConfiguredGroupsNoMatch", "fieldWithSingleValidationGroup", null, new Class<?>[]{Integer.class, Double.class}},
+            {"multipleConfiguredGroupsNoMatch", "fieldWithMultipleValidationGroups", null, new Class<?>[]{Integer.class, Double.class}}
+        };
+    }
+
+    @Test
+    @Parameters
+    @TestCaseName("{method}({0}, {1}, {2}) [{index}]")
+    public void testValidationGroupSetting(String testCase, String fieldName, Boolean expectedResult, Class<?>[] validationGroups) {
+        JakartaValidationModule module = new JakartaValidationModule();
+        if (validationGroups != null) {
+            module.forValidationGroups(validationGroups);
+        }
+        module.applyToConfigBuilder(this.configBuilder);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, Boolean>> captor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withNullableCheck(captor.capture());
+        TestType testType = new TestType(TestClassForValidationGroups.class);
+        FieldScope field = testType.getMemberField(fieldName);
+
+        Boolean result = captor.getValue().apply(field);
+        Assert.assertEquals(expectedResult, result);
+    }
+
+    private static class TestClassForNullableCheck {
+
+        Integer unannotatedField;
+        @NotNull(groups = Test.class)
+        Double notNullNumber;
+        Double notNullOnGetterNumber;
+        @NotEmpty(groups = Test.class)
+        List<Object> notEmptyList;
+        List<Object> notEmptyOnGetterList;
+        @NotBlank(groups = Test.class)
+        String notBlankString;
+        String notBlankOnGetterString;
+        @Null(groups = Test.class)
+        Object nullField;
+        Object nullGetter;
+
+        public Integer getUnannotatedField() {
+            return this.unannotatedField;
+        }
+
+        public Double getNotNullNumber() {
+            return this.notNullNumber;
+        }
+
+        @NotNull(groups = Test.class)
+        public Double getNotNullOnGetterNumber() {
+            return this.notNullOnGetterNumber;
+        }
+
+        public List<Object> getNotEmptyList() {
+            return this.notEmptyList;
+        }
+
+        @NotEmpty(groups = Test.class)
+        public List<Object> getNotEmptyOnGetterList() {
+            return this.notEmptyOnGetterList;
+        }
+
+        public String getNotBlankString() {
+            return this.notBlankString;
+        }
+
+        @NotBlank(groups = Test.class)
+        public String getNotBlankOnGetterString() {
+            return this.notBlankOnGetterString;
+        }
+
+        public Object getNullField() {
+            return this.nullField;
+        }
+
+        @Null(groups = Test.class)
+        public Object getNullGetter() {
+            return this.nullGetter;
+        }
+    }
+
+    private static class TestClassForArrayItemCount {
+
+        String[] unannotatedArray;
+        @Size(min = 10, max = 20, groups = Test.class)
+        String sizeTenToTwentyString;
+        String sizeTenToTwentyOnGetterString;
+        @Size(min = 5, groups = Test.class)
+        int[] minSizeFiveArray;
+        int[] minSizeFiveOnGetterArray;
+        @Size(max = 50, groups = Test.class)
+        long[] maxSizeFiftyArray;
+        long[] maxSizeFiftyOnGetterArray;
+        @Size(min = 10, max = 20, groups = Test.class)
+        Set<Boolean> sizeTenToTwentySet;
+        Set<Boolean> sizeTenToTwentyOnGetterSet;
+        @NotEmpty(groups = Test.class)
+        @Size(max = 100, groups = Test.class)
+        List<Double> nonEmptyMaxSizeHundredList;
+        List<Double> nonEmptyMaxSizeHundredOnGetterList;
+
+        @Size(min = 10, max = 20, groups = Test.class)
+        public String getSizeTenToTwentyString() {
+            return this.sizeTenToTwentyString;
+        }
+
+        @Size(min = 5, groups = Test.class)
+        public int[] getMinSizeFiveOnGetterArray() {
+            return this.minSizeFiveOnGetterArray;
+        }
+
+        @Size(max = 50, groups = Test.class)
+        public long[] getMaxSizeFiftyOnGetterArray() {
+            return this.maxSizeFiftyOnGetterArray;
+        }
+
+        @Size(min = 10, max = 20, groups = Test.class)
+        public Set<Boolean> getSizeTenToTwentyOnGetterSet() {
+            return this.sizeTenToTwentyOnGetterSet;
+        }
+
+        @NotEmpty(groups = Test.class)
+        @Size(max = 100, groups = Test.class)
+        public List<Double> getNonEmptyMaxSizeHundredOnGetterList() {
+            return this.nonEmptyMaxSizeHundredOnGetterList;
+        }
+    }
+
+    private static class TestClassForStringProperties {
+
+        String unannotatedString;
+        @Size(min = 10, max = 20, groups = Test.class)
+        @Email(groups = Test.class)
+        @Pattern(regexp = ".*", groups = Test.class)
+        int[] sizeTenToTwentyArray;
+        int[] sizeTenToTwentyOnGetterArray;
+        @Size(min = 5, groups = Test.class)
+        @Pattern(regexp = "^\\d+$", groups = Test.class)
+        CharSequence minSizeFiveSequence;
+        CharSequence minSizeFiveOnGetterSequence;
+        @Size(max = 50, groups = Test.class)
+        String maxSizeFiftyString;
+        String maxSizeFiftyOnGetterString;
+        @Size(min = 10, max = 20, groups = Test.class)
+        String sizeTenToTwentyString;
+        String sizeTenToTwentyOnGetterString;
+        @NotEmpty(groups = Test.class)
+        @Size(max = 100, groups = Test.class)
+        @Email(groups = Test.class)
+        String nonEmptyMaxSizeHundredString;
+        String nonEmptyMaxSizeHundredOnGetterString;
+        @NotBlank(groups = Test.class)
+        @Email(regexp = "^.+your-company\\.com$", groups = Test.class)
+        String nonBlankString;
+        String nonBlankOnGetterString;
+
+        @Size(min = 10, max = 20, groups = Test.class)
+        @Email(groups = Test.class)
+        @Pattern(regexp = ".*", groups = Test.class)
+        public int[] getSizeTenToTwentyOnGetterArray() {
+            return this.sizeTenToTwentyOnGetterArray;
+        }
+
+        @Size(min = 5, groups = Test.class)
+        @Pattern(regexp = "^\\d+$", groups = Test.class)
+        public CharSequence getMinSizeFiveOnGetterSequence() {
+            return this.minSizeFiveOnGetterSequence;
+        }
+
+        @Size(max = 50, groups = Test.class)
+        public String getMaxSizeFiftyOnGetterString() {
+            return this.maxSizeFiftyOnGetterString;
+        }
+
+        @Size(min = 10, max = 20, groups = Test.class)
+        public String getSizeTenToTwentyOnGetterString() {
+            return this.sizeTenToTwentyOnGetterString;
+        }
+
+        @NotEmpty(groups = Test.class)
+        @Size(max = 100, groups = Test.class)
+        @Email(groups = Test.class)
+        public String getNonEmptyMaxSizeHundredOnGetterString() {
+            return this.nonEmptyMaxSizeHundredOnGetterString;
+        }
+
+        @NotBlank(groups = Test.class)
+        @Email(regexp = "^.+your-company\\.com$", groups = Test.class)
+        public String getNonBlankOnGetterString() {
+            return this.nonBlankOnGetterString;
+        }
+    }
+
+    private static class TestClassForNumberMinMax {
+
+        int unannotatedInt;
+        @Min(value = -100L, groups = Test.class)
+        long minMinusHundredLong;
+        long minMinusHundredOnGetterLong;
+        @Max(value = 50, groups = Test.class)
+        short maxFiftyShort;
+        short maxFiftyOnGetterShort;
+        @DecimalMin(value = "10.1", groups = Test.class)
+        @DecimalMax(value = "20.2", groups = Test.class)
+        Integer tenToTwentyInclusiveInteger;
+        Integer tenToTwentyInclusiveOnGetterInteger;
+        @DecimalMin(value = "10.1", inclusive = false, groups = Test.class)
+        @DecimalMax(value = "20.2", inclusive = false, groups = Test.class)
+        Integer tenToTwentyExclusiveInteger;
+        Integer tenToTwentyExclusiveOnGetterInteger;
+        @Positive(groups = Test.class)
+        byte positiveByte;
+        byte positiveOnGetterByte;
+        @PositiveOrZero(groups = Test.class)
+        BigInteger positiveOrZeroBigInteger;
+        BigInteger positiveOrZeroOnGetterBigInteger;
+        @Negative(groups = Test.class)
+        BigDecimal negativeDecimal;
+        BigDecimal negativeOnGetterDecimal;
+        @NegativeOrZero(groups = Test.class)
+        Long negativeOrZeroLong;
+        Long negativeOrZeroOnGetterLong;
+
+        @Min(value = -100L, groups = Test.class)
+        public long getMinMinusHundredOnGetterLong() {
+            return minMinusHundredOnGetterLong;
+        }
+
+        @Max(value = 50, groups = Test.class)
+        public short getMaxFiftyOnGetterShort() {
+            return maxFiftyOnGetterShort;
+        }
+
+        @DecimalMin(value = "10.1", groups = Test.class)
+        @DecimalMax(value = "20.2", groups = Test.class)
+        public Integer getTenToTwentyInclusiveOnGetterInteger() {
+            return tenToTwentyInclusiveOnGetterInteger;
+        }
+
+        @DecimalMin(value = "10.1", inclusive = false, groups = Test.class)
+        @DecimalMax(value = "20.2", inclusive = false, groups = Test.class)
+        public Integer getTenToTwentyExclusiveOnGetterInteger() {
+            return tenToTwentyExclusiveOnGetterInteger;
+        }
+
+        @Positive(groups = Test.class)
+        public byte getPositiveOnGetterByte() {
+            return positiveOnGetterByte;
+        }
+
+        @PositiveOrZero(groups = Test.class)
+        public BigInteger getPositiveOrZeroOnGetterBigInteger() {
+            return positiveOrZeroOnGetterBigInteger;
+        }
+
+        @Negative(groups = Test.class)
+        public BigDecimal getNegativeOnGetterDecimal() {
+            return negativeOnGetterDecimal;
+        }
+
+        @NegativeOrZero(groups = Test.class)
+        public Long getNegativeOrZeroOnGetterLong() {
+            return negativeOrZeroOnGetterLong;
+        }
+    }
+
+    private static class TestClassForValidationGroups {
+
+        @Null
+        String fieldWithoutValidationGroup;
+        @Null(groups = Test.class)
+        String fieldWithSingleValidationGroup;
+        @Null(groups = {Test.class, Assert.class})
+        String fieldWithMultipleValidationGroups;
+    }
+}

--- a/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/TestType.java
+++ b/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/TestType.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 VicTools & Sascha Kohlmann
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.jakarta.validation;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.ResolvedTypeWithMembers;
+import com.fasterxml.classmate.members.ResolvedField;
+import com.fasterxml.classmate.members.ResolvedMethod;
+import com.github.victools.jsonschema.generator.FieldScope;
+import com.github.victools.jsonschema.generator.MethodScope;
+import com.github.victools.jsonschema.generator.TypeContext;
+import com.github.victools.jsonschema.generator.impl.TypeContextFactory;
+import java.util.stream.Stream;
+
+/**
+ * Helper class for constructing {@link FieldScope} and {@link MethodScope} instances in tests.
+ */
+public class TestType {
+
+    private final TypeContext context;
+    private final ResolvedType resolvedTestClass;
+    private final ResolvedTypeWithMembers testClassMembers;
+
+    public TestType(Class<?> testClass) {
+        this.context = TypeContextFactory.createDefaultTypeContext();
+        this.resolvedTestClass = this.context.resolve(testClass);
+        this.testClassMembers = this.context.resolveWithMembers(this.resolvedTestClass);
+    }
+
+    public FieldScope getMemberField(String fieldName) {
+        return this.getField(this.testClassMembers.getMemberFields(), fieldName);
+    }
+
+    public FieldScope getStaticField(String fieldName) {
+        return this.getField(this.testClassMembers.getStaticFields(), fieldName);
+    }
+
+    private FieldScope getField(ResolvedField[] fields, String fieldName) {
+        return Stream.of(fields)
+                .filter(field -> fieldName.equals(field.getName()))
+                .findAny()
+                .map(field -> this.context.createFieldScope(field, this.testClassMembers))
+                .get();
+    }
+
+    public MethodScope getMemberMethod(String methodName) {
+        return this.getMethod(this.testClassMembers.getMemberMethods(), methodName);
+    }
+
+    public MethodScope getStaticMethod(String methodName) {
+        return this.getMethod(this.testClassMembers.getStaticMethods(), methodName);
+    }
+
+    private MethodScope getMethod(ResolvedMethod[] methods, String methodName) {
+        return Stream.of(methods)
+                .filter(method -> methodName.equals(method.getName()))
+                .findAny()
+                .map(method -> this.context.createMethodScope(method, this.testClassMembers))
+                .get();
+    }
+}

--- a/jsonschema-module-jakarta-validation/src/test/resources/com/github/victools/jsonschema/module/jakarta/validation/integration-test-result.json
+++ b/jsonschema-module-jakarta-validation/src/test/resources/com/github/victools/jsonschema/module/jakarta/validation/integration-test-result.json
@@ -1,0 +1,88 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "object",
+    "properties": {
+        "exclusiveRangeDouble": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "exclusiveMaximum": 1
+        },
+        "inclusiveRangeInt": {
+            "type": "integer",
+            "minimum": 7,
+            "maximum": 38
+        },
+        "notBlankText": {
+            "type": "string",
+            "minLength": 1
+        },
+        "notEmptyList": {
+            "minItems": 1,
+            "type": "array",
+            "items": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "exclusiveMaximum": 1
+            }
+        },
+        "notEmptyPatternText": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\w+"
+        },
+        "notNullEmail": {
+            "type": "string",
+            "format": "email",
+            "pattern": ".+@.+\\..+"
+        },
+        "notNullList": {
+            "type": "array",
+            "items": {
+                "type": "integer",
+                "minimum": 2,
+                "maximum": 2048
+            }
+        },
+        "nullObject": {},
+        "optionalInclusiveRangeInt1": {
+            "type": ["integer", "null"],
+            "minimum": 1,
+            "maximum": 8
+        },
+        "optionalInclusiveRangeInt2": {
+            "type": ["integer", "null"],
+            "minimum": 2,
+            "maximum": 5
+        },
+        "optionalSizeRangeString1": {
+            "type": ["integer", "null"]
+        },
+        "optionalSizeRangeString2": {
+            "type": ["integer", "null"]
+        },
+        "sizeRangeList": {
+            "minItems": 3,
+            "maxItems": 25,
+            "type": "array",
+            "items": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 100
+            }
+        },
+        "sizeRangeListWithoutItemAnnotation": {
+            "minItems": 3,
+            "maxItems": 25,
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "sizeRangeText": {
+            "type": "string",
+            "minLength": 5,
+            "maxLength": 12
+        }
+    },
+    "required": ["notBlankText", "notEmptyList", "notEmptyPatternText", "notNullEmail", "notNullList"]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
     <modules>
         <module>jsonschema-generator</module>
         <module>jsonschema-module-jackson</module>
-        <module>jsonschema-module-javax-validation</module>
         <module>jsonschema-module-jakarta-validation</module>
+        <module>jsonschema-module-javax-validation</module>
         <module>jsonschema-module-swagger-1.5</module>
         <module>jsonschema-module-swagger-2</module>
         <module>jsonschema-maven-plugin</module>
@@ -96,8 +96,8 @@
 
         <version.classmate>1.5.1</version.classmate>
         <version.jackson>2.10.3</version.jackson>
-        <version.javax.validation>2.0.1.Final</version.javax.validation>
         <version.jakarta.validation>3.0.0</version.jakarta.validation>
+        <version.javax.validation>2.0.1.Final</version.javax.validation>
         <version.jsonassert>1.5.0</version.jsonassert>
         <version.junit>4.13.1</version.junit>
         <version.junitparams>1.1.1</version.junitparams>
@@ -124,12 +124,12 @@
             </dependency>
             <dependency>
                 <groupId>com.github.victools</groupId>
-                <artifactId>jsonschema-module-javax-validation</artifactId>
+                <artifactId>jsonschema-module-jakarta-validation</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.victools</groupId>
-                <artifactId>jsonschema-module-jakarta-validation</artifactId>
+                <artifactId>jsonschema-module-javax-validation</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <module>jsonschema-generator</module>
         <module>jsonschema-module-jackson</module>
         <module>jsonschema-module-javax-validation</module>
+        <module>jsonschema-module-jakarta-validation</module>
         <module>jsonschema-module-swagger-1.5</module>
         <module>jsonschema-module-swagger-2</module>
         <module>jsonschema-maven-plugin</module>
@@ -96,6 +97,7 @@
         <version.classmate>1.5.1</version.classmate>
         <version.jackson>2.10.3</version.jackson>
         <version.javax.validation>2.0.1.Final</version.javax.validation>
+        <version.jakarta.validation>3.0.0</version.jakarta.validation>
         <version.jsonassert>1.5.0</version.jsonassert>
         <version.junit>4.13.1</version.junit>
         <version.junitparams>1.1.1</version.junitparams>
@@ -123,6 +125,11 @@
             <dependency>
                 <groupId>com.github.victools</groupId>
                 <artifactId>jsonschema-module-javax-validation</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.victools</groupId>
+                <artifactId>jsonschema-module-jakarta-validation</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -159,6 +166,11 @@
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>${version.javax.validation}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${version.jakarta.validation}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -163,14 +163,14 @@
                 <version>${version.jackson}</version>
             </dependency>
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>${version.javax.validation}</version>
-            </dependency>
-            <dependency>
                 <groupId>jakarta.validation</groupId>
                 <artifactId>jakarta.validation-api</artifactId>
                 <version>${version.jakarta.validation}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${version.javax.validation}</version>
             </dependency>
             <dependency>
                 <groupId>io.swagger</groupId>


### PR DESCRIPTION
A simple Java Validation clone to support Jakarta Validation. 

A more elegant way might be to support both packages in one module. Nevertheless this requires more complex dependency management in the code for class accessibility. So I decide for the cloned and repackaged code.