### PR TITLE
#162 : add JacksonOption.RESPECT_JSONPROPERTY_REQUIRED

### DIFF
--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -98,6 +98,10 @@ public class JacksonModule implements Module {
             generalConfigPart.withPropertySorter(new JsonPropertySorter(true));
         }
 
+        if (this.options.contains(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED)) {
+            fieldConfigPart.withRequiredCheck( this::getRequiredCheckBasedOnJsonPropertyAnnotation );
+        }
+
         boolean lookUpSubtypes = !this.options.contains(JacksonOption.SKIP_SUBTYPE_LOOKUP);
         boolean includeTypeInfoTransform = !this.options.contains(JacksonOption.IGNORE_TYPE_INFO_TRANSFORM);
         if (lookUpSubtypes || includeTypeInfoTransform) {
@@ -248,4 +252,19 @@ public class JacksonModule implements Module {
         return beanDescription.findProperties().stream()
                 .noneMatch(propertyDefinition -> fieldName.equals(propertyDefinition.getInternalName()));
     }
+
+    /**
+     * Look-up the given field's {@link JsonProperty} annotation and its "required" attribute,  and calculate wether or not this field should be part of the required properties
+     *
+     * @param field field to look-up required strategy for
+     * @return whether the field should be in the "required" list or not
+     */
+    private boolean getRequiredCheckBasedOnJsonPropertyAnnotation(FieldScope field) {
+        JsonProperty jsonProperty = field.getAnnotationConsideringFieldAndGetter(JsonProperty.class) ;
+        if ( jsonProperty == null )
+            return false;
+        else
+            return jsonProperty.required();
+    }
+
 }

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -99,7 +99,7 @@ public class JacksonModule implements Module {
         }
 
         if (this.options.contains(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED)) {
-            fieldConfigPart.withRequiredCheck( this::getRequiredCheckBasedOnJsonPropertyAnnotation );
+            fieldConfigPart.withRequiredCheck(this::getRequiredCheckBasedOnJsonPropertyAnnotation);
         }
 
         boolean lookUpSubtypes = !this.options.contains(JacksonOption.SKIP_SUBTYPE_LOOKUP);
@@ -254,17 +254,14 @@ public class JacksonModule implements Module {
     }
 
     /**
-     * Look-up the given field's {@link JsonProperty} annotation and its "required" attribute,  and calculate wether or not this field should be part of the required properties
+     * Look-up the given field's {@link JsonProperty} annotation and consider its "required" attribute.
      *
      * @param field field to look-up required strategy for
      * @return whether the field should be in the "required" list or not
      */
     private boolean getRequiredCheckBasedOnJsonPropertyAnnotation(FieldScope field) {
         JsonProperty jsonProperty = field.getAnnotationConsideringFieldAndGetter(JsonProperty.class) ;
-        if ( jsonProperty == null )
-            return false;
-        else
-            return jsonProperty.required();
+        return jsonProperty != null && jsonProperty.required();
     }
 
 }

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
@@ -65,8 +65,7 @@ public enum JacksonOption {
      */
     IGNORE_TYPE_INFO_TRANSFORM,
     /**
-     * Use this option to follow the required flag based on {@code @JsonProperty} required attribute
-     * By default, for backward compatibility, the "required" attribute of @JsonProperty is not
+     * Use this option to include fields annotated with {@code @JsonProperty(required = true)} in the containing type's list of "required" properties.
      */
     RESPECT_JSONPROPERTY_REQUIRED
 }

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
@@ -63,5 +63,10 @@ public enum JacksonOption {
     /**
      * Use this option to skip the transformation according to {@code @JsonTypeInfo} annotations (typically used to identify specific subtypes).
      */
-    IGNORE_TYPE_INFO_TRANSFORM;
+    IGNORE_TYPE_INFO_TRANSFORM,
+    /**
+     * Use this option to follow the required flag based on {@code @JsonProperty} required attribute
+     * By default, for backward compatibility, the "required" attribute of @JsonProperty is not
+     */
+    RESPECT_JSONPROPERTY_REQUIRED
 }

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
@@ -132,9 +132,9 @@ public class JacksonModuleTest {
 
     public Object[] parametersForTestApplyToConfigBuilderWithEnumOptions() {
         return new Object[][]{
-            {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE}},
-            {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY}},
-            {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE, JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY}}
+                {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE}},
+                {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY}},
+                {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE, JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY}}
         };
     }
 
@@ -171,12 +171,12 @@ public class JacksonModuleTest {
 
     Object parametersForTestPropertyNameOverride() {
         return new Object[][]{
-            {"unannotatedField", null, "unannotated-field"},
-            {"fieldWithEmptyPropertyAnnotation", null, "field-with-empty-property-annotation"},
-            {"fieldWithSameValuePropertyAnnotation", null, "field-with-same-value-property-annotation"},
-            {"fieldWithNameOverride", "field override 1", "field-with-name-override"},
-            {"fieldWithNameOverrideOnGetter", "method override 1", "field-with-name-override-on-getter"},
-            {"fieldWithNameOverrideAndOnGetter", "field override 2", "field-with-name-override-and-on-getter"}
+                {"unannotatedField", null, "unannotated-field"},
+                {"fieldWithEmptyPropertyAnnotation", null, "field-with-empty-property-annotation"},
+                {"fieldWithSameValuePropertyAnnotation", null, "field-with-same-value-property-annotation"},
+                {"fieldWithNameOverride", "field override 1", "field-with-name-override"},
+                {"fieldWithNameOverrideOnGetter", "method override 1", "field-with-name-override-on-getter"},
+                {"fieldWithNameOverrideAndOnGetter", "field override 2", "field-with-name-override-and-on-getter"}
         };
     }
 
@@ -198,11 +198,11 @@ public class JacksonModuleTest {
 
     Object parametersForTestDescriptionResolver() {
         return new Object[][]{
-            {"unannotatedField", null},
-            {"fieldWithDescription", "field description 1"},
-            {"fieldWithDescriptionOnGetter", "getter description 1"},
-            {"fieldWithDescriptionAndOnGetter", "field description 2"},
-            {"fieldWithDescriptionOnType", null}
+                {"unannotatedField", null},
+                {"fieldWithDescription", "field description 1"},
+                {"fieldWithDescriptionOnGetter", "getter description 1"},
+                {"fieldWithDescriptionAndOnGetter", "field description 2"},
+                {"fieldWithDescriptionOnType", null}
         };
     }
 
@@ -219,13 +219,36 @@ public class JacksonModuleTest {
         Assert.assertEquals(expectedDescription, description);
     }
 
+    Object parametersForTestRequiredProperty() {
+        return new Object[][]{
+                {null,"requiredTrue", false},
+                {null,"requiredFalse", false},
+                {null,"requiredAbsent", false},
+                {JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,"requiredTrue", true},
+                {JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,"requiredFalse", false},
+                {JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,"requiredAbsent", false}
+        };
+    }
+
+    @Test
+    @Parameters
+    public void testRequiredProperty(JacksonOption requiredOption, String fieldName, boolean expectedRequired) {
+        new JacksonModule(requiredOption).applyToConfigBuilder(this.configBuilder);
+
+        FieldScope field = new TestType(TestClassWithRequiredAnnotatedFields.class).getMemberField(fieldName);
+        //this.fieldConfigPart.isRequired(field);
+
+        Assert.assertEquals(this.fieldConfigPart.isRequired(field), expectedRequired);
+    }
+
+
     Object parametersForTestDescriptionForTypeResolver() {
         return new Object[][]{
-            {"unannotatedField", null},
-            {"fieldWithDescription", null},
-            {"fieldWithDescriptionOnGetter", null},
-            {"fieldWithDescriptionAndOnGetter", null},
-            {"fieldWithDescriptionOnType", "class description text"}
+                {"unannotatedField", null},
+                {"fieldWithDescription", null},
+                {"fieldWithDescriptionOnGetter", null},
+                {"fieldWithDescriptionAndOnGetter", null},
+                {"fieldWithDescriptionOnType", "class description text"}
         };
     }
 
@@ -292,4 +315,16 @@ public class JacksonModuleTest {
             return fieldWithDescriptionAndOnGetter;
         }
     }
+
+    private static class TestClassWithRequiredAnnotatedFields {
+        @JsonProperty(required = true)
+        private String requiredTrue;
+
+        @JsonProperty(required = false)
+        private String requiredFalse;
+
+        private String requiredAbsent;
+
+    }
+
 }

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
@@ -132,9 +132,9 @@ public class JacksonModuleTest {
 
     public Object[] parametersForTestApplyToConfigBuilderWithEnumOptions() {
         return new Object[][]{
-                {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE}},
-                {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY}},
-                {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE, JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY}}
+            {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE}},
+            {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY}},
+            {new JacksonOption[]{JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE, JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY}}
         };
     }
 
@@ -171,12 +171,12 @@ public class JacksonModuleTest {
 
     Object parametersForTestPropertyNameOverride() {
         return new Object[][]{
-                {"unannotatedField", null, "unannotated-field"},
-                {"fieldWithEmptyPropertyAnnotation", null, "field-with-empty-property-annotation"},
-                {"fieldWithSameValuePropertyAnnotation", null, "field-with-same-value-property-annotation"},
-                {"fieldWithNameOverride", "field override 1", "field-with-name-override"},
-                {"fieldWithNameOverrideOnGetter", "method override 1", "field-with-name-override-on-getter"},
-                {"fieldWithNameOverrideAndOnGetter", "field override 2", "field-with-name-override-and-on-getter"}
+            {"unannotatedField", null, "unannotated-field"},
+            {"fieldWithEmptyPropertyAnnotation", null, "field-with-empty-property-annotation"},
+            {"fieldWithSameValuePropertyAnnotation", null, "field-with-same-value-property-annotation"},
+            {"fieldWithNameOverride", "field override 1", "field-with-name-override"},
+            {"fieldWithNameOverrideOnGetter", "method override 1", "field-with-name-override-on-getter"},
+            {"fieldWithNameOverrideAndOnGetter", "field override 2", "field-with-name-override-and-on-getter"}
         };
     }
 
@@ -198,11 +198,11 @@ public class JacksonModuleTest {
 
     Object parametersForTestDescriptionResolver() {
         return new Object[][]{
-                {"unannotatedField", null},
-                {"fieldWithDescription", "field description 1"},
-                {"fieldWithDescriptionOnGetter", "getter description 1"},
-                {"fieldWithDescriptionAndOnGetter", "field description 2"},
-                {"fieldWithDescriptionOnType", null}
+            {"unannotatedField", null},
+            {"fieldWithDescription", "field description 1"},
+            {"fieldWithDescriptionOnGetter", "getter description 1"},
+            {"fieldWithDescriptionAndOnGetter", "field description 2"},
+            {"fieldWithDescriptionOnType", null}
         };
     }
 
@@ -221,12 +221,14 @@ public class JacksonModuleTest {
 
     Object parametersForTestRequiredProperty() {
         return new Object[][]{
-                {null,"requiredTrue", false},
-                {null,"requiredFalse", false},
-                {null,"requiredAbsent", false},
-                {JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,"requiredTrue", true},
-                {JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,"requiredFalse", false},
-                {JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,"requiredAbsent", false}
+            {null, "requiredTrue", false},
+            {null, "requiredFalse", false},
+            {null, "requiredDefault", false},
+            {null, "requiredAbsent", false},
+            {JacksonOption.RESPECT_JSONPROPERTY_REQUIRED, "requiredTrue", true},
+            {JacksonOption.RESPECT_JSONPROPERTY_REQUIRED, "requiredFalse", false},
+            {JacksonOption.RESPECT_JSONPROPERTY_REQUIRED, "requiredDefault", false},
+            {JacksonOption.RESPECT_JSONPROPERTY_REQUIRED, "requiredAbsent", false}
         };
     }
 
@@ -236,19 +238,17 @@ public class JacksonModuleTest {
         new JacksonModule(requiredOption).applyToConfigBuilder(this.configBuilder);
 
         FieldScope field = new TestType(TestClassWithRequiredAnnotatedFields.class).getMemberField(fieldName);
-        //this.fieldConfigPart.isRequired(field);
 
         Assert.assertEquals(this.fieldConfigPart.isRequired(field), expectedRequired);
     }
 
-
     Object parametersForTestDescriptionForTypeResolver() {
         return new Object[][]{
-                {"unannotatedField", null},
-                {"fieldWithDescription", null},
-                {"fieldWithDescriptionOnGetter", null},
-                {"fieldWithDescriptionAndOnGetter", null},
-                {"fieldWithDescriptionOnType", "class description text"}
+            {"unannotatedField", null},
+            {"fieldWithDescription", null},
+            {"fieldWithDescriptionOnGetter", null},
+            {"fieldWithDescriptionAndOnGetter", null},
+            {"fieldWithDescriptionOnType", "class description text"}
         };
     }
 
@@ -322,6 +322,9 @@ public class JacksonModuleTest {
 
         @JsonProperty(required = false)
         private String requiredFalse;
+
+        @JsonProperty
+        private String requiredDefault;
 
         private String requiredAbsent;
 

--- a/slate-docs/source/includes/_jackson-module.md
+++ b/slate-docs/source/includes/_jackson-module.md
@@ -10,9 +10,9 @@ import com.github.victools.jsonschema.module.jackson.JacksonOption;
 
 JacksonModule module = new JacksonModule(
         JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE
-        );
-        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09)
-        .with(module);
+);
+SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09)
+    .with(module);
 ```
 
 1. Set a field/method's "description" as per `@JsonPropertyDescription`
@@ -20,10 +20,10 @@ JacksonModule module = new JacksonModule(
 3. Override a field's property name as per `@JsonProperty` annotations.
 4. Ignore fields that are marked with a `@JsonBackReference` annotation.
 5. Ignore fields that are deemed to be ignored according to various other `jackson-annotations` (e.g. `@JsonIgnore`, `@JsonIgnoreType`, `@JsonIgnoreProperties`) or are otherwise supposed to be excluded.
-6. Treat enum types as plain strings as per the `@JsonValue` annotated method, if there is one and the `JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE` was provided (i.e. this is an "opt-in").
-7. Optionally: treat enum types as plain strings, as per each enum constant's `@JsonProperty` annotation, if all values of an enum have such annotations and the `JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY` was provided (i.e. this is an "opt-in").
-8. Optionally: sort an object's properties according to its `@JsonPropertyOrder` annotation, if the `JacksonOption.RESPECT_JSONPROPERTY_ORDER` was provided (i.e. this is an "opt-in").
-9. Optionally: set a field as "required" as per `@JsonProperty(required=... )` annotations, if the `JacksonOption.RESPECT_JSONPROPERTY_REQUIRED` was provided (i.e. this is an "opt-in").
+6. Optionally: set a field as "required" as per `@JsonProperty` annotations, if the `JacksonOption.RESPECT_JSONPROPERTY_REQUIRED` was provided (i.e. this is an "opt-in").
+7. Optionally: treat enum types as plain strings as per the `@JsonValue` annotated method, if there is one and the `JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE` was provided (i.e. this is an "opt-in").
+8. Optionally: treat enum types as plain strings, as per each enum constant's `@JsonProperty` annotation, if all values of an enum have such annotations and the `JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY` was provided (i.e. this is an "opt-in").
+9. Optionally: sort an object's properties according to its `@JsonPropertyOrder` annotation, if the `JacksonOption.RESPECT_JSONPROPERTY_ORDER` was provided (i.e. this is an "opt-in").
 10. Subtype resolution according to `@JsonSubTypes` on a supertype in general or directly on specific fields/methods as an override of the per-type behavior unless `JacksonOption.SKIP_SUBTYPE_LOOKUP` was provided (i.e. this is an "opt-out").
 11. Apply structural changes for subtypes according to `@JsonTypeInfo` on a supertype in general or directly on specific fields/methods as an override of the per-type behavior unless `JacksonOption.IGNORE_TYPE_INFO_TRANSFORM` was provided (i.e. this is an "opt-out").
     * Considering `@JsonTypeInfo.include` with values `As.PROPERTY`, `As.EXISTING_PROPERTY`, `As.WRAPPER_ARRAY`, `As.WRAPPER_OBJECT`

--- a/slate-docs/source/includes/_jackson-module.md
+++ b/slate-docs/source/includes/_jackson-module.md
@@ -10,9 +10,9 @@ import com.github.victools.jsonschema.module.jackson.JacksonOption;
 
 JacksonModule module = new JacksonModule(
         JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE
-);
-SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09)
-    .with(module);
+        );
+        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09)
+        .with(module);
 ```
 
 1. Set a field/method's "description" as per `@JsonPropertyDescription`
@@ -23,8 +23,9 @@ SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(Sc
 6. Treat enum types as plain strings as per the `@JsonValue` annotated method, if there is one and the `JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE` was provided (i.e. this is an "opt-in").
 7. Optionally: treat enum types as plain strings, as per each enum constant's `@JsonProperty` annotation, if all values of an enum have such annotations and the `JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY` was provided (i.e. this is an "opt-in").
 8. Optionally: sort an object's properties according to its `@JsonPropertyOrder` annotation, if the `JacksonOption.RESPECT_JSONPROPERTY_ORDER` was provided (i.e. this is an "opt-in").
-9. Subtype resolution according to `@JsonSubTypes` on a supertype in general or directly on specific fields/methods as an override of the per-type behavior unless `JacksonOption.SKIP_SUBTYPE_LOOKUP` was provided (i.e. this is an "opt-out").
-10. Apply structural changes for subtypes according to `@JsonTypeInfo` on a supertype in general or directly on specific fields/methods as an override of the per-type behavior unless `JacksonOption.IGNORE_TYPE_INFO_TRANSFORM` was provided (i.e. this is an "opt-out").
+9. Optionally: set a field as "required" as per `@JsonProperty(required=... )` annotations, if the `JacksonOption.RESPECT_JSONPROPERTY_REQUIRED` was provided (i.e. this is an "opt-in").
+10. Subtype resolution according to `@JsonSubTypes` on a supertype in general or directly on specific fields/methods as an override of the per-type behavior unless `JacksonOption.SKIP_SUBTYPE_LOOKUP` was provided (i.e. this is an "opt-out").
+11. Apply structural changes for subtypes according to `@JsonTypeInfo` on a supertype in general or directly on specific fields/methods as an override of the per-type behavior unless `JacksonOption.IGNORE_TYPE_INFO_TRANSFORM` was provided (i.e. this is an "opt-out").
     * Considering `@JsonTypeInfo.include` with values `As.PROPERTY`, `As.EXISTING_PROPERTY`, `As.WRAPPER_ARRAY`, `As.WRAPPER_OBJECT`
     * Considering `@JsonTypeInfo.use` with values `Id.CLASS`, `Id.NAME`
 


### PR DESCRIPTION
This PR will hopefully add an option, JacksonOption.RESPECT_JSONPROPERTY_REQUIRED, to populate "required" json schema property according to @JsonProperty(required...) value