### PR TITLE
feat: support jackson typeinfo annotation on interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-module-jackson`
+#### Changed
+- subtype resolution now also respects `@JsonTypeInfo` annotation on common interface (and not just common super class)
 
 ## [4.18.0] - 2021-03-21
 ### `jsonschema-generator`

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
@@ -34,6 +34,7 @@ import com.github.victools.jsonschema.generator.SubtypeResolver;
 import com.github.victools.jsonschema.generator.TypeContext;
 import com.github.victools.jsonschema.generator.impl.AttributeCollector;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -109,6 +110,15 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
         JsonTypeInfo typeInfoAnnotation;
         do {
             typeInfoAnnotation = targetSuperType.getAnnotation(JsonTypeInfo.class);
+            if (typeInfoAnnotation == null) {
+                // the @JsonTypeInfo annotation may also be present on a common interface rather than a super class
+                // assumption: there are never multiple interfaces with such an annotation on a single class
+                typeInfoAnnotation = Stream.of(targetSuperType.getInterfaces())
+                        .map(superInterface -> superInterface.getAnnotation(JsonTypeInfo.class))
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .orElse(null);
+            }
             targetSuperType = targetSuperType.getSuperclass();
         } while (typeInfoAnnotation == null && targetSuperType != null);
 

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolverCustomDefinitionsTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolverCustomDefinitionsTest.java
@@ -89,29 +89,36 @@ public class JsonSubTypesResolverCustomDefinitionsTest extends AbstractTypeAware
 
     public Object[] parametersForTestProvideCustomPropertySchemaDefinitionForField() {
         return new Object[][]{
-            {"supertypeNoAnnotation", null, null},
-            {"supertypeNoAnnotation", TestSubClass1.class, null},
-            {"supertypeNoAnnotation", TestSubClass2.class, null},
-            {"supertypeWithAnnotationOnField", null, null},
-            {"supertypeWithAnnotationOnField", TestSubClass1.class,
+            {"superTypeNoAnnotation", null, null},
+            {"superTypeNoAnnotation", TestSubClass1.class, null},
+            {"superTypeNoAnnotation", TestSubClass2.class, null},
+            {"superTypeWithAnnotationOnField", null, null},
+            {"superTypeWithAnnotationOnField", TestSubClass1.class,
                 "{\"allOf\":[{},{\"title\":\"property attribute\",\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
                 + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass1\"}}}]}"},
-            {"supertypeWithAnnotationOnField", TestSubClass2.class,
+            {"superTypeWithAnnotationOnField", TestSubClass2.class,
                 "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
                 + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass2\"}}}]}"},
-            {"supertypeWithAnnotationOnGetter", null, null},
-            {"supertypeWithAnnotationOnGetter", TestSubClass1.class,
+            {"superTypeWithAnnotationOnGetter", null, null},
+            {"superTypeWithAnnotationOnGetter", TestSubClass1.class,
                 "{\"allOf\":[{},{\"title\":\"property attribute\",\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_1\"}}}]}"},
-            {"supertypeWithAnnotationOnGetter", TestSubClass2.class,
+            {"superTypeWithAnnotationOnGetter", TestSubClass2.class,
                 "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_2\"}}}]}"},
-            {"supertypeWithAnnotationOnFieldAndGetter", null, null},
-            {"supertypeWithAnnotationOnFieldAndGetter", TestSubClass1.class,
+            {"superTypeWithAnnotationOnFieldAndGetter", null, null},
+            {"superTypeWithAnnotationOnFieldAndGetter", TestSubClass1.class,
                 "{\"type\":\"array\",\"items\":[{\"type\":\"string\",\"const\":"
                 + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass1\"},"
                 + "{\"allOf\":[{},{\"title\":\"property attribute\"}]}]}"},
-            {"supertypeWithAnnotationOnFieldAndGetter", TestSubClass2.class,
+            {"superTypeWithAnnotationOnFieldAndGetter", TestSubClass2.class,
                 "{\"type\":\"array\",\"items\":[{\"type\":\"string\",\"const\":"
-                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass2\"},{}]}"}
+                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass2\"},{}]}"},
+            {"superInterfaceWithAnnotationOnField", null, null},
+            {"superInterfaceWithAnnotationOnField", TestSubClass3.class,
+                "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
+                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass3\"}}}]}"},
+            {"superInterfaceWithAnnotationOnField", TestSubClass4.class,
+                "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
+                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass4\"}}}]}"}
         };
     }
 
@@ -129,25 +136,25 @@ public class JsonSubTypesResolverCustomDefinitionsTest extends AbstractTypeAware
 
     public Object[] parametersForTestProvideCustomPropertySchemaDefinitionForMethod() {
         return new Object[][]{
-            {"getSupertypeNoAnnotation", null, null},
-            {"getSupertypeNoAnnotation", TestSubClass1.class, null},
-            {"getSupertypeNoAnnotation", TestSubClass2.class, null},
-            {"getSupertypeWithAnnotationOnField", null, null},
-            {"getSupertypeWithAnnotationOnField", TestSubClass1.class,
+            {"getSuperTypeNoAnnotation", null, null},
+            {"getSuperTypeNoAnnotation", TestSubClass1.class, null},
+            {"getSuperTypeNoAnnotation", TestSubClass2.class, null},
+            {"getSuperTypeWithAnnotationOnField", null, null},
+            {"getSuperTypeWithAnnotationOnField", TestSubClass1.class,
                 "{\"allOf\":[{},{\"title\":\"property attribute\",\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
                 + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass1\"}}}]}"},
-            {"getSupertypeWithAnnotationOnField", TestSubClass2.class,
+            {"getSuperTypeWithAnnotationOnField", TestSubClass2.class,
                 "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
                 + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass2\"}}}]}"},
-            {"getSupertypeWithAnnotationOnGetter", null, null},
-            {"getSupertypeWithAnnotationOnGetter", TestSubClass1.class,
+            {"getSuperTypeWithAnnotationOnGetter", null, null},
+            {"getSuperTypeWithAnnotationOnGetter", TestSubClass1.class,
                 "{\"allOf\":[{},{\"title\":\"property attribute\",\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_1\"}}}]}"},
-            {"getSupertypeWithAnnotationOnGetter", TestSubClass2.class,
+            {"getSuperTypeWithAnnotationOnGetter", TestSubClass2.class,
                 "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_2\"}}}]}"},
-            {"getSupertypeWithAnnotationOnFieldAndGetter", null, null},
-            {"getSupertypeWithAnnotationOnFieldAndGetter", TestSubClass1.class,
+            {"getSuperTypeWithAnnotationOnFieldAndGetter", null, null},
+            {"getSuperTypeWithAnnotationOnFieldAndGetter", TestSubClass1.class,
                 "{\"type\":\"object\",\"properties\":{\"SUB_CLASS_1\":{\"allOf\":[{},{\"title\":\"property attribute\"}]}}}"},
-            {"getSupertypeWithAnnotationOnFieldAndGetter", TestSubClass2.class,
+            {"getSuperTypeWithAnnotationOnFieldAndGetter", TestSubClass2.class,
                 "{\"type\":\"object\",\"properties\":{\"SUB_CLASS_2\":{}}}"}
         };
     }
@@ -166,29 +173,31 @@ public class JsonSubTypesResolverCustomDefinitionsTest extends AbstractTypeAware
 
     private static class TestClassWithSuperTypeReferences {
 
-        public TestSuperClassWithNameProperty supertypeNoAnnotation;
+        public TestSuperClassWithNameProperty superTypeNoAnnotation;
         @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "fullClass", include = JsonTypeInfo.As.EXISTING_PROPERTY)
-        public TestSuperClassWithNameProperty supertypeWithAnnotationOnField;
-        public TestSuperClassWithNameProperty supertypeWithAnnotationOnGetter;
+        public TestSuperClassWithNameProperty superTypeWithAnnotationOnField;
+        public TestSuperClassWithNameProperty superTypeWithAnnotationOnGetter;
         @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_ARRAY)
-        public TestSuperClassWithNameProperty supertypeWithAnnotationOnFieldAndGetter;
+        public TestSuperClassWithNameProperty superTypeWithAnnotationOnFieldAndGetter;
+        @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "fullClass", include = JsonTypeInfo.As.PROPERTY)
+        public TestSuperInterface superInterfaceWithAnnotationOnField;
 
-        public TestSuperClassWithNameProperty getSupertypeNoAnnotation() {
-            return this.supertypeNoAnnotation;
+        public TestSuperClassWithNameProperty getSuperTypeNoAnnotation() {
+            return this.superTypeNoAnnotation;
         }
 
-        public TestSuperClassWithNameProperty getSupertypeWithAnnotationOnField() {
-            return this.supertypeWithAnnotationOnField;
+        public TestSuperClassWithNameProperty getSuperTypeWithAnnotationOnField() {
+            return this.superTypeWithAnnotationOnField;
         }
 
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
-        public TestSuperClassWithNameProperty getSupertypeWithAnnotationOnGetter() {
-            return this.supertypeWithAnnotationOnGetter;
+        public TestSuperClassWithNameProperty getSuperTypeWithAnnotationOnGetter() {
+            return this.superTypeWithAnnotationOnGetter;
         }
 
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
-        public TestSuperClassWithNameProperty getSupertypeWithAnnotationOnFieldAndGetter() {
-            return this.supertypeWithAnnotationOnFieldAndGetter;
+        public TestSuperClassWithNameProperty getSuperTypeWithAnnotationOnFieldAndGetter() {
+            return this.superTypeWithAnnotationOnFieldAndGetter;
         }
     }
 
@@ -208,5 +217,21 @@ public class JsonSubTypesResolverCustomDefinitionsTest extends AbstractTypeAware
 
     @JsonTypeName("SUB_CLASS_2")
     private static class TestSubClass2 extends TestSuperClassWithNameProperty {
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+    @JsonSubTypes({
+        @JsonSubTypes.Type(TestSubClass3.class),
+        @JsonSubTypes.Type(TestSubClass4.class)
+    })
+    private interface TestSuperInterface {
+    }
+
+    @JsonTypeName("SUB_CLASS_3")
+    private static class TestSubClass3 implements TestSuperInterface {
+    }
+
+    @JsonTypeName("SUB_CLASS_4")
+    private static class TestSubClass4 implements TestSuperInterface {
     }
 }

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolverLookUpTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolverLookUpTest.java
@@ -57,7 +57,8 @@ public class JsonSubTypesResolverLookUpTest extends AbstractTypeAwareTest {
     public Object[] parametersForTestFindSubtypes() {
         return new Object[][]{
             {JsonSubTypesResolverLookUpTest.class, null},
-            {TestSuperClassWithNameProperty.class, Arrays.asList(TestSubClass1.class, TestSubClass2.class, TestSubClass3.class)}
+            {TestSuperClassWithNameProperty.class, Arrays.asList(TestSubClass1.class, TestSubClass2.class, TestSubClass3.class)},
+            {TestInterfaceWithTypeInfo.class, Arrays.asList(TestSubClass4.class, TestSubClass5.class)}
         };
     }
 
@@ -150,6 +151,14 @@ public class JsonSubTypesResolverLookUpTest extends AbstractTypeAwareTest {
         }
     }
 
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", include = JsonTypeInfo.As.PROPERTY)
+    @JsonSubTypes({
+        @JsonSubTypes.Type(TestSubClass4.class),
+        @JsonSubTypes.Type(TestSubClass5.class)
+    })
+    private interface TestInterfaceWithTypeInfo {
+    }
+
     @JsonTypeName("SUB_CLASS_1")
     private static class TestSubClass1 extends TestSuperClassWithNameProperty {
     }
@@ -160,5 +169,13 @@ public class JsonSubTypesResolverLookUpTest extends AbstractTypeAwareTest {
 
     @JsonTypeName("SUB_CLASS_3")
     private static class TestSubClass3 extends TestSuperClassWithNameProperty {
+    }
+
+    @JsonTypeName("SUB_CLASS_4")
+    private static class TestSubClass4 implements TestInterfaceWithTypeInfo {
+    }
+
+    @JsonTypeName("SUB_CLASS_5")
+    private static class TestSubClass5 implements TestInterfaceWithTypeInfo {
     }
 }

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-interface-integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-interface-integration-test-result.json
@@ -1,0 +1,145 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$defs": {
+        "TestSubClass2-1": {
+            "type": "object",
+            "properties": {
+                "superClassViaExistingProperty": {
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "$ref": "#/$defs/TestSubClassWithTypeNameAnnotation-1",
+                            "type": "object",
+                            "properties": {
+                                "typeString": {
+                                    "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionFromInterfaceIntegrationTest$TestSubClassWithTypeNameAnnotation"
+                                }
+                            }
+                        }, {
+                            "$ref": "#/$defs/TestSubClass3-1",
+                            "type": "object",
+                            "properties": {
+                                "typeString": {
+                                    "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass3"
+                                }
+                            }
+                        }]
+                },
+                "typeString": {
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "TestSubClass2-2": {
+            "type": "object",
+            "properties": {
+                "SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass2": {
+                    "$ref": "#/$defs/TestSubClass2-1"
+                }
+            }
+        },
+        "TestSubClass3-1": {
+            "type": "object",
+            "properties": {
+                "recursiveSubClass3": {
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "$ref": "#/$defs/TestSubClass3-1",
+                            "type": "object",
+                            "properties": {
+                                "@type": {
+                                    "const": "SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass3"
+                                }
+                            }
+                        }]
+                },
+                "typeString": {
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "TestSubClass3-2": {
+            "type": "object",
+            "properties": {
+                "SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass3": {
+                    "$ref": "#/$defs/TestSubClass3-1"
+                }
+            }
+        },
+        "TestSubClassWithTypeNameAnnotation-1": {
+            "type": "object",
+            "properties": {
+                "directSubClass2": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "#/$defs/TestSubClass2-2"
+                    }
+                },
+                "typeString": {
+                    "type": ["string", "null"]
+                }
+            }
+        },
+        "TestSubClassWithTypeNameAnnotation-2": {
+            "type": "object",
+            "properties": {
+                "AnnotatedSubTypeName": {
+                    "$ref": "#/$defs/TestSubClassWithTypeNameAnnotation-1"
+                }
+            }
+        }
+    },
+    "type": "object",
+    "properties": {
+        "supertypeAsWrapperArray": {
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "type": "array",
+                    "items": [{
+                            "type": "string",
+                            "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionFromInterfaceIntegrationTest$TestSubClassWithTypeNameAnnotation"
+                        }, {
+                            "$ref": "#/$defs/TestSubClassWithTypeNameAnnotation-1"
+                        }]
+                }, {
+                    "type": "array",
+                    "items": [{
+                            "type": "string",
+                            "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass2"
+                        }, {
+                            "$ref": "#/$defs/TestSubClass2-1"
+                        }]
+                }, {
+                    "type": "array",
+                    "items": [{
+                            "type": "string",
+                            "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass3"
+                        }, {
+                            "$ref": "#/$defs/TestSubClass3-1"
+                        }]
+                }]
+        },
+        "supertypeWithJsonSubTypesAnnotation": {
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "$ref": "#/$defs/TestSubClassWithTypeNameAnnotation-2"
+                }, {
+                    "$ref": "#/$defs/TestSubClass2-2"
+                }]
+        },
+        "supertypeWithoutAnnotation": {
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "$ref": "#/$defs/TestSubClassWithTypeNameAnnotation-2"
+                }, {
+                    "$ref": "#/$defs/TestSubClass2-2"
+                }, {
+                    "$ref": "#/$defs/TestSubClass3-2"
+                }]
+        }
+    }
+}


### PR DESCRIPTION
> subtype resolution now also respects `@JsonTypeInfo` annotation on the common interface (and not just common superclass)

This addresses raised issue https://github.com/victools/jsonschema-generator/issues/185.

The assumption here is, that such a `@JsonTypeInfo` annotation is only present on either a superclass or up to one implemented interface, therefore not requiring any sophisticated logic for determining which one to take. Similarly, there is no need to toggle this extended behavior through some explicit `Option`.