### PR TITLE
Update SchemaBuilderTest.java

### DIFF
--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
@@ -50,7 +50,7 @@ public class SchemaBuilder {
      * @param typeParameters optional type parameters (in case of the {@code mainTargetType} being a parameterised type)
      * @return generated JSON Schema
      */
-    static ObjectNode createSingleTypeSchema(SchemaGeneratorConfig config, TypeContext typeContext,
+    public static ObjectNode createSingleTypeSchema(SchemaGeneratorConfig config, TypeContext typeContext,
             Type mainTargetType, Type... typeParameters) {
         SchemaBuilder instance = new SchemaBuilder(config, typeContext);
         return instance.createSchemaForSingleType(mainTargetType, typeParameters);
@@ -65,7 +65,7 @@ public class SchemaBuilder {
      * @see #createSchemaReference(Type, Type...) : adding a single type to the builder instance
      * @see #collectDefinitions(String) : generate an {@link ObjectNode} listing the common schema definitions
      */
-    static SchemaBuilder forMultipleTypes(SchemaGeneratorConfig config, TypeContext typeContext) {
+    public static SchemaBuilder forMultipleTypes(SchemaGeneratorConfig config, TypeContext typeContext) {
         return new SchemaBuilder(config, typeContext);
     }
 

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
@@ -50,7 +50,7 @@ public class SchemaBuilder {
      * @param typeParameters optional type parameters (in case of the {@code mainTargetType} being a parameterised type)
      * @return generated JSON Schema
      */
-    public static ObjectNode createSingleTypeSchema(SchemaGeneratorConfig config, TypeContext typeContext,
+    static ObjectNode createSingleTypeSchema(SchemaGeneratorConfig config, TypeContext typeContext,
             Type mainTargetType, Type... typeParameters) {
         SchemaBuilder instance = new SchemaBuilder(config, typeContext);
         return instance.createSchemaForSingleType(mainTargetType, typeParameters);
@@ -65,7 +65,7 @@ public class SchemaBuilder {
      * @see #createSchemaReference(Type, Type...) : adding a single type to the builder instance
      * @see #collectDefinitions(String) : generate an {@link ObjectNode} listing the common schema definitions
      */
-    public static SchemaBuilder forMultipleTypes(SchemaGeneratorConfig config, TypeContext typeContext) {
+    static SchemaBuilder forMultipleTypes(SchemaGeneratorConfig config, TypeContext typeContext) {
         return new SchemaBuilder(config, typeContext);
     }
 

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaBuilderTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaBuilderTest.java
@@ -36,12 +36,12 @@ public class SchemaBuilderTest {
         this.config = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
                 .with(Option.PLAIN_DEFINITION_KEYS)
                 .build();
-        this.typeContext = TypeContextFactory.createDefaultTypeContext();
     }
 
     @Test
     public void testMultiTypeSchemaGeneration() throws Exception {
-        SchemaBuilder instance = SchemaBuilder.forMultipleTypes(this.config, this.typeContext);
+        SchemaGenerator generator = new SchemaGenerator(this.config);
+        SchemaBuilder instance = generator.buildMultipleSchemaDefinitions();
 
         ObjectNode result = this.config.createObjectNode();
         result.put("openapi", "3.0.0");


### PR DESCRIPTION
Small fix to make `createSingleTypeSchema` and `forMultipleTypes` public (and accessible outside of com.github.victools.jsonschema.generator).  Current test examples work because they are within the same package namespace; but currently other users of jsonschema.generator cannot access these methods.  Awesome tool!