### PR TITLE
Jackson module features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### `jsonschema-module-jackson`
 #### Added
-- Consider `@JsonProperty.name` override for methods
-- Look-up `"description"` for methods (if included) based on `@JsonProperty.description`
+- Consider `@JsonProperty.value` override for methods
+- Look-up `"description"` for methods (if included) based on `@JsonPropertyDescription`
 - Consider `@JsonProperty(access = Access.READ_ONLY)` when determining whether a field/method should be marked as `readOnly`
 - Consider `@JsonProperty(access = Access.WRITE_ONLY)` when determining whether a field/method should be marked as `writeOnly`
 - Introduce `JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS` to enable easy inclusion of annotated non-getter methods (typically in combination with the general `Option.FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS` and `Option.NONSTATIC_NONVOID_NONGETTER_METHODS`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-module-jackson`
+#### Added
+- Consider `@JsonProperty.name` override for methods
+- Look-up `"description"` for methods (if included) based on `@JsonProperty.description`
 
 ## [4.20.0] - 2021-09-04
 ### `jsonschema-generator`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Look-up `"description"` for methods (if included) based on `@JsonProperty.description`
 - Consider `@JsonProperty(access = Access.READ_ONLY)` when determining whether a field/method should be marked as `readOnly`
 - Consider `@JsonProperty(access = Access.WRITE_ONLY)` when determining whether a field/method should be marked as `writeOnly`
+- Introduce `JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS` to enable easy inclusion of annotated non-getter methods (typically in combination with the general `Option.FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS` and `Option.NONSTATIC_NONVOID_NONGETTER_METHODS`)
+
+#### Changed
+- Ignore getter methods when their associated field is being ignored (according to various Jackson annotations)
+- Ignore methods when they or their associated field are marked as `@JsonBackReference`
 
 ## [4.20.0] - 2021-09-04
 ### `jsonschema-generator`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - Consider `@JsonProperty.name` override for methods
 - Look-up `"description"` for methods (if included) based on `@JsonProperty.description`
+- Consider `@JsonProperty(access = Access.READ_ONLY)` when determining whether a field/method should be marked as `readOnly`
+- Consider `@JsonProperty(access = Access.WRITE_ONLY)` when determining whether a field/method should be marked as `writeOnly`
 
 ## [4.20.0] - 2021-09-04
 ### `jsonschema-generator`

--- a/jsonschema-module-jackson/README.md
+++ b/jsonschema-module-jackson/README.md
@@ -4,12 +4,12 @@
 Module for the [jsonschema-generator](../jsonschema-generator) – deriving JSON Schema attributes from `jackson` annotations.
 
 ## Features
-1. Populate a field/method's "description" as per `@JsonPropertyDescription`
-2. Populate a type's "description" as per `@JsonClassDescription`.
-3. Apply alternative field names defined in `@JsonProperty` annotations or as per `@JsonNaming` annotations.
-4. Ignore fields that are marked with a `@JsonBackReference` annotation.
-5. Ignore fields that are deemed to be ignored according to various other `jackson-annotations` (e.g. `@JsonIgnore`, `@JsonIgnoreType`, `@JsonIgnoreProperties`) or are otherwise supposed to be excluded.
-6. Optionally: set a field as "required" as per `@JsonProperty` annotations, if the `JacksonOption.RESPECT_JSONPROPERTY_REQUIRED` was provided (i.e. this is an "opt-in").
+1. Set a field/method's "description" as per `@JsonPropertyDescription`
+2. Set a type's "description" as per `@JsonClassDescription`.
+3. Override a field's/method's property name as per `@JsonProperty` annotations.
+4. Ignore fields/methods that are marked with a `@JsonBackReference` annotation.
+5. Ignore fields (and their associated getter methods) that are deemed to be ignored according to various other `jackson-annotations` (e.g. `@JsonIgnore`, `@JsonIgnoreType`, `@JsonIgnoreProperties`) or are otherwise supposed to be excluded.
+6. Optionally: set a field/method as "required" as per `@JsonProperty` annotations, if the `JacksonOption.RESPECT_JSONPROPERTY_REQUIRED` was provided (i.e. this is an "opt-in").
 7. Optionally: treat enum types as plain strings as per the `@JsonValue` annotated method, if there is one and the `JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE` was provided (i.e. this is an "opt-in").
 8. Optionally: treat enum types as plain strings, as per each enum constant's `@JsonProperty` annotation, if all values of an enum have such annotations and the `JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY` was provided (i.e. this is an "opt-in").
 9. Optionally: sort an object's properties according to its `@JsonPropertyOrder` annotation, if the `JacksonOption.RESPECT_JSONPROPERTY_ORDER` was provided (i.e. this is an "opt-in").
@@ -17,6 +17,8 @@ Module for the [jsonschema-generator](../jsonschema-generator) – deriving JSON
 11. Apply structural changes for subtypes according to `@JsonTypeInfo` on a supertype in general or directly on specific fields/methods as an override of the per-type behavior unless `JacksonOption.IGNORE_TYPE_INFO_TRANSFORM` was provided (i.e. this is an "opt-out").
     * Considering `@JsonTypeInfo.include` with values `As.PROPERTY`, `As.EXISTING_PROPERTY`, `As.WRAPPER_ARRAY`, `As.WRAPPER_OBJECT`
     * Considering `@JsonTypeInfo.use` with values `Id.CLASS`, `Id.NAME`
+12. Consider `@JsonProperty.access` for marking a field/method as `readOnly` or `writeOnly`
+13. Optionally: ignore all methods but those with a `@JsonProperty` annotation, if the `JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS` was provided (i.e. this is an "opt-in").
 
 Schema attributes derived from validation annotations on getter methods are also applied to their associated fields.
 

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -80,7 +80,6 @@ public class JacksonModule implements Module {
         this.objectMapper = builder.getObjectMapper();
         SchemaGeneratorConfigPart<FieldScope> fieldConfigPart = builder.forFields();
         SchemaGeneratorConfigPart<MethodScope> methodConfigPart = builder.forMethods();
-        SchemaGeneratorGeneralConfigPart generalConfigPart = builder.forTypesInGeneral();
 
         this.applyToConfigBuilderPart(fieldConfigPart);
         this.applyToConfigBuilderPart(methodConfigPart);
@@ -92,6 +91,7 @@ public class JacksonModule implements Module {
             fieldConfigPart.withPropertyNameOverrideResolver(this::getPropertyNameOverrideBasedOnJsonNamingAnnotation);
         }
 
+        SchemaGeneratorGeneralConfigPart generalConfigPart = builder.forTypesInGeneral();
         generalConfigPart.withDescriptionResolver(this::resolveDescriptionForType);
 
         boolean considerEnumJsonValue = this.options.contains(JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE);
@@ -286,8 +286,8 @@ public class JacksonModule implements Module {
         if (getterField == null && method.getAnnotationConsideringFieldAndGetterIfSupported(JsonBackReference.class) != null) {
             return true;
         }
-        return !this.options.contains(JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS)
-                || method.getAnnotationConsideringFieldAndGetter(JsonProperty.class) != null;
+        return this.options.contains(JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS)
+                && method.getAnnotationConsideringFieldAndGetter(JsonProperty.class) == null;
     }
 
     /**

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.github.victools.jsonschema.generator.FieldScope;
+import com.github.victools.jsonschema.generator.MemberScope;
 import com.github.victools.jsonschema.generator.MethodScope;
 import com.github.victools.jsonschema.generator.Module;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
@@ -78,15 +79,19 @@ public class JacksonModule implements Module {
     public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
         this.objectMapper = builder.getObjectMapper();
         SchemaGeneratorConfigPart<FieldScope> fieldConfigPart = builder.forFields();
-        fieldConfigPart.withDescriptionResolver(this::resolveDescription)
-                .withPropertyNameOverrideResolver(this::getPropertyNameOverrideBasedOnJsonPropertyAnnotation)
-                .withIgnoreCheck(this::shouldIgnoreField);
+        SchemaGeneratorConfigPart<MethodScope> methodConfigPart = builder.forMethods();
         SchemaGeneratorGeneralConfigPart generalConfigPart = builder.forTypesInGeneral();
-        generalConfigPart.withDescriptionResolver(this::resolveDescriptionForType);
 
+        this.applyToConfigBuilderPart(fieldConfigPart);
+        this.applyToConfigBuilderPart(methodConfigPart);
+
+        fieldConfigPart.withIgnoreCheck(this::shouldIgnoreField);
         if (!this.options.contains(JacksonOption.IGNORE_PROPERTY_NAMING_STRATEGY)) {
+            // only consider @JsonNaming as fall-back
             fieldConfigPart.withPropertyNameOverrideResolver(this::getPropertyNameOverrideBasedOnJsonNamingAnnotation);
         }
+
+        generalConfigPart.withDescriptionResolver(this::resolveDescriptionForType);
 
         boolean considerEnumJsonValue = this.options.contains(JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE);
         boolean considerEnumJsonProperty = this.options.contains(JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY);
@@ -98,15 +103,10 @@ public class JacksonModule implements Module {
             generalConfigPart.withPropertySorter(new JsonPropertySorter(true));
         }
 
-        if (this.options.contains(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED)) {
-            fieldConfigPart.withRequiredCheck(this::getRequiredCheckBasedOnJsonPropertyAnnotation);
-        }
-
         boolean lookUpSubtypes = !this.options.contains(JacksonOption.SKIP_SUBTYPE_LOOKUP);
         boolean includeTypeInfoTransform = !this.options.contains(JacksonOption.IGNORE_TYPE_INFO_TRANSFORM);
         if (lookUpSubtypes || includeTypeInfoTransform) {
             JsonSubTypesResolver subtypeResolver = new JsonSubTypesResolver();
-            SchemaGeneratorConfigPart<MethodScope> methodConfigPart = builder.forMethods();
             if (lookUpSubtypes) {
                 generalConfigPart.withSubtypeResolver(subtypeResolver);
                 fieldConfigPart.withTargetTypeOverridesResolver(subtypeResolver::findTargetTypeOverrides);
@@ -121,18 +121,32 @@ public class JacksonModule implements Module {
     }
 
     /**
-     * Determine the given type's associated "description" in the following order of priority.
+     * Apply common member configurations.
+     *
+     * @param configPart config builder part for either fields or methods
+     */
+    private void applyToConfigBuilderPart(SchemaGeneratorConfigPart<?> configPart) {
+        configPart.withDescriptionResolver(this::resolveDescription);
+        configPart.withPropertyNameOverrideResolver(this::getPropertyNameOverrideBasedOnJsonPropertyAnnotation);
+
+        if (this.options.contains(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED)) {
+            configPart.withRequiredCheck(this::getRequiredCheckBasedOnJsonPropertyAnnotation);
+        }
+    }
+
+    /**
+     * Determine the given member's associated "description" in the following order of priority.
      * <ol>
-     * <li>{@link JsonPropertyDescription} annotation on the field itself</li>
-     * <li>{@link JsonPropertyDescription} annotation on the field's getter method</li>
+     * <li>{@link JsonPropertyDescription} annotation on the field/method itself</li>
+     * <li>{@link JsonPropertyDescription} annotation on the field's getter method or the getter method's associated field</li>
      * </ol>
      *
-     * @param field field for which to collect an available description
+     * @param member field/method for which to collect an available description
      * @return successfully looked-up description (or {@code null})
      */
-    protected String resolveDescription(FieldScope field) {
+    protected String resolveDescription(MemberScope<?, ?> member) {
         // look for property specific description
-        JsonPropertyDescription propertyAnnotation = field.getAnnotationConsideringFieldAndGetterIfSupported(JsonPropertyDescription.class);
+        JsonPropertyDescription propertyAnnotation = member.getAnnotationConsideringFieldAndGetterIfSupported(JsonPropertyDescription.class);
         if (propertyAnnotation != null) {
             return propertyAnnotation.value();
         }
@@ -160,19 +174,19 @@ public class JacksonModule implements Module {
     /**
      * Look-up an alternative name as per the following order of priority.
      * <ol>
-     * <li>{@link JsonProperty} annotation on the field itself</li>
-     * <li>{@link JsonProperty} annotation on the field's getter method</li>
+     * <li>{@link JsonProperty} annotation on the member itself</li>
+     * <li>{@link JsonProperty} annotation on the field's getter method or the getter method's associated field</li>
      * </ol>
      *
-     * @param field field to look-up alternative property name for
+     * @param member field/method to look-up alternative property name for
      * @return alternative property name (or {@code null})
      */
-    protected String getPropertyNameOverrideBasedOnJsonPropertyAnnotation(FieldScope field) {
-        JsonProperty annotation = field.getAnnotationConsideringFieldAndGetter(JsonProperty.class);
+    protected String getPropertyNameOverrideBasedOnJsonPropertyAnnotation(MemberScope<?, ?> member) {
+        JsonProperty annotation = member.getAnnotationConsideringFieldAndGetter(JsonProperty.class);
         if (annotation != null) {
             String nameOverride = annotation.value();
             // check for invalid overrides
-            if (nameOverride != null && !nameOverride.isEmpty() && !nameOverride.equals(field.getDeclaredName())) {
+            if (nameOverride != null && !nameOverride.isEmpty() && !nameOverride.equals(member.getDeclaredName())) {
                 return nameOverride;
             }
         }
@@ -236,7 +250,7 @@ public class JacksonModule implements Module {
      * @return whether field should be excluded
      */
     protected boolean shouldIgnoreField(FieldScope field) {
-        if (field.getAnnotationConsideringFieldAndGetter(JsonBackReference.class) != null) {
+        if (field.getAnnotationConsideringFieldAndGetterIfSupported(JsonBackReference.class) != null) {
             return true;
         }
         // instead of re-creating the various ways a property may be included/excluded in jackson: just use its built-in introspection
@@ -254,13 +268,13 @@ public class JacksonModule implements Module {
     }
 
     /**
-     * Look-up the given field's {@link JsonProperty} annotation and consider its "required" attribute.
+     * Look-up the given field's/method's {@link JsonProperty} annotation and consider its "required" attribute.
      *
-     * @param field field to look-up required strategy for
+     * @param member field/method to look-up required strategy for
      * @return whether the field should be in the "required" list or not
      */
-    private boolean getRequiredCheckBasedOnJsonPropertyAnnotation(FieldScope field) {
-        JsonProperty jsonProperty = field.getAnnotationConsideringFieldAndGetter(JsonProperty.class) ;
+    protected boolean getRequiredCheckBasedOnJsonPropertyAnnotation(MemberScope<?, ?> member) {
+        JsonProperty jsonProperty = member.getAnnotationConsideringFieldAndGetterIfSupported(JsonProperty.class) ;
         return jsonProperty != null && jsonProperty.required();
     }
 

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -128,6 +128,8 @@ public class JacksonModule implements Module {
     private void applyToConfigBuilderPart(SchemaGeneratorConfigPart<?> configPart) {
         configPart.withDescriptionResolver(this::resolveDescription);
         configPart.withPropertyNameOverrideResolver(this::getPropertyNameOverrideBasedOnJsonPropertyAnnotation);
+        configPart.withReadOnlyCheck(this::getReadOnlyCheck);
+        configPart.withWriteOnlyCheck(this::getWriteOnlyCheck);
 
         if (this.options.contains(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED)) {
             configPart.withRequiredCheck(this::getRequiredCheckBasedOnJsonPropertyAnnotation);
@@ -278,4 +280,25 @@ public class JacksonModule implements Module {
         return jsonProperty != null && jsonProperty.required();
     }
 
+    /**
+     * Determine whether the given field's/method's {@link JsonProperty} annotation marks it as read-only.
+     *
+     * @param member field/method to check read-only status for
+     * @return whether the field should be marked as read-only
+     */
+    protected boolean getReadOnlyCheck(MemberScope<?, ?> member) {
+        JsonProperty jsonProperty = member.getAnnotationConsideringFieldAndGetter(JsonProperty.class);
+        return jsonProperty != null && jsonProperty.access() == JsonProperty.Access.READ_ONLY;
+    }
+
+    /**
+     * Determine whether the given field's/method's {@link JsonProperty} annotation marks it as write-only.
+     *
+     * @param member field/method to check write-only status for
+     * @return whether the field should be marked as write-only
+     */
+    protected boolean getWriteOnlyCheck(MemberScope<?, ?> member) {
+        JsonProperty jsonProperty = member.getAnnotationConsideringFieldAndGetter(JsonProperty.class);
+        return jsonProperty != null && jsonProperty.access() == JsonProperty.Access.WRITE_ONLY;
+    }
 }

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
@@ -53,6 +53,15 @@ public enum JacksonOption {
      */
     RESPECT_JSONPROPERTY_ORDER,
     /**
+     * Use this option to ignore all methods that don't have a {@link com.fasterxml.jackson.annotation.JsonProperty JsonProperty} annotation
+     * themselves or in case of getter methods on their associated field. When including non-getter methods with annotated property names, you'll
+     * probably want to enable the general {@code Option.FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS} as well, in order to avoid parentheses at the end.
+     *
+     * @see com.github.victools.jsonschema.generator.Option#FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS
+     * @since 4.21.0
+     */
+    INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS,
+    /**
      * Use this option to skip property name changes according to {@link com.fasterxml.jackson.databind.annotation.JsonNaming JsonNaming} annotations.
      */
     IGNORE_PROPERTY_NAMING_STRATEGY,

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
@@ -48,9 +48,11 @@ public class IntegrationTest {
      */
     @Test
     public void testIntegration() throws Exception {
-        JacksonModule module = new JacksonModule(JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE, JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY);
+        JacksonModule module = new JacksonModule(JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE, JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY,
+                JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS);
         SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), SchemaVersion.DRAFT_7, OptionPreset.PLAIN_JSON)
                 .with(Option.NULLABLE_ARRAY_ITEMS_ALLOWED)
+                .with(Option.NONSTATIC_NONVOID_NONGETTER_METHODS, Option.FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS)
                 .with(module)
                 .build();
         SchemaGenerator generator = new SchemaGenerator(config);
@@ -81,7 +83,7 @@ public class IntegrationTest {
         @JsonPropertyDescription("field description")
         public String fieldWithDescription;
 
-        @JsonProperty("fieldWithOverriddenName")
+        @JsonProperty(value = "fieldWithOverriddenName", access = JsonProperty.Access.WRITE_ONLY)
         public boolean originalFieldName;
 
         public TestEnum enumValueHandledByStandardOption;
@@ -89,6 +91,16 @@ public class IntegrationTest {
         public TestEnumWithJsonValueAnnotation enumValueWithJsonValueAnnotation;
 
         public TestEnumWithJsonPropertyAnnotations enumValueWithJsonPropertyAnnotations;
+
+        public String ignoredUnannotatedMethod() {
+            return "nothing";
+        }
+
+        @JsonProperty(value = "calculated", access = JsonProperty.Access.READ_ONLY)
+        @JsonPropertyDescription("calculated value from non-getter method")
+        public double getCalculatedValue() {
+            return 19.75;
+        }
     }
 
     static enum TestEnum {

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
@@ -2,6 +2,11 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
+        "calculated": {
+            "type": "number",
+            "description": "calculated value from non-getter method",
+            "readOnly": true
+        },
         "enumValueHandledByStandardOption": {
             "type": "string",
             "enum": ["A", "B", "C"]
@@ -19,7 +24,8 @@
             "description": "field description"
         },
         "fieldWithOverriddenName": {
-            "type": "boolean"
+            "type": "boolean",
+            "writeOnly": true
         }
     },
     "description": "test description"

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
             <url>https://github.com/jochenberger</url>
             <roles>
                 <role>Provided PRs #116 and #118 (part of initial Swagger2Module)</role>
+                <role>Provided implementation for #204 (readOnly/writeOnly in JacksonModule)</role>
             </roles>
         </contributor>
         <contributor>

--- a/slate-docs/source/includes/_jackson-module.md
+++ b/slate-docs/source/includes/_jackson-module.md
@@ -17,10 +17,10 @@ SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(Sc
 
 1. Set a field/method's "description" as per `@JsonPropertyDescription`
 2. Set a type's "description" as per `@JsonClassDescription`.
-3. Override a field's property name as per `@JsonProperty` annotations.
-4. Ignore fields that are marked with a `@JsonBackReference` annotation.
-5. Ignore fields that are deemed to be ignored according to various other `jackson-annotations` (e.g. `@JsonIgnore`, `@JsonIgnoreType`, `@JsonIgnoreProperties`) or are otherwise supposed to be excluded.
-6. Optionally: set a field as "required" as per `@JsonProperty` annotations, if the `JacksonOption.RESPECT_JSONPROPERTY_REQUIRED` was provided (i.e. this is an "opt-in").
+3. Override a field's/method's property name as per `@JsonProperty` annotations.
+4. Ignore fields/methods that are marked with a `@JsonBackReference` annotation.
+5. Ignore fields (and their associated getter methods) that are deemed to be ignored according to various other `jackson-annotations` (e.g. `@JsonIgnore`, `@JsonIgnoreType`, `@JsonIgnoreProperties`) or are otherwise supposed to be excluded.
+6. Optionally: set a field/method as "required" as per `@JsonProperty` annotations, if the `JacksonOption.RESPECT_JSONPROPERTY_REQUIRED` was provided (i.e. this is an "opt-in").
 7. Optionally: treat enum types as plain strings as per the `@JsonValue` annotated method, if there is one and the `JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE` was provided (i.e. this is an "opt-in").
 8. Optionally: treat enum types as plain strings, as per each enum constant's `@JsonProperty` annotation, if all values of an enum have such annotations and the `JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY` was provided (i.e. this is an "opt-in").
 9. Optionally: sort an object's properties according to its `@JsonPropertyOrder` annotation, if the `JacksonOption.RESPECT_JSONPROPERTY_ORDER` was provided (i.e. this is an "opt-in").
@@ -28,6 +28,8 @@ SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(Sc
 11. Apply structural changes for subtypes according to `@JsonTypeInfo` on a supertype in general or directly on specific fields/methods as an override of the per-type behavior unless `JacksonOption.IGNORE_TYPE_INFO_TRANSFORM` was provided (i.e. this is an "opt-out").
     * Considering `@JsonTypeInfo.include` with values `As.PROPERTY`, `As.EXISTING_PROPERTY`, `As.WRAPPER_ARRAY`, `As.WRAPPER_OBJECT`
     * Considering `@JsonTypeInfo.use` with values `Id.CLASS`, `Id.NAME`
+12. Consider `@JsonProperty.access` for marking a field/method as `readOnly` or `writeOnly`
+13. Optionally: ignore all methods but those with a `@JsonProperty` annotation, if the `JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS` was provided (i.e. this is an "opt-in").
 
 Schema attributes derived from annotations on getter methods are also applied to their associated fields.
 


### PR DESCRIPTION
### `jsonschema-module-jackson`
#### Added
- Consider `@JsonProperty.value` override for methods
- Look-up `"description"` for methods (if included) based on `@JsonPropertyDescription`
- Consider `@JsonProperty(access = Access.READ_ONLY)` when determining whether a field/method should be marked as `readOnly`
- Consider `@JsonProperty(access = Access.WRITE_ONLY)` when determining whether a field/method should be marked as `writeOnly`
- Introduce `JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS` to enable easy inclusion of annotated non-getter methods (typically in combination with the general `Option.FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS` and `Option.NONSTATIC_NONVOID_NONGETTER_METHODS`)

#### Changed
- Ignore getter methods when their associated field is being ignored (according to various Jackson annotations)
- Ignore methods when they or their associated field are marked as `@JsonBackReference`

----

The default handling of methods via the `JacksonModule` is being changed here. Based on the assumption that the majority of existing use-cases involving the `JacksonModule` either ignore all (non-getter) methods implicitly or explicitly already, there is no need to introduce another `JacksonOption` for turning the new method-related logic off in general.
Such a `JacksonOption` could be easily added (as "opt-out") if someone asks for it.

----

Resolves #198
Resolves #204