### PR TITLE
Correctly handle nullable enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-generator`
+#### Changed
+- default `ObjectMapper` when none is given in `SchemaGeneratorConfigBuilder` constructor now enables `JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS`
+
 ### `jsonschema-module-jackson`
 #### Added
 - Consider `@JsonProperty.value` override for methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### `jsonschema-generator`
+#### Fixed
+- prevent mixing of `type: null` with `const`/`enum` in order to avoid validation error when `const`/`enum` does not include `null`
+
 #### Changed
 - default `ObjectMapper` when none is given in `SchemaGeneratorConfigBuilder` constructor now enables `JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS`
 

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
@@ -16,6 +16,7 @@
 
 package com.github.victools.jsonschema.generator;
 
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.victools.jsonschema.generator.impl.SchemaGeneratorConfigImpl;
 import java.util.EnumSet;
@@ -30,6 +31,19 @@ import java.util.stream.Collectors;
  * Builder class for creating a configuration object to be passed into the SchemaGenerator's constructor.
  */
 public class SchemaGeneratorConfigBuilder {
+
+    /**
+     * Instantiate an ObjectMapper to be used in case no specific instance is provided in constructor.
+     *
+     * @return default ObjectMapper instance
+     */
+    private static ObjectMapper createDefaultObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.getSerializationConfig()
+                // since version 4.21.0
+                .with(JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS);
+        return mapper;
+    }
 
     private final ObjectMapper objectMapper;
     private final OptionPreset preset;
@@ -73,7 +87,7 @@ public class SchemaGeneratorConfigBuilder {
      * @see #SchemaGeneratorConfigBuilder(ObjectMapper, SchemaVersion, OptionPreset)
      */
     public SchemaGeneratorConfigBuilder(SchemaVersion schemaVersion) {
-        this(new ObjectMapper(), schemaVersion, OptionPreset.FULL_DOCUMENTATION);
+        this(createDefaultObjectMapper(), schemaVersion, OptionPreset.FULL_DOCUMENTATION);
     }
 
     /**
@@ -96,7 +110,7 @@ public class SchemaGeneratorConfigBuilder {
      * @param preset default settings for standard {@link Option} values
      */
     public SchemaGeneratorConfigBuilder(SchemaVersion schemaVersion, OptionPreset preset) {
-        this(new ObjectMapper(), schemaVersion, preset);
+        this(createDefaultObjectMapper(), schemaVersion, preset);
     }
 
     /**

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImpl.java
@@ -747,16 +747,19 @@ public class SchemaGenerationContextImpl implements SchemaGenerationContext {
         if (node.has(this.getKeyword(SchemaKeyword.TAG_REF))
                 || node.has(this.getKeyword(SchemaKeyword.TAG_ALLOF))
                 || node.has(this.getKeyword(SchemaKeyword.TAG_ANYOF))
-                || node.has(this.getKeyword(SchemaKeyword.TAG_ONEOF))) {
-            // cannot be sure what is specified in those other schema parts, instead simply create a oneOf wrapper
+                || node.has(this.getKeyword(SchemaKeyword.TAG_ONEOF))
+                // since version 4.21.0
+                || node.has(this.getKeyword(SchemaKeyword.TAG_CONST))
+                || node.has(this.getKeyword(SchemaKeyword.TAG_ENUM))) {
+            // cannot be sure what is specified in those other schema parts, instead simply create an anyOf wrapper
             ObjectNode nullSchema = this.generatorConfig.createObjectNode()
                     .put(this.getKeyword(SchemaKeyword.TAG_TYPE), nullTypeName);
             ArrayNode anyOf = this.generatorConfig.createArrayNode()
-                    // one option in the oneOf should be null
+                    // one option in the anyOf should be null
                     .add(nullSchema)
                     // the other option is the given (assumed to be) not-nullable node
                     .add(this.generatorConfig.createObjectNode().setAll(node));
-            // replace all existing (and already copied properties with the oneOf wrapper
+            // replace all existing (and already copied properties with the anyOf wrapper
             node.removeAll();
             node.set(this.getKeyword(SchemaKeyword.TAG_ANYOF), anyOf);
         } else {

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilderTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilderTest.java
@@ -16,7 +16,6 @@
 
 package com.github.victools.jsonschema.generator;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,7 +29,7 @@ public class SchemaGeneratorConfigBuilderTest {
 
     @Before
     public void setUp() {
-        this.builder = new SchemaGeneratorConfigBuilder(new ObjectMapper(), SchemaVersion.DRAFT_2019_09);
+        this.builder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09);
     }
 
     @Test

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSimpleTypesTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSimpleTypesTest.java
@@ -17,7 +17,6 @@
 package com.github.victools.jsonschema.generator;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.EnumSet;
 import junitparams.JUnitParamsRunner;
@@ -88,7 +87,7 @@ public class SchemaGeneratorSimpleTypesTest {
     @Parameters
     public void testGenerateSchema_SimpleTypeWithoutFormat(Class<?> targetType, SchemaKeyword expectedJsonSchemaType, SchemaVersion schemaVersion)
             throws Exception {
-        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), schemaVersion)
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(schemaVersion)
                 .with(Option.ADDITIONAL_FIXED_TYPES)
                 .build();
         SchemaGenerator generator = new SchemaGenerator(config);
@@ -106,7 +105,7 @@ public class SchemaGeneratorSimpleTypesTest {
     @Parameters
     public void testGenerateSchema_SimpleTypeWithFormat(Class<?> targetType, SchemaKeyword expectedJsonSchemaType, String expectedFormat,
             SchemaVersion schemaVersion) throws Exception {
-        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), schemaVersion)
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(schemaVersion)
                 .with(Option.ADDITIONAL_FIXED_TYPES, Option.EXTRA_OPEN_API_FORMAT_VALUES)
                 .build();
         SchemaGenerator generator = new SchemaGenerator(config);
@@ -129,7 +128,7 @@ public class SchemaGeneratorSimpleTypesTest {
     @Parameters(method = "parametersForTestGenerateSchema_SimpleTypeWithoutFormat")
     public void testGenerateSchema_SimpleType_withAdditionalPropertiesOption(Class<?> targetType, SchemaKeyword expectedJsonSchemaType,
             SchemaVersion schemaVersion) throws Exception {
-        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), schemaVersion)
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(schemaVersion)
                 .with(Option.ADDITIONAL_FIXED_TYPES, Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT)
                 .build();
         SchemaGenerator generator = new SchemaGenerator(config);

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSubtypesTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSubtypesTest.java
@@ -18,7 +18,6 @@ package com.github.victools.jsonschema.generator;
 
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -54,7 +53,7 @@ public class SchemaGeneratorSubtypesTest {
     @Parameters
     @TestCaseName(value = "{method}({0}) [{index}]")
     public void testGenerateSchema(String caseTitle, List<Class<?>> subtypes, SchemaVersion schemaVersion) throws Exception {
-        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(new ObjectMapper(), schemaVersion, OptionPreset.PLAIN_JSON)
+        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(schemaVersion, OptionPreset.PLAIN_JSON)
                 .with(Option.DEFINITIONS_FOR_ALL_OBJECTS, Option.NULLABLE_FIELDS_BY_DEFAULT);
         configBuilder.forTypesInGeneral()
                 .withSubtypeResolver(new TestSubtypeResolver(subtypes))

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-FULL_DOCUMENTATION-typeattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-FULL_DOCUMENTATION-typeattributes.json
@@ -53,7 +53,7 @@
                     "enum": [1, 2, 3, 4, 5],
                     "minimum": 1,
                     "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
+                    "maximum": 10,
                     "exclusiveMaximum": 11,
                     "multipleOf": 1
                 }]
@@ -96,7 +96,7 @@
             "enum": [1, 2, 3, 4, 5],
             "minimum": 1,
             "exclusiveMinimum": 0,
-            "maximum": 1E+1,
+            "maximum": 10,
             "exclusiveMaximum": 11,
             "multipleOf": 1
         }

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-FULL_DOCUMENTATION-typeattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-FULL_DOCUMENTATION-typeattributes.json
@@ -2,15 +2,19 @@
     "type": "object",
     "properties": {
         "genericValue": {
-            "type": ["string", "null"],
-            "$anchor": "#anchor",
-            "title": "String",
-            "description": "for type in general: String",
-            "const": "constant string value",
-            "minLength": 1,
-            "maxLength": 256,
-            "format": "date",
-            "pattern": "^.{1,256}$"
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "type": "string",
+                    "$anchor": "#anchor",
+                    "title": "String",
+                    "description": "for type in general: String",
+                    "const": "constant string value",
+                    "minLength": 1,
+                    "maxLength": 256,
+                    "format": "date",
+                    "pattern": "^.{1,256}$"
+                }]
         },
         "genericArray": {
             "type": ["array", "null"],
@@ -38,17 +42,28 @@
             "description": "for type in general: int"
         },
         "ignoredInternalValue": {
-            "type": ["integer", "null"],
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "type": "integer",
+                    "$anchor": "#anchor",
+                    "title": "Integer",
+                    "description": "for type in general: Integer",
+                    "default": 1,
+                    "enum": [1, 2, 3, 4, 5],
+                    "minimum": 1,
+                    "exclusiveMinimum": 0,
+                    "maximum": 1E+1,
+                    "exclusiveMaximum": 11,
+                    "multipleOf": 1
+                }]
+        },
+        "calculateSomething(Number, Number)": false,
+        "getPrimitiveValue()": {
+            "type": "integer",
             "$anchor": "#anchor",
-            "title": "Integer",
-            "description": "for type in general: Integer",
-            "default": 1,
-            "enum": [1, 2, 3, 4, 5],
-            "minimum": 1,
-            "exclusiveMinimum": 0,
-            "maximum": 1E+1,
-            "exclusiveMaximum": 11,
-            "multipleOf": 1
+            "title": "int",
+            "description": "for type in general: int"
         },
         "isSimpleTestClass()": {
             "type": "boolean",
@@ -56,23 +71,20 @@
             "title": "boolean",
             "description": "for type in general: boolean"
         },
-        "getPrimitiveValue()": {
-            "type": "integer",
-            "$anchor": "#anchor",
-            "title": "int",
-            "description": "for type in general: int"
-        },
-        "calculateSomething(Number, Number)": false,
         "getGenericValue()": {
-            "type": ["string", "null"],
-            "$anchor": "#anchor",
-            "title": "String",
-            "description": "for type in general: String",
-            "const": "constant string value",
-            "minLength": 1,
-            "maxLength": 256,
-            "format": "date",
-            "pattern": "^.{1,256}$"
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "type": "string",
+                    "$anchor": "#anchor",
+                    "title": "String",
+                    "description": "for type in general: String",
+                    "const": "constant string value",
+                    "minLength": 1,
+                    "maxLength": 256,
+                    "format": "date",
+                    "pattern": "^.{1,256}$"
+                }]
         },
         "CONSTANT": {
             "type": "integer",

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-JAVA_OBJECT-methodattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-JAVA_OBJECT-methodattributes.json
@@ -12,14 +12,18 @@
             }
         },
         "genericValue": {
-            "type": ["string", "null"],
-            "title": "String",
-            "description": "looked-up from method: String",
-            "const": "constant string value",
-            "minLength": 1,
-            "maxLength": 256,
-            "format": "date",
-            "pattern": "^.{1,256}$"
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "type": "string",
+                    "title": "String",
+                    "description": "looked-up from method: String",
+                    "const": "constant string value",
+                    "minLength": 1,
+                    "maxLength": 256,
+                    "format": "date",
+                    "pattern": "^.{1,256}$"
+                }]
         },
         "primitiveValue": {
             "type": ["integer", "null"],

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-PLAIN_JSON-fieldattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-PLAIN_JSON-fieldattributes.json
@@ -21,26 +21,34 @@
             }
         },
         "genericValue": {
-            "type": ["string", "null"],
-            "title": "String",
-            "description": "looked-up from field: String",
-            "const": "constant string value",
-            "minLength": 1,
-            "maxLength": 256,
-            "format": "date",
-            "pattern": "^.{1,256}$"
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "type": "string",
+                    "title": "String",
+                    "description": "looked-up from field: String",
+                    "const": "constant string value",
+                    "minLength": 1,
+                    "maxLength": 256,
+                    "format": "date",
+                    "pattern": "^.{1,256}$"
+                }]
         },
         "ignoredInternalValue": {
-            "type": ["integer", "null"],
-            "title": "Integer",
-            "description": "looked-up from field: Integer",
-            "default": 1,
-            "enum": [1, 2, 3, 4, 5],
-            "minimum": 1,
-            "exclusiveMinimum": 0,
-            "maximum": 1E+1,
-            "exclusiveMaximum": 11,
-            "multipleOf": 1
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "type": "integer",
+                    "title": "Integer",
+                    "description": "looked-up from field: Integer",
+                    "default": 1,
+                    "enum": [1, 2, 3, 4, 5],
+                    "minimum": 1,
+                    "exclusiveMinimum": 0,
+                    "maximum": 1E+1,
+                    "exclusiveMaximum": 11,
+                    "multipleOf": 1
+                }]
         },
         "primitiveValue": {
             "type": ["integer", "null"],

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-PLAIN_JSON-fieldattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass1-PLAIN_JSON-fieldattributes.json
@@ -45,7 +45,7 @@
                     "enum": [1, 2, 3, 4, 5],
                     "minimum": 1,
                     "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
+                    "maximum": 10,
                     "exclusiveMaximum": 11,
                     "multipleOf": 1
                 }]

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION-typeattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION-typeattributes.json
@@ -3,37 +3,45 @@
         "Optional(Integer)-nullable": {
             "type": ["object", "null"],
             "properties": {
-                "get()": {
-                    "type": ["integer", "null"],
-                    "$anchor": "#anchor",
-                    "title": "Integer",
-                    "description": "for type in general: Integer",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
-                },
                 "orElse(Integer)": {
-                    "type": ["integer", "null"],
-                    "$anchor": "#anchor",
-                    "title": "Integer",
-                    "description": "for type in general: Integer",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "integer",
+                            "$anchor": "#anchor",
+                            "title": "Integer",
+                            "description": "for type in general: Integer",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
+                        }]
                 },
                 "isPresent()": {
                     "type": "boolean",
                     "$anchor": "#anchor",
                     "title": "boolean",
                     "description": "for type in general: boolean"
+                },
+                "get()": {
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "integer",
+                            "$anchor": "#anchor",
+                            "title": "Integer",
+                            "description": "for type in general: Integer",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
+                        }]
                 }
             },
             "$anchor": "#anchor",
@@ -45,15 +53,19 @@
             "type": "object",
             "properties": {
                 "name": {
-                    "type": ["string", "null"],
-                    "$anchor": "#anchor",
-                    "title": "String",
-                    "description": "for type in general: String",
-                    "const": "constant string value",
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "string",
+                            "$anchor": "#anchor",
+                            "title": "String",
+                            "description": "for type in general: String",
+                            "const": "constant string value",
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "format": "date",
+                            "pattern": "^.{1,256}$"
+                        }]
                 },
                 "ordinal": {
                     "type": "integer",
@@ -119,15 +131,19 @@
             "type": "object",
             "properties": {
                 "genericValue": {
-                    "type": ["string", "null"],
-                    "$anchor": "#anchor",
-                    "title": "String",
-                    "description": "for type in general: String",
-                    "const": "constant string value",
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "string",
+                            "$anchor": "#anchor",
+                            "title": "String",
+                            "description": "for type in general: String",
+                            "const": "constant string value",
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "format": "date",
+                            "pattern": "^.{1,256}$"
+                        }]
                 },
                 "genericArray": {
                     "type": ["array", "null"],
@@ -155,17 +171,28 @@
                     "description": "for type in general: int"
                 },
                 "ignoredInternalValue": {
-                    "type": ["integer", "null"],
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "integer",
+                            "$anchor": "#anchor",
+                            "title": "Integer",
+                            "description": "for type in general: Integer",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
+                        }]
+                },
+                "calculateSomething(Number, Number)": false,
+                "getPrimitiveValue()": {
+                    "type": "integer",
                     "$anchor": "#anchor",
-                    "title": "Integer",
-                    "description": "for type in general: Integer",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
+                    "title": "int",
+                    "description": "for type in general: int"
                 },
                 "isSimpleTestClass()": {
                     "type": "boolean",
@@ -173,23 +200,20 @@
                     "title": "boolean",
                     "description": "for type in general: boolean"
                 },
-                "getPrimitiveValue()": {
-                    "type": "integer",
-                    "$anchor": "#anchor",
-                    "title": "int",
-                    "description": "for type in general: int"
-                },
-                "calculateSomething(Number, Number)": false,
                 "getGenericValue()": {
-                    "type": ["string", "null"],
-                    "$anchor": "#anchor",
-                    "title": "String",
-                    "description": "for type in general: String",
-                    "const": "constant string value",
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "string",
+                            "$anchor": "#anchor",
+                            "title": "String",
+                            "description": "for type in general: String",
+                            "const": "constant string value",
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "format": "date",
+                            "pattern": "^.{1,256}$"
+                        }]
                 },
                 "CONSTANT": {
                     "type": "integer",
@@ -229,17 +253,21 @@
             "type": "object",
             "properties": {
                 "genericValue": {
-                    "type": ["integer", "null"],
-                    "$anchor": "#anchor",
-                    "title": "Long",
-                    "description": "for type in general: Long",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "integer",
+                            "$anchor": "#anchor",
+                            "title": "Long",
+                            "description": "for type in general: Long",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
+                        }]
                 },
                 "genericArray": {
                     "type": ["array", "null"],
@@ -263,17 +291,21 @@
                     "uniqueItems": false
                 },
                 "getGenericValue()": {
-                    "type": ["integer", "null"],
-                    "$anchor": "#anchor",
-                    "title": "Long",
-                    "description": "for type in general: Long",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "integer",
+                            "$anchor": "#anchor",
+                            "title": "Long",
+                            "description": "for type in general: Long",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
+                        }]
                 }
             },
             "$id": "id-TestClass2<Long>",
@@ -308,15 +340,19 @@
             "type": "object",
             "properties": {
                 "genericValue": {
-                    "type": ["string", "null"],
-                    "$anchor": "#anchor",
-                    "title": "String",
-                    "description": "for type in general: String",
-                    "const": "constant string value",
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "string",
+                            "$anchor": "#anchor",
+                            "title": "String",
+                            "description": "for type in general: String",
+                            "const": "constant string value",
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "format": "date",
+                            "pattern": "^.{1,256}$"
+                        }]
                 },
                 "genericArray": {
                     "type": ["array", "null"],
@@ -338,15 +374,19 @@
                     "uniqueItems": false
                 },
                 "getGenericValue()": {
-                    "type": ["string", "null"],
-                    "$anchor": "#anchor",
-                    "title": "String",
-                    "description": "for type in general: String",
-                    "const": "constant string value",
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "string",
+                            "$anchor": "#anchor",
+                            "title": "String",
+                            "description": "for type in general: String",
+                            "const": "constant string value",
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "format": "date",
+                            "pattern": "^.{1,256}$"
+                        }]
                 }
             },
             "$id": "id-TestClass2<String>",
@@ -537,6 +577,12 @@
         "class4": {
             "$ref": "#/definitions/TestClass4(Integer,String)-nullable"
         },
+        "getNestedLong()": {
+            "$ref": "#/definitions/TestClass2(Long)-nullable"
+        },
+        "getNestedClass1Array()": {
+            "$ref": "#/definitions/TestClass2(TestClass1*)-nullable"
+        },
         "getNestedLongList()": {
             "type": ["array", "null"],
             "items": {
@@ -551,12 +597,6 @@
         },
         "getClass4()": {
             "$ref": "#/definitions/TestClass4(Integer,String)-nullable"
-        },
-        "getNestedLong()": {
-            "$ref": "#/definitions/TestClass2(Long)-nullable"
-        },
-        "getNestedClass1Array()": {
-            "$ref": "#/definitions/TestClass2(TestClass1*)-nullable"
         }
     },
     "$id": "id-TestClass3",

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION-typeattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION-typeattributes.json
@@ -15,7 +15,7 @@
                             "enum": [1, 2, 3, 4, 5],
                             "minimum": 1,
                             "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
+                            "maximum": 10,
                             "exclusiveMaximum": 11,
                             "multipleOf": 1
                         }]
@@ -38,7 +38,7 @@
                             "enum": [1, 2, 3, 4, 5],
                             "minimum": 1,
                             "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
+                            "maximum": 10,
                             "exclusiveMaximum": 11,
                             "multipleOf": 1
                         }]
@@ -182,7 +182,7 @@
                             "enum": [1, 2, 3, 4, 5],
                             "minimum": 1,
                             "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
+                            "maximum": 10,
                             "exclusiveMaximum": 11,
                             "multipleOf": 1
                         }]
@@ -225,7 +225,7 @@
                     "enum": [1, 2, 3, 4, 5],
                     "minimum": 1,
                     "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
+                    "maximum": 10,
                     "exclusiveMaximum": 11,
                     "multipleOf": 1
                 }
@@ -264,7 +264,7 @@
                             "enum": [1, 2, 3, 4, 5],
                             "minimum": 1,
                             "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
+                            "maximum": 10,
                             "exclusiveMaximum": 11,
                             "multipleOf": 1
                         }]
@@ -280,7 +280,7 @@
                         "enum": [1, 2, 3, 4, 5],
                         "minimum": 1,
                         "exclusiveMinimum": 0,
-                        "maximum": 1E+1,
+                        "maximum": 10,
                         "exclusiveMaximum": 11,
                         "multipleOf": 1
                     },
@@ -302,7 +302,7 @@
                             "enum": [1, 2, 3, 4, 5],
                             "minimum": 1,
                             "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
+                            "maximum": 10,
                             "exclusiveMaximum": 11,
                             "multipleOf": 1
                         }]
@@ -323,7 +323,7 @@
                     "enum": [1, 2, 3, 4, 5],
                     "minimum": 1,
                     "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
+                    "maximum": 10,
                     "exclusiveMaximum": 11,
                     "multipleOf": 1
                 }

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
@@ -124,7 +124,7 @@
                             "enum": [1, 2, 3, 4, 5],
                             "minimum": 1,
                             "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
+                            "maximum": 10,
                             "exclusiveMaximum": 11,
                             "multipleOf": 1
                         }]
@@ -222,7 +222,7 @@
                                     "enum": [1, 2, 3, 4, 5],
                                     "minimum": 1,
                                     "exclusiveMinimum": 0,
-                                    "maximum": 1E+1,
+                                    "maximum": 10,
                                     "exclusiveMaximum": 11,
                                     "multipleOf": 1
                                 }]
@@ -238,7 +238,7 @@
                                     "enum": [1, 2, 3, 4, 5],
                                     "minimum": 1,
                                     "exclusiveMinimum": 0,
-                                    "maximum": 1E+1,
+                                    "maximum": 10,
                                     "exclusiveMaximum": 11,
                                     "multipleOf": 1
                                 }]

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
@@ -9,15 +9,19 @@
                     "description": "looked-up from method: int"
                 },
                 "name()": {
-                    "type": ["string", "null"],
-                    "title": "String",
-                    "description": "looked-up from method: String",
-                    "const": "constant string value",
-                    "readOnly": true,
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "string",
+                            "title": "String",
+                            "description": "looked-up from method: String",
+                            "const": "constant string value",
+                            "readOnly": true,
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "format": "date",
+                            "pattern": "^.{1,256}$"
+                        }]
                 },
                 "valueOf(String)": {
                     "allOf": [{
@@ -74,14 +78,18 @@
                     }
                 },
                 "genericValue": {
-                    "type": ["string", "null"],
-                    "title": "String",
-                    "description": "looked-up from method: String",
-                    "const": "constant string value",
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "string",
+                            "title": "String",
+                            "description": "looked-up from method: String",
+                            "const": "constant string value",
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "format": "date",
+                            "pattern": "^.{1,256}$"
+                        }]
                 },
                 "primitiveValue": {
                     "type": ["integer", "null"],
@@ -106,16 +114,20 @@
                     }
                 },
                 "genericValue": {
-                    "type": ["integer", "null"],
-                    "title": "Long",
-                    "description": "looked-up from method: Long",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "integer",
+                            "title": "Long",
+                            "description": "looked-up from method: Long",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
+                        }]
                 }
             }
         },
@@ -129,14 +141,18 @@
                     }
                 },
                 "genericValue": {
-                    "type": ["string", "null"],
-                    "title": "String",
-                    "description": "looked-up from method: String",
-                    "const": "constant string value",
-                    "minLength": 1,
-                    "maxLength": 256,
-                    "format": "date",
-                    "pattern": "^.{1,256}$"
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "string",
+                            "title": "String",
+                            "description": "looked-up from method: String",
+                            "const": "constant string value",
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "format": "date",
+                            "pattern": "^.{1,256}$"
+                        }]
                 }
             }
         }
@@ -196,28 +212,36 @@
                             "description": "looked-up from method: boolean"
                         },
                         "get()": {
-                            "type": ["integer", "null"],
-                            "title": "Integer",
-                            "description": "looked-up from method: Integer",
-                            "default": 1,
-                            "enum": [1, 2, 3, 4, 5],
-                            "minimum": 1,
-                            "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
-                            "exclusiveMaximum": 11,
-                            "multipleOf": 1
+                            "anyOf": [{
+                                    "type": "null"
+                                }, {
+                                    "type": "integer",
+                                    "title": "Integer",
+                                    "description": "looked-up from method: Integer",
+                                    "default": 1,
+                                    "enum": [1, 2, 3, 4, 5],
+                                    "minimum": 1,
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 1E+1,
+                                    "exclusiveMaximum": 11,
+                                    "multipleOf": 1
+                                }]
                         },
                         "orElse(Integer)": {
-                            "type": ["integer", "null"],
-                            "title": "Integer",
-                            "description": "looked-up from method: Integer",
-                            "default": 1,
-                            "enum": [1, 2, 3, 4, 5],
-                            "minimum": 1,
-                            "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
-                            "exclusiveMaximum": 11,
-                            "multipleOf": 1
+                            "anyOf": [{
+                                    "type": "null"
+                                }, {
+                                    "type": "integer",
+                                    "title": "Integer",
+                                    "description": "looked-up from method: Integer",
+                                    "default": 1,
+                                    "enum": [1, 2, 3, 4, 5],
+                                    "minimum": 1,
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 1E+1,
+                                    "exclusiveMaximum": 11,
+                                    "multipleOf": 1
+                                }]
                         }
                     }
                 }

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-fieldattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-fieldattributes.json
@@ -161,7 +161,7 @@
                             "enum": [1, 2, 3, 4, 5],
                             "minimum": 1,
                             "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
+                            "maximum": 10,
                             "exclusiveMaximum": 11,
                             "multipleOf": 1
                         }]
@@ -237,7 +237,7 @@
                                             "enum": [1, 2, 3, 4, 5],
                                             "minimum": 1,
                                             "exclusiveMinimum": 0,
-                                            "maximum": 1E+1,
+                                            "maximum": 10,
                                             "exclusiveMaximum": 11,
                                             "multipleOf": 1
                                         }]
@@ -304,7 +304,7 @@
                                         "enum": [1, 2, 3, 4, 5],
                                         "minimum": 1,
                                         "exclusiveMinimum": 0,
-                                        "maximum": 1E+1,
+                                        "maximum": 10,
                                         "exclusiveMaximum": 11,
                                         "multipleOf": 1
                                     }]
@@ -378,7 +378,7 @@
                                         "enum": [1, 2, 3, 4, 5],
                                         "minimum": 1,
                                         "exclusiveMinimum": 0,
-                                        "maximum": 1E+1,
+                                        "maximum": 10,
                                         "exclusiveMaximum": 11,
                                         "multipleOf": 1
                                     }]
@@ -411,7 +411,7 @@
                         "enum": [1, 2, 3, 4, 5],
                         "minimum": 1,
                         "exclusiveMinimum": 0,
-                        "maximum": 1E+1,
+                        "maximum": 10,
                         "exclusiveMaximum": 11,
                         "multipleOf": 1
                     }
@@ -427,7 +427,7 @@
                             "enum": [1, 2, 3, 4, 5],
                             "minimum": 1,
                             "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
+                            "maximum": 10,
                             "exclusiveMaximum": 11,
                             "multipleOf": 1
                         }]
@@ -467,7 +467,7 @@
                             "enum": [1, 2, 3, 4, 5],
                             "minimum": 1,
                             "exclusiveMinimum": 0,
-                            "maximum": 1E+1,
+                            "maximum": 10,
                             "exclusiveMaximum": 11,
                             "multipleOf": 1
                         }
@@ -483,7 +483,7 @@
                                 "enum": [1, 2, 3, 4, 5],
                                 "minimum": 1,
                                 "exclusiveMinimum": 0,
-                                "maximum": 1E+1,
+                                "maximum": 10,
                                 "exclusiveMaximum": 11,
                                 "multipleOf": 1
                             }]

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-fieldattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-PLAIN_JSON-fieldattributes.json
@@ -37,14 +37,18 @@
                                         }
                                     },
                                     "genericValue": {
-                                        "type": ["string", "null"],
-                                        "title": "String",
-                                        "description": "looked-up from field: String",
-                                        "const": "constant string value",
-                                        "minLength": 1,
-                                        "maxLength": 256,
-                                        "format": "date",
-                                        "pattern": "^.{1,256}$"
+                                        "anyOf": [{
+                                                "type": "null"
+                                            }, {
+                                                "type": "string",
+                                                "title": "String",
+                                                "description": "looked-up from field: String",
+                                                "const": "constant string value",
+                                                "minLength": 1,
+                                                "maxLength": 256,
+                                                "format": "date",
+                                                "pattern": "^.{1,256}$"
+                                            }]
                                     }
                                 },
                                 "title": "TestClass2<String>",
@@ -79,14 +83,18 @@
                                     }
                                 },
                                 "genericValue": {
-                                    "type": ["string", "null"],
-                                    "title": "String",
-                                    "description": "looked-up from field: String",
-                                    "const": "constant string value",
-                                    "minLength": 1,
-                                    "maxLength": 256,
-                                    "format": "date",
-                                    "pattern": "^.{1,256}$"
+                                    "anyOf": [{
+                                            "type": "null"
+                                        }, {
+                                            "type": "string",
+                                            "title": "String",
+                                            "description": "looked-up from field: String",
+                                            "const": "constant string value",
+                                            "minLength": 1,
+                                            "maxLength": 256,
+                                            "format": "date",
+                                            "pattern": "^.{1,256}$"
+                                        }]
                                 }
                             },
                             "title": "TestClass2<String>",
@@ -125,30 +133,38 @@
                                     }
                                 },
                                 "genericValue": {
-                                    "type": ["string", "null"],
-                                    "title": "String",
-                                    "description": "looked-up from field: String",
-                                    "const": "constant string value",
-                                    "minLength": 1,
-                                    "maxLength": 256,
-                                    "format": "date",
-                                    "pattern": "^.{1,256}$"
+                                    "anyOf": [{
+                                            "type": "null"
+                                        }, {
+                                            "type": "string",
+                                            "title": "String",
+                                            "description": "looked-up from field: String",
+                                            "const": "constant string value",
+                                            "minLength": 1,
+                                            "maxLength": 256,
+                                            "format": "date",
+                                            "pattern": "^.{1,256}$"
+                                        }]
                                 }
                             }
                         }
                     }
                 },
                 "optionalS": {
-                    "type": ["integer", "null"],
-                    "title": "Integer",
-                    "description": "looked-up from field: Integer",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "integer",
+                            "title": "Integer",
+                            "description": "looked-up from field: Integer",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
+                        }]
                 }
             },
             "title": "TestClass4<Integer, String>",
@@ -197,26 +213,34 @@
                                     }
                                 },
                                 "genericValue": {
-                                    "type": ["string", "null"],
-                                    "title": "String",
-                                    "description": "looked-up from field: String",
-                                    "const": "constant string value",
-                                    "minLength": 1,
-                                    "maxLength": 256,
-                                    "format": "date",
-                                    "pattern": "^.{1,256}$"
+                                    "anyOf": [{
+                                            "type": "null"
+                                        }, {
+                                            "type": "string",
+                                            "title": "String",
+                                            "description": "looked-up from field: String",
+                                            "const": "constant string value",
+                                            "minLength": 1,
+                                            "maxLength": 256,
+                                            "format": "date",
+                                            "pattern": "^.{1,256}$"
+                                        }]
                                 },
                                 "ignoredInternalValue": {
-                                    "type": ["integer", "null"],
-                                    "title": "Integer",
-                                    "description": "looked-up from field: Integer",
-                                    "default": 1,
-                                    "enum": [1, 2, 3, 4, 5],
-                                    "minimum": 1,
-                                    "exclusiveMinimum": 0,
-                                    "maximum": 1E+1,
-                                    "exclusiveMaximum": 11,
-                                    "multipleOf": 1
+                                    "anyOf": [{
+                                            "type": "null"
+                                        }, {
+                                            "type": "integer",
+                                            "title": "Integer",
+                                            "description": "looked-up from field: Integer",
+                                            "default": 1,
+                                            "enum": [1, 2, 3, 4, 5],
+                                            "minimum": 1,
+                                            "exclusiveMinimum": 0,
+                                            "maximum": 1E+1,
+                                            "exclusiveMaximum": 11,
+                                            "multipleOf": 1
+                                        }]
                                 },
                                 "primitiveValue": {
                                     "type": ["integer", "null"],
@@ -256,26 +280,34 @@
                                 }
                             },
                             "genericValue": {
-                                "type": ["string", "null"],
-                                "title": "String",
-                                "description": "looked-up from field: String",
-                                "const": "constant string value",
-                                "minLength": 1,
-                                "maxLength": 256,
-                                "format": "date",
-                                "pattern": "^.{1,256}$"
+                                "anyOf": [{
+                                        "type": "null"
+                                    }, {
+                                        "type": "string",
+                                        "title": "String",
+                                        "description": "looked-up from field: String",
+                                        "const": "constant string value",
+                                        "minLength": 1,
+                                        "maxLength": 256,
+                                        "format": "date",
+                                        "pattern": "^.{1,256}$"
+                                    }]
                             },
                             "ignoredInternalValue": {
-                                "type": ["integer", "null"],
-                                "title": "Integer",
-                                "description": "looked-up from field: Integer",
-                                "default": 1,
-                                "enum": [1, 2, 3, 4, 5],
-                                "minimum": 1,
-                                "exclusiveMinimum": 0,
-                                "maximum": 1E+1,
-                                "exclusiveMaximum": 11,
-                                "multipleOf": 1
+                                "anyOf": [{
+                                        "type": "null"
+                                    }, {
+                                        "type": "integer",
+                                        "title": "Integer",
+                                        "description": "looked-up from field: Integer",
+                                        "default": 1,
+                                        "enum": [1, 2, 3, 4, 5],
+                                        "minimum": 1,
+                                        "exclusiveMinimum": 0,
+                                        "maximum": 1E+1,
+                                        "exclusiveMaximum": 11,
+                                        "multipleOf": 1
+                                    }]
                             },
                             "primitiveValue": {
                                 "type": ["integer", "null"],
@@ -322,26 +354,34 @@
                                 }
                             },
                             "genericValue": {
-                                "type": ["string", "null"],
-                                "title": "String",
-                                "description": "looked-up from field: String",
-                                "const": "constant string value",
-                                "minLength": 1,
-                                "maxLength": 256,
-                                "format": "date",
-                                "pattern": "^.{1,256}$"
+                                "anyOf": [{
+                                        "type": "null"
+                                    }, {
+                                        "type": "string",
+                                        "title": "String",
+                                        "description": "looked-up from field: String",
+                                        "const": "constant string value",
+                                        "minLength": 1,
+                                        "maxLength": 256,
+                                        "format": "date",
+                                        "pattern": "^.{1,256}$"
+                                    }]
                             },
                             "ignoredInternalValue": {
-                                "type": ["integer", "null"],
-                                "title": "Integer",
-                                "description": "looked-up from field: Integer",
-                                "default": 1,
-                                "enum": [1, 2, 3, 4, 5],
-                                "minimum": 1,
-                                "exclusiveMinimum": 0,
-                                "maximum": 1E+1,
-                                "exclusiveMaximum": 11,
-                                "multipleOf": 1
+                                "anyOf": [{
+                                        "type": "null"
+                                    }, {
+                                        "type": "integer",
+                                        "title": "Integer",
+                                        "description": "looked-up from field: Integer",
+                                        "default": 1,
+                                        "enum": [1, 2, 3, 4, 5],
+                                        "minimum": 1,
+                                        "exclusiveMinimum": 0,
+                                        "maximum": 1E+1,
+                                        "exclusiveMaximum": 11,
+                                        "multipleOf": 1
+                                    }]
                             },
                             "primitiveValue": {
                                 "type": ["integer", "null"],
@@ -377,16 +417,20 @@
                     }
                 },
                 "genericValue": {
-                    "type": ["integer", "null"],
-                    "title": "Long",
-                    "description": "looked-up from field: Long",
-                    "default": 1,
-                    "enum": [1, 2, 3, 4, 5],
-                    "minimum": 1,
-                    "exclusiveMinimum": 0,
-                    "maximum": 1E+1,
-                    "exclusiveMaximum": 11,
-                    "multipleOf": 1
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "type": "integer",
+                            "title": "Long",
+                            "description": "looked-up from field: Long",
+                            "default": 1,
+                            "enum": [1, 2, 3, 4, 5],
+                            "minimum": 1,
+                            "exclusiveMinimum": 0,
+                            "maximum": 1E+1,
+                            "exclusiveMaximum": 11,
+                            "multipleOf": 1
+                        }]
                 }
             },
             "title": "TestClass2<Long>",
@@ -429,16 +473,20 @@
                         }
                     },
                     "genericValue": {
-                        "type": ["integer", "null"],
-                        "title": "Long",
-                        "description": "looked-up from field: Long",
-                        "default": 1,
-                        "enum": [1, 2, 3, 4, 5],
-                        "minimum": 1,
-                        "exclusiveMinimum": 0,
-                        "maximum": 1E+1,
-                        "exclusiveMaximum": 11,
-                        "multipleOf": 1
+                        "anyOf": [{
+                                "type": "null"
+                            }, {
+                                "type": "integer",
+                                "title": "Long",
+                                "description": "looked-up from field: Long",
+                                "default": 1,
+                                "enum": [1, 2, 3, 4, 5],
+                                "minimum": 1,
+                                "exclusiveMinimum": 0,
+                                "maximum": 1E+1,
+                                "exclusiveMaximum": 11,
+                                "multipleOf": 1
+                            }]
                     }
                 },
                 "title": "TestClass2<Long>",

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
@@ -50,7 +49,7 @@ public class IntegrationTest {
     public void testIntegration() throws Exception {
         JacksonModule module = new JacksonModule(JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE, JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY,
                 JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS);
-        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), SchemaVersion.DRAFT_7, OptionPreset.PLAIN_JSON)
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_7, OptionPreset.PLAIN_JSON)
                 .with(Option.NULLABLE_ARRAY_ITEMS_ALLOWED)
                 .with(Option.NONSTATIC_NONVOID_NONGETTER_METHODS, Option.FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS)
                 .with(module)

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionFromInterfaceIntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionFromInterfaceIntegrationTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
@@ -52,7 +51,7 @@ public class SubtypeResolutionFromInterfaceIntegrationTest {
     @Test
     public void testIntegration() throws Exception {
         JacksonModule module = new JacksonModule(JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE);
-        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
                 .with(Option.DEFINITIONS_FOR_ALL_OBJECTS, Option.NULLABLE_FIELDS_BY_DEFAULT)
                 .with(module)
                 .build();

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionIntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionIntegrationTest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
@@ -52,7 +51,7 @@ public class SubtypeResolutionIntegrationTest {
     @Test
     public void testIntegration() throws Exception {
         JacksonModule module = new JacksonModule(JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE);
-        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON)
                 .with(Option.DEFINITIONS_FOR_ALL_OBJECTS, Option.NULLABLE_FIELDS_BY_DEFAULT)
                 .with(module)
                 .build();

--- a/jsonschema-module-swagger-1.5/src/test/java/com/github/victools/jsonschema/module/swagger15/IntegrationTest.java
+++ b/jsonschema-module-swagger-1.5/src/test/java/com/github/victools/jsonschema/module/swagger15/IntegrationTest.java
@@ -17,8 +17,8 @@
 package com.github.victools.jsonschema.module.swagger15;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.victools.jsonschema.generator.Option;
+import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
@@ -50,7 +50,7 @@ public class IntegrationTest {
         SwaggerModule module = new SwaggerModule(
                 SwaggerOption.ENABLE_PROPERTY_NAME_OVERRIDES,
                 SwaggerOption.IGNORING_HIDDEN_PROPERTIES);
-        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(new ObjectMapper(), SchemaVersion.DRAFT_2019_09)
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2019_09, OptionPreset.FULL_DOCUMENTATION)
                 .with(Option.NULLABLE_ARRAY_ITEMS_ALLOWED)
                 .with(module)
                 .build();

--- a/jsonschema-module-swagger-1.5/src/test/resources/com/github/victools/jsonschema/module/swagger15/integration-test-result.json
+++ b/jsonschema-module-swagger-1.5/src/test/resources/com/github/victools/jsonschema/module/swagger15/integration-test-result.json
@@ -2,9 +2,13 @@
     "type": "object",
     "properties": {
         "fieldWithDescriptionAndAllowableValues": {
-            "type": ["string", "null"],
-            "description": "field description",
-            "enum": ["A", "B", "C", "D"]
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "type": "string",
+                    "description": "field description",
+                    "enum": ["A", "B", "C", "D"]
+                }]
         },
         "fieldWithExclusiveNumericRange": {
             "type": "integer",

--- a/jsonschema-module-swagger-2/src/test/resources/com/github/victools/jsonschema/module/swagger2/integration-test-result-TestClass.json
+++ b/jsonschema-module-swagger-2/src/test/resources/com/github/victools/jsonschema/module/swagger2/integration-test-result-TestClass.json
@@ -17,7 +17,7 @@
         "fieldWithInclusiveNumericRange": {
             "type": "integer",
             "minimum": 15,
-            "maximum": 2E+1
+            "maximum": 20
         },
         "fieldWithOverriddenName": {
             "minItems": 1,

--- a/jsonschema-module-swagger-2/src/test/resources/com/github/victools/jsonschema/module/swagger2/integration-test-result-TestClass.json
+++ b/jsonschema-module-swagger-2/src/test/resources/com/github/victools/jsonschema/module/swagger2/integration-test-result-TestClass.json
@@ -3,11 +3,15 @@
     "type": "object",
     "properties": {
         "fieldWithDescriptionAndAllowableValues": {
-            "type": ["string", "null"],
-            "description": "field description",
-            "enum": ["A", "B", "C", "D"],
-            "minLength": 1,
-            "maxLength": 1
+            "anyOf": [{
+                    "type": "null"
+                }, {
+                    "type": "string",
+                    "description": "field description",
+                    "enum": ["A", "B", "C", "D"],
+                    "minLength": 1,
+                    "maxLength": 1
+                }]
         },
         "fieldWithExclusiveNumericRange": {
             "type": "integer",


### PR DESCRIPTION
As pointed out in https://github.com/victools/jsonschema-generator/discussions/212, JSON Schema Validators (e.g. the "networknt/json-schema-validator") do not allow `null` values for a schema like the following:
```json
{
  "type": ["string", "null"],
  "enum": ["A", "B", "C"]
}
```
Instead, the schema needs to look like this:
```json
{
  "anyOf": [
    {
      "type": "null"
    },
    {
      "type": "string",
      "enum": ["A", "B", "C"]
    }
  ]
}
```
----

This is already working correctly when the same type is being encountered both in nullable and non-nullable form.
But if a given type only appears in nullable form, the wrong schema is being created.

----

While updating the test accordingly, I also introduced a small change to the default `ObjectMapper` instance, which is being used when no specific one is given in the `SchemaGeneratorConfigBuilder` constructor invocation.
Now, that default `ObjectMapper` avoids scientific notation of numbers, i.e., now should write `10` instead of `1E+1`. This may have no effect, depending on your usage of the `ObjectMapper`.