### PR TITLE
Add support for Draft 2020-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### `jsonschema-generator`
+#### Added
+- Introduce support for `SchemaVersion.DRAFT_2020_12`
+
 #### Dependency Update
 - Replace `log4j` test dependency with `logback` (still only test dependency)
 

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaVersion.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaVersion.java
@@ -22,7 +22,8 @@ package com.github.victools.jsonschema.generator;
 public enum SchemaVersion {
     DRAFT_6("http://json-schema.org/draft-06/schema#"),
     DRAFT_7("http://json-schema.org/draft-07/schema#"),
-    DRAFT_2019_09("https://json-schema.org/draft/2019-09/schema");
+    DRAFT_2019_09("https://json-schema.org/draft/2019-09/schema"),
+    DRAFT_2020_12("https://json-schema.org/draft/2020-12/schema");
 
     private final String identifier;
 

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/circular-custom-definition-DRAFT_2020_12.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/circular-custom-definition-DRAFT_2020_12.json
@@ -1,0 +1,34 @@
+{
+    "$defs": {
+        "List(TestCircularClass1)-nullable": {
+            "type": ["object", "null"],
+            "properties": {
+                "get(0)": {
+                    "$ref": "#"
+                }
+            }
+        },
+        "List(TestCircularClass2)-nullable": {
+            "type": ["object", "null"],
+            "properties": {
+                "get(0)": {
+                    "$ref": "#/$defs/TestCircularClass2"
+                }
+            }
+        },
+        "TestCircularClass2": {
+            "type": "object",
+            "properties": {
+                "list1": {
+                    "$ref": "#/$defs/List(TestCircularClass1)-nullable"
+                }
+            }
+        }
+    },
+    "type": "object",
+    "properties": {
+        "list2": {
+            "$ref": "#/$defs/List(TestCircularClass2)-nullable"
+        }
+    }
+}

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/custom-property-definition-DRAFT_2020_12.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/custom-property-definition-DRAFT_2020_12.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "number": {
+            "type": "integer",
+            "title": "custom title",
+            "description": "field description"
+        },
+        "self": {
+            "$ref": "#",
+            "description": "field description"
+        },
+        "text": {
+            "type": "string",
+            "title": "type title",
+            "description": "custom description"
+        }
+    },
+    "title": "type title"
+}

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/multiple-definitions-one-type-DRAFT_2020_12.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/multiple-definitions-one-type-DRAFT_2020_12.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$defs": {
+        "int(a)": {
+            "title": "Custom Definition #2 for int",
+            "anyOf": [{
+                    "type": "integer"
+                }, {
+                    "type": "null"
+                }]
+        },
+        "int(b)": {
+            "title": "Custom Definition #1 for int",
+            "anyOf": [{
+                    "$ref": "#/$defs/int(a)"
+                }, {
+                    "type": "null"
+                }]
+        },
+        "string": {
+            "title": "Custom Definition #1 for String",
+            "anyOf": [{
+                    "type": "string"
+                }, {
+                    "type": "null"
+                }]
+        },
+        "testdirectcircularclass(a)": {
+            "type": "object",
+            "properties": {
+                "number": {
+                    "$ref": "#/$defs/int(b)"
+                },
+                "self": {
+                    "$ref": "#"
+                },
+                "text": {
+                    "$ref": "#/$defs/string"
+                }
+            }
+        },
+        "testdirectcircularclass(b)": {
+            "title": "Custom Definition #2 for com.github.victools.jsonschema.generator.SchemaGeneratorCustomDefinitionsTest$TestDirectCircularClass",
+            "anyOf": [{
+                    "$ref": "#/$defs/testdirectcircularclass(a)"
+                }, {
+                    "type": "null"
+                }]
+        }
+    },
+    "title": "Custom Definition #1 for TestDirectCircularClass",
+    "anyOf": [{
+            "$ref": "#/$defs/testdirectcircularclass(b)"
+        }, {
+            "type": "null"
+        }]
+}


### PR DESCRIPTION
None of the standard keywords were changed in a relevant way, most notably:
- `items` when used for tuples are renamed to `prefixItems` – since no explicit tuple support exists, no change is needed
- `additionalItems` got renamed to `items` – since no explicit support for that keyword exists, no change is needed
- logic around `dynamicAnchor`/`dynamicRef` was altered – since no explicit support for those keywords exists, no change is needed
- support for creating a composite schema sounds interesting but is not necessary at this stage and is maybe added later (once someone asks for it or even provides a PR).