### PR TITLE
Marked SchemaGeneratorMojo as ThreadSafe

### DIFF
--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
@@ -69,7 +69,8 @@ import org.reflections.util.ConfigurationBuilder;
 @Mojo(name = "generate",
         defaultPhase = LifecyclePhase.COMPILE,
         requiresDependencyResolution = ResolutionScope.COMPILE,
-        requiresDependencyCollection = ResolutionScope.COMPILE)
+        requiresDependencyCollection = ResolutionScope.COMPILE,
+        threadSafe = true)
 public class SchemaGeneratorMojo extends AbstractMojo {
 
     /**


### PR DESCRIPTION
When running `mvn install --threads 1C` with a project that has this plugin you get the following warnings. This change will remove those warnings:

```
[WARNING] *****************************************************************
[WARNING] * Your build is requesting parallel execution, but project      *
[WARNING] * contains the following plugin(s) that have goals not marked   *
[WARNING] * as @threadSafe to support parallel building.                  *
[WARNING] * While this /may/ work fine, please look for plugin updates    *
[WARNING] * and/or request plugins be made thread-safe.                   *
[WARNING] * If reporting an issue, report it against the plugin in        *
[WARNING] * question, not against maven-core                              *
[WARNING] *****************************************************************
[WARNING] The following plugins are not marked @threadSafe in cfa-api-sdk-integration-test:
[WARNING] com.github.victools:jsonschema-maven-plugin:4.18.0
[WARNING] Enable debug to see more precisely which goals are not marked @threadSafe.
[WARNING] *****************************************************************
```