### PR TITLE
Fix typo in Java code snippet

### DIFF
--- a/slate-docs/source/includes/_faq.md
+++ b/slate-docs/source/includes/_faq.md
@@ -124,7 +124,7 @@ Refer to https://json-schema.org/understanding-json-schema/reference/regular_exp
 ```java
 configBuilder.forFields().withDefaultResolver(field -> {
     JsonProperty annotation = field.getAnnotationConsideringFieldAndGetter(JsonProperty.class);
-    return annotation == null || annotation.defaultValue().isEmpty() ? null : annotation.defaultValue());
+    return annotation == null || annotation.defaultValue().isEmpty() ? null : annotation.defaultValue();
 });
 ```
 


### PR DESCRIPTION
spurious additional `)` character, code compiles when removed:

![image](https://user-images.githubusercontent.com/1699252/153726813-3bd7ee57-7bb8-4aba-9bc5-a265f7a4d215.png)
