### PR TITLE
Jackson Module: subtype resolution does not look-up discriminator value correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - Declare thread-safety, to avoid warnings at runtime
 
+### `jsonschema-module-jackson`
+#### Fixed
+- Sub type resolution utilising `JsonTypeInfo.Id.NAME` now considers `@JsonSubTypes.value[].name` instead of relying on `@JsonTypeName` being present
+
 ## [4.22.0] - 2022-01-10
 ### `jsonschema-generator`
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 - Sub type resolution utilising `JsonTypeInfo.Id.NAME` now considers `@JsonSubTypes.value[].name` instead of relying on `@JsonTypeName` being present
 
+#### Changed
+- Sub type resolution utilising `JsonTypeInfo.As.PROPERTY`/`JsonTypeInfo.As.EXISTING_PROPERTY` now marks discriminator property as `"required"`
+- Sub type resolution utilising `JsonTypeInfo.As.WRAPPER_OBJECT` now marks discriminator value as `"required"` in wrapper object
+
 ## [4.22.0] - 2022-01-10
 ### `jsonschema-generator`
 #### Added

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
@@ -284,6 +284,7 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
                         .add(context.createStandardDefinitionReference(javaType, this))
                         .add(attributesToInclude);
             }
+            definition.withArray(context.getKeyword(SchemaKeyword.TAG_REQUIRED)).add(typeIdentifier);
             break;
         case PROPERTY:
         case EXISTING_PROPERTY:
@@ -300,6 +301,8 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
                     .with(context.getKeyword(SchemaKeyword.TAG_PROPERTIES))
                     .with(propertyName)
                     .put(context.getKeyword(SchemaKeyword.TAG_CONST), typeIdentifier);
+            additionalPart.withArray(context.getKeyword(SchemaKeyword.TAG_REQUIRED))
+                    .add(propertyName);
             break;
         default:
             return null;

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
@@ -34,7 +34,6 @@ import com.github.victools.jsonschema.generator.SubtypeResolver;
 import com.github.victools.jsonschema.generator.TypeContext;
 import com.github.victools.jsonschema.generator.impl.AttributeCollector;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -106,26 +105,14 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
      */
     @Override
     public CustomDefinition provideCustomSchemaDefinition(ResolvedType javaType, SchemaGenerationContext context) {
-        Class<?> targetSuperType = javaType.getErasedType();
-        JsonTypeInfo typeInfoAnnotation;
-        do {
-            typeInfoAnnotation = targetSuperType.getAnnotation(JsonTypeInfo.class);
-            if (typeInfoAnnotation == null) {
-                // the @JsonTypeInfo annotation may also be present on a common interface rather than a super class
-                // assumption: there are never multiple interfaces with such an annotation on a single class
-                typeInfoAnnotation = Stream.of(targetSuperType.getInterfaces())
-                        .map(superInterface -> superInterface.getAnnotation(JsonTypeInfo.class))
-                        .filter(Objects::nonNull)
-                        .findFirst()
-                        .orElse(null);
-            }
-            targetSuperType = targetSuperType.getSuperclass();
-        } while (typeInfoAnnotation == null && targetSuperType != null);
-
-        if (typeInfoAnnotation == null || javaType.getErasedType().getDeclaredAnnotation(JsonSubTypes.class) != null) {
+        Class<?> typeWithTypeInfo = this.getTypeDeclaringJsonTypeInfoAnnotation(javaType.getErasedType());
+        if (typeWithTypeInfo == null || javaType.getErasedType().getAnnotation(JsonSubTypes.class) != null) {
+            // no @JsonTypeInfo annotation found or the given javaType is the super type, that should be replaced
             return null;
         }
-        ObjectNode definition = this.createSubtypeDefinition(javaType, typeInfoAnnotation, null, context);
+        JsonTypeInfo typeInfoAnnotation = typeWithTypeInfo.getAnnotation(JsonTypeInfo.class);
+        JsonSubTypes subTypesAnnotation = typeWithTypeInfo.getAnnotation(JsonSubTypes.class);
+        ObjectNode definition = this.createSubtypeDefinition(javaType, typeInfoAnnotation, subTypesAnnotation, null, context);
         if (definition == null) {
             return null;
         }
@@ -140,8 +127,12 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
      * @return applicable custom per-property override schema definition (may be {@code null})
      */
     public CustomPropertyDefinition provideCustomPropertySchemaDefinition(MemberScope<?, ?> scope, SchemaGenerationContext context) {
+        if (scope.getType() == null || scope.getType().getErasedType().getDeclaredAnnotation(JsonSubTypes.class) != null) {
+            return null;
+        }
         JsonTypeInfo typeInfoAnnotation = scope.getAnnotationConsideringFieldAndGetter(JsonTypeInfo.class);
-        if (typeInfoAnnotation == null || scope.getType().getErasedType().getDeclaredAnnotation(JsonSubTypes.class) != null) {
+        if (typeInfoAnnotation == null) {
+            // neither of the two annotations is overriding the per-type behaviour, i.e., no need for inline custom property schema
             return null;
         }
         ObjectNode attributes;
@@ -152,11 +143,31 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
         } else {
             attributes = null;
         }
-        ObjectNode definition = this.createSubtypeDefinition(scope.getType(), typeInfoAnnotation, attributes, context);
+        JsonSubTypes subTypesAnnotation = scope.getAnnotationConsideringFieldAndGetter(JsonSubTypes.class);
+        ObjectNode definition = this.createSubtypeDefinition(scope.getType(), typeInfoAnnotation, subTypesAnnotation, attributes, context);
         if (definition == null) {
             return null;
         }
         return new CustomPropertyDefinition(definition, CustomDefinition.AttributeInclusion.NO);
+    }
+
+    private Class<?> getTypeDeclaringJsonTypeInfoAnnotation(Class<?> erasedTargetType) {
+        Class<?> targetSuperType = erasedTargetType;
+        do {
+            if (targetSuperType.getAnnotation(JsonTypeInfo.class) != null) {
+                return targetSuperType;
+            }
+            // the @JsonTypeInfo annotation may also be present on a common interface rather than a super class
+            // assumption: there are never multiple interfaces with such an annotation on a single class
+            Optional<Class<?>> interfaceWithAnnotation = Stream.of(targetSuperType.getInterfaces())
+                    .filter(superInterface -> superInterface.getAnnotation(JsonTypeInfo.class) != null)
+                    .findFirst();
+            if (interfaceWithAnnotation.isPresent()) {
+                return interfaceWithAnnotation.get();
+            }
+            targetSuperType = targetSuperType.getSuperclass();
+        } while (targetSuperType != null);
+        return null;
     }
 
     /**
@@ -164,17 +175,17 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
      *
      * @param javaType specific subtype to identify
      * @param typeInfoAnnotation annotation for determining what kind of identifier to use
+     * @param subTypesAnnotation annotation to consider for certain kinds of discriminators
      * @return type identifier (or {@code null} if no supported value could be found)
      */
-    private String getTypeIdentifier(ResolvedType javaType, JsonTypeInfo typeInfoAnnotation) {
+    private String getTypeIdentifier(ResolvedType javaType, JsonTypeInfo typeInfoAnnotation, JsonSubTypes subTypesAnnotation) {
         Class<?> erasedTargetType = javaType.getErasedType();
         final String typeIdentifier;
         switch (typeInfoAnnotation.use()) {
         case NAME:
-            typeIdentifier = Optional.ofNullable(erasedTargetType.getAnnotation(JsonTypeName.class))
-                    .map(JsonTypeName::value)
-                    .filter(name -> !name.isEmpty())
-                    .orElseGet(() -> getUnqualifiedClassName(erasedTargetType));
+            typeIdentifier = getNameFromSubTypeAnnotation(erasedTargetType, subTypesAnnotation)
+                    .orElseGet(() -> getNameFromTypeNameAnnotation(erasedTargetType)
+                    .orElseGet(() -> getUnqualifiedClassName(erasedTargetType)));
             break;
         case CLASS:
             typeIdentifier = erasedTargetType.getName();
@@ -186,7 +197,37 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
     }
 
     /**
-     * In case of a missing {@link JsonTypeName} annotation for a {@code JsonTypeInfo.Id.NAME}, determine the unqualified name of the given class.
+     * In case of a {@code JsonTypeInfo.Id.NAME}, try to look up the reference via {@link JsonSubTypes} annotation.
+     *
+     * @param erasedTargetType class to look-up the "name" for
+     * @param subTypesAnnotation {@link JsonSubTypes} annotation instance of consider
+     * @return successfully looked-up "name" (otherwise an empty {@code Optional})
+     */
+    private static Optional<String> getNameFromSubTypeAnnotation(Class<?> erasedTargetType, JsonSubTypes subTypesAnnotation) {
+        if (subTypesAnnotation == null) {
+            return Optional.empty();
+        }
+        return Stream.of(subTypesAnnotation.value())
+                .filter(subTypeAnnotation -> erasedTargetType.equals(subTypeAnnotation.value()))
+                .findFirst()
+                .map(subTypeAnnotation -> subTypeAnnotation.name())
+                .filter(name -> !name.isEmpty());
+    }
+
+    /**
+     * Determine the unqualified name of the given class, e.g., as fall-back value for subtype reference with {@code JsonTypeInfo.Id.NAME}.
+     *
+     * @param erasedTargetType class to produce unqualified class name for
+     * @return simple class name, with declaring class's unqualified name as prefix for member classes
+     */
+    private static Optional<String> getNameFromTypeNameAnnotation(Class<?> erasedTargetType) {
+        return Optional.ofNullable(erasedTargetType.getAnnotation(JsonTypeName.class))
+                .map(JsonTypeName::value)
+                .filter(name -> !name.isEmpty());
+    }
+
+    /**
+     * Determine the unqualified name of the given class, e.g., as fall-back value for subtype reference with {@code JsonTypeInfo.Id.NAME}.
      *
      * @param erasedTargetType class to produce unqualified class name for
      * @return simple class name, with declaring class's unqualified name as prefix for member classes
@@ -204,13 +245,14 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
      *
      * @param javaType targeted subtype
      * @param typeInfoAnnotation annotation for looking up the type identifier and determining the kind of inclusion/serialization
+     * @param subTypesAnnotation annotation specifying the mapping from super to subtypes (potentially including the discriminator values)
      * @param attributesToInclude optional: additional attributes to include on the actual/contained schema definition
      * @param context generation context
      * @return created custom definition (or {@code null} if no supported subtype resolution scenario could be detected
      */
-    private ObjectNode createSubtypeDefinition(ResolvedType javaType, JsonTypeInfo typeInfoAnnotation, ObjectNode attributesToInclude,
-            SchemaGenerationContext context) {
-        final String typeIdentifier = this.getTypeIdentifier(javaType, typeInfoAnnotation);
+    private ObjectNode createSubtypeDefinition(ResolvedType javaType, JsonTypeInfo typeInfoAnnotation, JsonSubTypes subTypesAnnotation,
+            ObjectNode attributesToInclude, SchemaGenerationContext context) {
+        final String typeIdentifier = this.getTypeIdentifier(javaType, typeInfoAnnotation, subTypesAnnotation);
         if (typeIdentifier == null) {
             return null;
         }

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolverCustomDefinitionsTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolverCustomDefinitionsTest.java
@@ -75,7 +75,8 @@ public class JsonSubTypesResolverCustomDefinitionsTest extends AbstractTypeAware
         return new Object[][]{
             {TestClassWithSuperTypeReferences.class, null},
             {TestSuperClassWithNameProperty.class, null},
-            {TestSubClass1.class, "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_1\"}}}]}"}
+            {TestSubClass1.class, "{\"allOf\":[{},"
+                + "{\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_1\"}},\"required\":[\"@type\"]}]}"}
         };
     }
 
@@ -95,15 +96,18 @@ public class JsonSubTypesResolverCustomDefinitionsTest extends AbstractTypeAware
             {"superTypeWithAnnotationOnField", null, null},
             {"superTypeWithAnnotationOnField", TestSubClass1.class,
                 "{\"allOf\":[{},{\"title\":\"property attribute\",\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
-                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass1\"}}}]}"},
+                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass1\"}},"
+                + "\"required\":[\"fullClass\"]}]}"},
             {"superTypeWithAnnotationOnField", TestSubClass2.class,
                 "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
-                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass2\"}}}]}"},
+                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass2\"}},"
+                + "\"required\":[\"fullClass\"]}]}"},
             {"superTypeWithAnnotationOnGetter", null, null},
             {"superTypeWithAnnotationOnGetter", TestSubClass1.class,
-                "{\"allOf\":[{},{\"title\":\"property attribute\",\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_1\"}}}]}"},
+                "{\"allOf\":[{},{\"title\":\"property attribute\",\"type\":\"object\","
+                + "\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_1\"}},\"required\":[\"@type\"]}]}"},
             {"superTypeWithAnnotationOnGetter", TestSubClass2.class,
-                "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_2\"}}}]}"},
+                "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_2\"}},\"required\":[\"@type\"]}]}"},
             {"superTypeWithAnnotationOnFieldAndGetter", null, null},
             {"superTypeWithAnnotationOnFieldAndGetter", TestSubClass1.class,
                 "{\"type\":\"array\",\"items\":[{\"type\":\"string\",\"const\":"
@@ -115,10 +119,12 @@ public class JsonSubTypesResolverCustomDefinitionsTest extends AbstractTypeAware
             {"superInterfaceWithAnnotationOnField", null, null},
             {"superInterfaceWithAnnotationOnField", TestSubClass3.class,
                 "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
-                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass3\"}}}]}"},
+                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass3\"}},"
+                + "\"required\":[\"fullClass\"]}]}"},
             {"superInterfaceWithAnnotationOnField", TestSubClass4.class,
                 "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
-                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass4\"}}}]}"}
+                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass4\"}},"
+                + "\"required\":[\"fullClass\"]}]}"}
         };
     }
 
@@ -142,20 +148,24 @@ public class JsonSubTypesResolverCustomDefinitionsTest extends AbstractTypeAware
             {"getSuperTypeWithAnnotationOnField", null, null},
             {"getSuperTypeWithAnnotationOnField", TestSubClass1.class,
                 "{\"allOf\":[{},{\"title\":\"property attribute\",\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
-                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass1\"}}}]}"},
+                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass1\"}},"
+                + "\"required\":[\"fullClass\"]}]}"},
             {"getSuperTypeWithAnnotationOnField", TestSubClass2.class,
                 "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"fullClass\":{\"const\":"
-                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass2\"}}}]}"},
+                + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass2\"}},"
+                + "\"required\":[\"fullClass\"]}]}"},
             {"getSuperTypeWithAnnotationOnGetter", null, null},
             {"getSuperTypeWithAnnotationOnGetter", TestSubClass1.class,
-                "{\"allOf\":[{},{\"title\":\"property attribute\",\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_1\"}}}]}"},
+                "{\"allOf\":[{},{\"title\":\"property attribute\",\"type\":\"object\","
+                + "\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_1\"}},\"required\":[\"@type\"]}]}"},
             {"getSuperTypeWithAnnotationOnGetter", TestSubClass2.class,
-                "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_2\"}}}]}"},
+                "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_2\"}},\"required\":[\"@type\"]}]}"},
             {"getSuperTypeWithAnnotationOnFieldAndGetter", null, null},
             {"getSuperTypeWithAnnotationOnFieldAndGetter", TestSubClass1.class,
-                "{\"type\":\"object\",\"properties\":{\"SUB_CLASS_1\":{\"allOf\":[{},{\"title\":\"property attribute\"}]}}}"},
+                "{\"type\":\"object\",\"properties\":{\"SUB_CLASS_1\":{\"allOf\":[{},{\"title\":\"property attribute\"}]}},"
+                + "\"required\":[\"SUB_CLASS_1\"]}"},
             {"getSuperTypeWithAnnotationOnFieldAndGetter", TestSubClass2.class,
-                "{\"type\":\"object\",\"properties\":{\"SUB_CLASS_2\":{}}}"}
+                "{\"type\":\"object\",\"properties\":{\"SUB_CLASS_2\":{}},\"required\":[\"SUB_CLASS_2\"]}"}
         };
     }
 

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionFromInterfaceIntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionFromInterfaceIntegrationTest.java
@@ -116,7 +116,7 @@ public class SubtypeResolutionFromInterfaceIntegrationTest {
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
     @JsonSubTypes({
-        @JsonSubTypes.Type(value = TestSubClassWithTypeNameAnnotation.class, name = "SubClass1"),
+        @JsonSubTypes.Type(value = TestSubClassWithTypeNameAnnotation.class),
         @JsonSubTypes.Type(value = TestSubClass2.class, name = "SubClass2"),
         @JsonSubTypes.Type(value = TestSubClass3.class, name = "SubClass3")
     })
@@ -126,7 +126,6 @@ public class SubtypeResolutionFromInterfaceIntegrationTest {
     @JsonTypeName("AnnotatedSubTypeName")
     private static class TestSubClassWithTypeNameAnnotation implements TestSuperInterface {
 
-        public String typeString;
         public List<TestSubClass2> directSubClass2;
 
         TestSubClassWithTypeNameAnnotation(TestSubClass2... directSubClass2) {
@@ -136,32 +135,28 @@ public class SubtypeResolutionFromInterfaceIntegrationTest {
 
     private static class TestSubClass2 implements TestSuperInterface {
 
-        public String typeString;
-        @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "typeString")
+        @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "typeString")
         @JsonSubTypes({
             @JsonSubTypes.Type(value = TestSubClassWithTypeNameAnnotation.class, name = "Sub1"),
             @JsonSubTypes.Type(value = TestSubClass3.class, name = "Sub3")
         })
-        public TestSuperInterface superClassViaExistingProperty;
+        public TestSuperInterface superClassViaProperty;
 
         public TestSubClass2() {
-            this.superClassViaExistingProperty = null;
+            this.superClassViaProperty = null;
         }
 
-        public TestSubClass2(TestSubClassWithTypeNameAnnotation superClassViaExistingProperty) {
-            this.superClassViaExistingProperty = superClassViaExistingProperty;
-            superClassViaExistingProperty.typeString = "Sub1";
+        public TestSubClass2(TestSubClassWithTypeNameAnnotation superClassViaProperty) {
+            this.superClassViaProperty = superClassViaProperty;
         }
 
-        public TestSubClass2(TestSubClass3 superClassViaExistingProperty) {
-            this.superClassViaExistingProperty = superClassViaExistingProperty;
-            superClassViaExistingProperty.typeString = "Sub3";
+        public TestSubClass2(TestSubClass3 superClassViaProperty) {
+            this.superClassViaProperty = superClassViaProperty;
         }
     }
 
     private static class TestSubClass3 implements TestSuperInterface {
 
-        public String typeString;
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
         public TestSubClass3 recursiveSubClass3;
 

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionIntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionIntegrationTest.java
@@ -84,7 +84,6 @@ public class SubtypeResolutionIntegrationTest {
         }
         String fileAsString = stringBuilder.toString();
         return fileAsString;
-
     }
 
     private static class TestClassForSubtypeResolution {
@@ -122,7 +121,6 @@ public class SubtypeResolutionIntegrationTest {
     })
     private static class TestSuperClass {
 
-        public String typeString;
     }
 
     @JsonTypeName("AnnotatedSubTypeName")
@@ -137,25 +135,23 @@ public class SubtypeResolutionIntegrationTest {
 
     private static class TestSubClass2 extends TestSuperClass {
 
-        @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "typeString")
+        @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "typeString")
         @JsonSubTypes({
             @JsonSubTypes.Type(value = TestSubClassWithTypeNameAnnotation.class, name = "Sub1"),
             @JsonSubTypes.Type(value = TestSubClass3.class, name = "Sub3")
         })
-        public TestSuperClass superClassViaExistingProperty;
+        public TestSuperClass superClassViaProperty;
 
         public TestSubClass2() {
-            this.superClassViaExistingProperty = null;
+            this.superClassViaProperty = null;
         }
 
-        public TestSubClass2(TestSubClassWithTypeNameAnnotation superClassViaExistingProperty) {
-            this.superClassViaExistingProperty = superClassViaExistingProperty;
-            this.superClassViaExistingProperty.typeString = "Sub1";
+        public TestSubClass2(TestSubClassWithTypeNameAnnotation superClassViaProperty) {
+            this.superClassViaProperty = superClassViaProperty;
         }
 
-        public TestSubClass2(TestSubClass3 superClassViaExistingProperty) {
-            this.superClassViaExistingProperty = superClassViaExistingProperty;
-            this.superClassViaExistingProperty.typeString = "Sub3";
+        public TestSubClass2(TestSubClass3 superClassViaProperty) {
+            this.superClassViaProperty = superClassViaProperty;
         }
     }
 

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-integration-test-result.json
@@ -14,7 +14,8 @@
                                 "typeString": {
                                     "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionIntegrationTest$TestSubClassWithTypeNameAnnotation"
                                 }
-                            }
+                            },
+                            "required": ["typeString"]
                         }, {
                             "$ref": "#/$defs/TestSubClass3-1",
                             "type": "object",
@@ -22,7 +23,8 @@
                                 "typeString": {
                                     "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionIntegrationTest$TestSubClass3"
                                 }
-                            }
+                            },
+                            "required": ["typeString"]
                         }]
                 }
             }
@@ -33,7 +35,8 @@
                 "SubClass2": {
                     "$ref": "#/$defs/TestSubClass2-1"
                 }
-            }
+            },
+            "required": ["SubClass2"]
         },
         "TestSubClass3-1": {
             "type": "object",
@@ -48,7 +51,8 @@
                                 "@type": {
                                     "const": "SubtypeResolutionIntegrationTest$TestSubClass3"
                                 }
-                            }
+                            },
+                            "required": ["@type"]
                         }]
                 }
             }
@@ -59,7 +63,8 @@
                 "SubClass3": {
                     "$ref": "#/$defs/TestSubClass3-1"
                 }
-            }
+            },
+            "required": ["SubClass3"]
         },
         "TestSubClassWithTypeNameAnnotation-1": {
             "type": "object",
@@ -78,7 +83,8 @@
                 "SubClass1": {
                     "$ref": "#/$defs/TestSubClassWithTypeNameAnnotation-1"
                 }
-            }
+            },
+            "required": ["SubClass1"]
         }
     },
     "type": "object",

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-integration-test-result.json
@@ -4,7 +4,7 @@
         "TestSubClass2-1": {
             "type": "object",
             "properties": {
-                "superClassViaExistingProperty": {
+                "superClassViaProperty": {
                     "anyOf": [{
                             "type": "null"
                         }, {
@@ -24,16 +24,13 @@
                                 }
                             }
                         }]
-                },
-                "typeString": {
-                    "type": ["string", "null"]
                 }
             }
         },
         "TestSubClass2-2": {
             "type": "object",
             "properties": {
-                "SubtypeResolutionIntegrationTest$TestSubClass2": {
+                "SubClass2": {
                     "$ref": "#/$defs/TestSubClass2-1"
                 }
             }
@@ -53,16 +50,13 @@
                                 }
                             }
                         }]
-                },
-                "typeString": {
-                    "type": ["string", "null"]
                 }
             }
         },
         "TestSubClass3-2": {
             "type": "object",
             "properties": {
-                "SubtypeResolutionIntegrationTest$TestSubClass3": {
+                "SubClass3": {
                     "$ref": "#/$defs/TestSubClass3-1"
                 }
             }
@@ -75,16 +69,13 @@
                     "items": {
                         "$ref": "#/$defs/TestSubClass2-2"
                     }
-                },
-                "typeString": {
-                    "type": ["string", "null"]
                 }
             }
         },
         "TestSubClassWithTypeNameAnnotation-2": {
             "type": "object",
             "properties": {
-                "AnnotatedSubTypeName": {
+                "SubClass1": {
                     "$ref": "#/$defs/TestSubClassWithTypeNameAnnotation-1"
                 }
             }

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-interface-integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-interface-integration-test-result.json
@@ -14,7 +14,8 @@
                                 "typeString": {
                                     "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionFromInterfaceIntegrationTest$TestSubClassWithTypeNameAnnotation"
                                 }
-                            }
+                            },
+                            "required": ["typeString"]
                         }, {
                             "$ref": "#/$defs/TestSubClass3-1",
                             "type": "object",
@@ -22,7 +23,8 @@
                                 "typeString": {
                                     "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass3"
                                 }
-                            }
+                            },
+                            "required": ["typeString"]
                         }]
                 }
             }
@@ -33,7 +35,8 @@
                 "SubClass2": {
                     "$ref": "#/$defs/TestSubClass2-1"
                 }
-            }
+            },
+            "required": ["SubClass2"]
         },
         "TestSubClass3-1": {
             "type": "object",
@@ -48,7 +51,8 @@
                                 "@type": {
                                     "const": "SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass3"
                                 }
-                            }
+                            },
+                            "required": ["@type"]
                         }]
                 }
             }
@@ -59,7 +63,8 @@
                 "SubClass3": {
                     "$ref": "#/$defs/TestSubClass3-1"
                 }
-            }
+            },
+            "required": ["SubClass3"]
         },
         "TestSubClassWithTypeNameAnnotation-1": {
             "type": "object",
@@ -78,7 +83,8 @@
                 "AnnotatedSubTypeName": {
                     "$ref": "#/$defs/TestSubClassWithTypeNameAnnotation-1"
                 }
-            }
+            },
+            "required": ["AnnotatedSubTypeName"]
         }
     },
     "type": "object",

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-interface-integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-interface-integration-test-result.json
@@ -4,7 +4,7 @@
         "TestSubClass2-1": {
             "type": "object",
             "properties": {
-                "superClassViaExistingProperty": {
+                "superClassViaProperty": {
                     "anyOf": [{
                             "type": "null"
                         }, {
@@ -24,16 +24,13 @@
                                 }
                             }
                         }]
-                },
-                "typeString": {
-                    "type": ["string", "null"]
                 }
             }
         },
         "TestSubClass2-2": {
             "type": "object",
             "properties": {
-                "SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass2": {
+                "SubClass2": {
                     "$ref": "#/$defs/TestSubClass2-1"
                 }
             }
@@ -53,16 +50,13 @@
                                 }
                             }
                         }]
-                },
-                "typeString": {
-                    "type": ["string", "null"]
                 }
             }
         },
         "TestSubClass3-2": {
             "type": "object",
             "properties": {
-                "SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass3": {
+                "SubClass3": {
                     "$ref": "#/$defs/TestSubClass3-1"
                 }
             }
@@ -75,9 +69,6 @@
                     "items": {
                         "$ref": "#/$defs/TestSubClass2-2"
                     }
-                },
-                "typeString": {
-                    "type": ["string", "null"]
                 }
             }
         },


### PR DESCRIPTION
According to the Jackson Documentation the [JsonSubTypes.Type](http://fasterxml.github.io/jackson-annotations/javadoc/2.13/com/fasterxml/jackson/annotation/JsonSubTypes.Type.html)) values inside a `@JsonSubTypes` annotation are:
> Definition of a subtype, along with optional name(s). If no name is defined (empty Strings are ignored), class of the type will be checked for [JsonTypeName](http://fasterxml.github.io/jackson-annotations/javadoc/2.13/com/fasterxml/jackson/annotation/JsonTypeName.html) annotation; and if that is also missing or empty, a default name will be constructed by type id mechanism. Default name is usually based on class name.

I.e. it should be:
1. `@JsonSubTypes.value[].name` if present and not empty (on supertype or respective property)
2. `@JsonTypeName.name` if present and not empty (on subtype)
3. generated name based on subtype's class name

However, the existing behavior up until version 4.22.0 has been:
1. `@JsonTypeName.name` if present and not empty (on subtype)
2. generated name based on subtype's class name

**The `@JsonSubTypes.value[].name` needs to be considered correctly!**

Additionally, the reason for this slipping through needs to be addressed:
- issue: When the wrong discriminator was included in schema, the subtype's schema definition was effectively ignored as the "real" subtype instance in a given JSON would be deemed an "additional property"
- solution: mark the discriminator value as `"required"` and thereby ensure that it is not simply omitted.
- considered but discarded: at least for the `WRAPPER_OBJECT` strategy, one could go a step further and declare `"additionalProperties": false` but I'd rather avoid that in the interest of extensibility – and it doesn't seem worth adding another `JacksonOption` for that.