### PR TITLE
Support jackson subtype property override with JsonTypeInfo.Id.NONE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-module-jackson`
+#### Added
+- Support for sub type resolution on properties with `JsonTypeInfo.Id.NONE` override avoiding the default wrapping/modification
 
 ## [4.23.0] - 2022-03-13
 ### `jsonschema-generator-bom`

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
@@ -132,8 +132,15 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
         }
         JsonTypeInfo typeInfoAnnotation = scope.getAnnotationConsideringFieldAndGetter(JsonTypeInfo.class);
         if (typeInfoAnnotation == null) {
-            // neither of the two annotations is overriding the per-type behaviour, i.e., no need for inline custom property schema
+            // the normal per-type behaviour is not being overridden, i.e., no need for an inline custom property schema
             return null;
+        }
+        if (typeInfoAnnotation.use() == JsonTypeInfo.Id.NONE) {
+            ObjectNode definition = context.getGeneratorConfig().createObjectNode();
+            // wrap reference into "allOf" in order to force correct handling, in case the field/method being nullable
+            definition.withArray(context.getKeyword(SchemaKeyword.TAG_ALLOF))
+                    .add(context.createStandardDefinitionReference(scope.getType(), this));
+            return new CustomPropertyDefinition(definition, CustomDefinition.AttributeInclusion.YES);
         }
         ObjectNode attributes;
         if (scope instanceof FieldScope) {

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionIntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionIntegrationTest.java
@@ -127,9 +127,16 @@ public class SubtypeResolutionIntegrationTest {
     private static class TestSubClassWithTypeNameAnnotation extends TestSuperClass {
 
         public List<TestSubClass2> directSubClass2;
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NONE)
+        public TestSubClass2 unwrappedSubClass2;
 
         TestSubClassWithTypeNameAnnotation(TestSubClass2... directSubClass2) {
             this.directSubClass2 = Arrays.asList(directSubClass2);
+            if (this.directSubClass2.isEmpty()) {
+                this.unwrappedSubClass2 = null;
+            } else {
+                this.unwrappedSubClass2 = directSubClass2[0];
+            }
         }
     }
 

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-integration-test-result.json
@@ -74,6 +74,13 @@
                     "items": {
                         "$ref": "#/$defs/TestSubClass2-2"
                     }
+                },
+                "unwrappedSubClass2": {
+                    "anyOf": [{
+                            "type": "null"
+                        }, {
+                            "$ref": "#/$defs/TestSubClass2-1"
+                        }]
                 }
             }
         },


### PR DESCRIPTION
Jackson supports adding a `@JsonTypeInfo(use = JsonTypeInfo.Id.NONE)` annotation on a property, in order to avoid the "normal" wrapping/modification being applied by the combination of `@JsonTypeInfo` and `@JsonSubTypes`.

This should be supported by the `JacksonModule` accordingly.

Closes #165.