### PR TITLE
chore(fix): Jackson @JsonPropertyOrder should be considered only on target type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-module-jackson`
+#### Fixed
+-  `@JsonPropertyOrder` is only considered on the targeted type, i.e., no attempt is made to respect a super type's property order
 
 ## [4.24.2]
 ### `jsonschema-generator-bom`

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonPropertySorter.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonPropertySorter.java
@@ -16,6 +16,7 @@
 
 package com.github.victools.jsonschema.module.jackson;
 
+import com.fasterxml.classmate.members.HierarchicType;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.github.victools.jsonschema.generator.MemberScope;
 import com.github.victools.jsonschema.generator.MethodScope;
@@ -69,8 +70,9 @@ public class JsonPropertySorter implements Comparator<MemberScope<?, ?>> {
      * @return specific property index or {@link Integer#MAX_VALUE}
      */
     protected int getPropertyIndex(MemberScope<?, ?> property) {
+        HierarchicType topMostHierarchyType = property.getDeclaringTypeMembers().allTypesAndOverrides().get(0);
         List<String> sortedProperties = this.propertyOrderPerDeclaringType
-                .computeIfAbsent(property.getDeclaringType().getErasedType(), this::getAnnotatedPropertyOrder);
+                .computeIfAbsent(topMostHierarchyType.getErasedType(), this::getAnnotatedPropertyOrder);
         String fieldName;
         if (property instanceof MethodScope) {
             fieldName = Optional.ofNullable(((MethodScope) property).findGetterField()).map(MemberScope::getSchemaPropertyName).orElse(null);

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonPropertySorterTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonPropertySorterTest.java
@@ -67,14 +67,12 @@ public class JsonPropertySorterTest extends AbstractTypeAwareTest {
     }
 
     @JsonPropertyOrder(value = {"a", "c", "e", "b", "f"}, alphabetic = true)
-    private static class AnnotatedTestClass {
+    private static class AnnotatedTestClass extends TestSuperClass {
 
         private char x;
         private String a;
         private int b;
-        private long c;
         private Boolean d;
-        private Object e;
         private double f;
 
         public char getX() {
@@ -89,20 +87,26 @@ public class JsonPropertySorterTest extends AbstractTypeAwareTest {
             return this.b;
         }
 
-        public long getC() {
-            return this.c;
-        }
-
         public Boolean getD() {
             return this.d;
         }
 
-        public Object getE() {
-            return this.e;
-        }
-
         public double getF() {
             return this.f;
+        }
+    }
+
+    private static class TestSuperClass {
+
+        private Object e;
+        private long c;
+
+        public long getC() {
+            return this.c;
+        }
+
+        public Object getE() {
+            return this.e;
         }
     }
 }


### PR DESCRIPTION
As per description on #243:
> In the super class all field index values are MAX integer. So when generating the schema it reads incorrectly the field index value from two different indexes so the values are in no way comparable.
> 
> The sub class order should completely override the super class order and the super class order in [its] entirety [should] be ignored. Super class order should only be used when the super class is the schema root entity.

Closes #243.