### PR TITLE
chore: fix javadoc with Java 9 and later

### DIFF
--- a/jsonschema-generator-parent/pom.xml
+++ b/jsonschema-generator-parent/pom.xml
@@ -295,7 +295,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.4.0</version>
                     <configuration>
                         <source>${maven.compiler.source}</source>
                     </configuration>


### PR DESCRIPTION
The javadoc path varies between Java 8 and 11, the Java 8 one having an
extra `jre` directory in the pathname:

Java 8:

  $ /usr/lib/jvm/java-8-openjdk-amd64/bin/java \
    -XshowSettings:properties -version 2>&1|grep java.home
   java.home = /usr/lib/jvm/java-8-openjdk-amd64/jre

Java 11

  $ /usr/lib/jvm/java-11-openjdk-amd64/bin/java \
    -XshowSettings:properties -version 2>&1|grep java.home
   java.home = /usr/lib/jvm/java-11-openjdk-amd64

Set javadocExecutable via Maven profiles which activate based on the JDK
version being used.

That fixes the build under Java 11 when `JAVA_HOME` is not set.