### PR TITLE
fix: subtype resolution with single result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - new `Option.FLATTENED_SUPPLIERS` to unwrap the supplied type; `Supplier<T>` would thus be a type `T`
 
 #### Fixed
+- when resolving subtypes with a single other type, under some circumstances the type definition gets lost
 - set default `ObjectMapper` node factory to `JsonNodeFactory.withExactBigDecimals(true)` to avoid scientific notation for numbers
 
 #### Changed

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImpl.java
@@ -332,14 +332,10 @@ public class SchemaGenerationContextImpl implements SchemaGenerationContext {
             this.generateObjectDefinition(targetType, definition);
             return false;
         }
-        if (subtypes.size() == 1) {
-            // avoid unnecessary "anyOf" by making the definition a direct reference to the subtype's definition
-            this.traverseGenericType(subtypes.get(0), definition, false);
-        } else {
-            ArrayNode anyOfArrayNode = this.generatorConfig.createArrayNode();
-            subtypes.forEach(subtype -> this.traverseGenericType(subtype, anyOfArrayNode.addObject(), false));
-            definition.set(this.getKeyword(SchemaKeyword.TAG_ANYOF), anyOfArrayNode);
-        }
+        // always wrap subtype definitions, in order to avoid pointing at the same definition node as the super type
+        SchemaKeyword arrayNodeName = subtypes.size() == 1 ? SchemaKeyword.TAG_ALLOF : SchemaKeyword.TAG_ANYOF;
+        ArrayNode subtypeDefinitionArrayNode = definition.withArray(this.getKeyword(arrayNodeName));
+        subtypes.forEach(subtype -> this.traverseGenericType(subtype, subtypeDefinitionArrayNode.addObject(), false));
         return true;
     }
 

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/impl/module/additional-property-with-subtype.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/impl/module/additional-property-with-subtype.json
@@ -1,0 +1,16 @@
+{
+  "type" : "object",
+  "properties" : {
+    "map" : {
+      "type" : "object",
+      "additionalProperties" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Although this was reported in the context of `additionalProperties` it is actually a general fix for the combination of the following conditions:
- A configured `SubtypeResolver` (standard/built-in or custom) returns a single subtype for some given supertype.
- The default logic for "schema inlining" is enabled (i.e., neither `Option.INLINE_ALL_SCHEMAS` nor ` Option.DEFINITIONS_FOR_ALL_OBJECTS` are  used)
- The supertype is only referenced once, i.e., gets replaced with its inline schema definition at the end of the generation process.

Closes #261.