### PR TITLE
Swagger2 Module: Support anyOf and oneOf on fields/methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [4.25.0] - 2022-06-24
 ### `jsonschema-generator`
 #### Added
@@ -602,6 +604,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Indicate a number's "exclusiveMaximum" according to `@DecimalMax` or `@Negative`
 
 
+[Unreleased]: https://github.com/victools/jsonschema-generator/compare/v4.25.0...HEAD
 [4.25.0]: https://github.com/victools/jsonschema-generator/compare/v4.24.3...v4.25.0
 [4.24.3]: https://github.com/victools/jsonschema-generator/compare/v4.24.2...v4.24.3
 [4.24.2]: https://github.com/victools/jsonschema-generator/compare/v4.24.1...v4.24.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-module-swagger-2`
+#### Added
+- support `@Schema.anyOf` and `@Schema.oneOf` on fields/methods
 
 ## [4.25.0] - 2022-06-24
 ### `jsonschema-generator`

--- a/jsonschema-generator-bom/pom.xml
+++ b/jsonschema-generator-bom/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.github.victools</groupId>
     <artifactId>jsonschema-generator-bom</artifactId>
-    <version>4.25.0</version>
+    <version>4.26.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -26,7 +26,7 @@
         <connection>scm:git:https://github.com/victools/jsonschema-generator.git</connection>
         <developerConnection>scm:git:https://github.com/victools/jsonschema-generator.git</developerConnection>
         <url>https://github.com/victools/jsonschema-generator</url>
-        <tag>v4.25.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <organization>

--- a/jsonschema-generator-parent/pom.xml
+++ b/jsonschema-generator-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-bom</artifactId>
-        <version>4.25.0</version>
+        <version>4.26.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-bom/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-generator-parent</artifactId>

--- a/jsonschema-generator/pom.xml
+++ b/jsonschema-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.25.0</version>
+        <version>4.26.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-generator</artifactId>

--- a/jsonschema-maven-plugin/pom.xml
+++ b/jsonschema-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.25.0</version>
+        <version>4.26.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-maven-plugin</artifactId>

--- a/jsonschema-module-jackson/pom.xml
+++ b/jsonschema-module-jackson/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.25.0</version>
+        <version>4.26.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-module-jackson</artifactId>

--- a/jsonschema-module-jakarta-validation/pom.xml
+++ b/jsonschema-module-jakarta-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.25.0</version>
+        <version>4.26.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-module-jakarta-validation</artifactId>

--- a/jsonschema-module-javax-validation/pom.xml
+++ b/jsonschema-module-javax-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.25.0</version>
+        <version>4.26.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-module-javax-validation</artifactId>

--- a/jsonschema-module-swagger-1.5/pom.xml
+++ b/jsonschema-module-swagger-1.5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.25.0</version>
+        <version>4.26.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-module-swagger-1.5</artifactId>

--- a/jsonschema-module-swagger-2/README.md
+++ b/jsonschema-module-swagger-2/README.md
@@ -16,26 +16,28 @@ Module for the [jsonschema-generator](../jsonschema-generator) – deriving JSON
 10. From `@Schema(name = …)` on fields/methods, override property names.
 11. From `@Schema(ref = …)` on fields/methods, replace subschema with `"$ref"` to external/separate schema.
 12. From `@Schema(allOf = …)` on fields/methods, include `"allOf"` parts.
-13. From `@Schema(not = …)` on fields/methods, include the indicated `"not"` subschema.
-14. From `@Schema(required = true)` on fields/methods, mark property as `"required"` in the schema containing the property.
-15. From `@Schema(requiredProperties = …)` on fields/methods, derive its `"required"` properties.
-16. From `@Schema(minProperties = …)` on fields/methods, derive its `"minProperties"`.
-17. From `@Schema(maxProperties = …)` on fields/methods, derive its `"maxProperties"`.
-18. From `@Schema(nullable = true)` on fields/methods, include `null` in its `"type"`.
-19. From `@Schema(allowableValues = …)` on fields/methods, derive its `"const"`/`"enum"`.
-20. From `@Schema(defaultValue = …)` on fields/methods, derive its `"default"`.
-21. From `@Schema(accessMode = AccessMode.READ_ONLY)` on fields/methods, to mark them as `"readOnly"`.
-22. From `@Schema(accessMode = AccessMode.WRITE_ONLY)` on fields/methods, to mark them as `"writeOnly"`.
-23. From `@Schema(minLength = …)` on fields/methods, derive its `"minLength"`.
-24. From `@Schema(maxLength = …)` on fields/methods, derive its `"maxLength"`.
-25. From `@Schema(format = …)` on fields/methods, derive its `"format"`.
-26. From `@Schema(pattern = …)` on fields/methods, derive its `"pattern"`.
-27. From `@Schema(multipleOf = …)` on fields/methods, derive its `"multipleOf"`.
-28. From `@Schema(minimum = …, exclusiveMinimum = …)` on fields/methods, derive its `"minimum"`/`"exclusiveMinimum"`.
-29. From `@Schema(maximum = …, exclusiveMaximum = …)` on fields/methods, derive its `"maximum"`/`"exclusiveMaximum"`.
-30. From `@ArraySchema(minItems = …)` on fields/methods, derive its `"minItems"`.
-31. From `@ArraySchema(maxItems = …)` on fields/methods, derive its `"maxItems"`.
-32. From `@ArraySchema(uniqueItems = …)` on fields/methods, derive its `"uniqueItems"`.
+13. From `@Schema(anyOf = …)` on fields/methods, include `"anyOf"` parts.
+14. From `@Schema(oneOf = …)` on fields/methods, include `"oneOf"` parts.
+15. From `@Schema(not = …)` on fields/methods, include the indicated `"not"` subschema.
+16. From `@Schema(required = true)` on fields/methods, mark property as `"required"` in the schema containing the property.
+17. From `@Schema(requiredProperties = …)` on fields/methods, derive its `"required"` properties.
+18. From `@Schema(minProperties = …)` on fields/methods, derive its `"minProperties"`.
+19. From `@Schema(maxProperties = …)` on fields/methods, derive its `"maxProperties"`.
+20. From `@Schema(nullable = true)` on fields/methods, include `null` in its `"type"`.
+21. From `@Schema(allowableValues = …)` on fields/methods, derive its `"const"`/`"enum"`.
+22. From `@Schema(defaultValue = …)` on fields/methods, derive its `"default"`.
+23. From `@Schema(accessMode = AccessMode.READ_ONLY)` on fields/methods, to mark them as `"readOnly"`.
+24. From `@Schema(accessMode = AccessMode.WRITE_ONLY)` on fields/methods, to mark them as `"writeOnly"`.
+25. From `@Schema(minLength = …)` on fields/methods, derive its `"minLength"`.
+26. From `@Schema(maxLength = …)` on fields/methods, derive its `"maxLength"`.
+27. From `@Schema(format = …)` on fields/methods, derive its `"format"`.
+28. From `@Schema(pattern = …)` on fields/methods, derive its `"pattern"`.
+29. From `@Schema(multipleOf = …)` on fields/methods, derive its `"multipleOf"`.
+30. From `@Schema(minimum = …, exclusiveMinimum = …)` on fields/methods, derive its `"minimum"`/`"exclusiveMinimum"`.
+31. From `@Schema(maximum = …, exclusiveMaximum = …)` on fields/methods, derive its `"maximum"`/`"exclusiveMaximum"`.
+32. From `@ArraySchema(minItems = …)` on fields/methods, derive its `"minItems"`.
+33. From `@ArraySchema(maxItems = …)` on fields/methods, derive its `"maxItems"`.
+34. From `@ArraySchema(uniqueItems = …)` on fields/methods, derive its `"uniqueItems"`.
 
 Schema attributes derived from `@Schema` on fields are also applied to their respective getter methods.
 Schema attributes derived from `@Schema` on getter methods are also applied to their associated fields.

--- a/jsonschema-module-swagger-2/pom.xml
+++ b/jsonschema-module-swagger-2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.25.0</version>
+        <version>4.26.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-module-swagger-2</artifactId>

--- a/jsonschema-module-swagger-2/src/main/java/com/github/victools/jsonschema/module/swagger2/Swagger2Module.java
+++ b/jsonschema-module-swagger-2/src/main/java/com/github/victools/jsonschema/module/swagger2/Swagger2Module.java
@@ -432,10 +432,29 @@ public class Swagger2Module implements Module {
                     context.createDefinitionReference(context.getTypeContext().resolve(annotation.not())));
         }
         if (annotation.allOf().length > 0) {
+            ArrayNode allOfArray = memberAttributes.withArray(context.getKeyword(SchemaKeyword.TAG_ALLOF));
             Stream.of(annotation.allOf())
-                    .map(rawType -> context.getTypeContext().resolve(rawType))
-                    .map(context::createDefinitionReference).forEach(memberAttributes
-                    .withArray(context.getKeyword(SchemaKeyword.TAG_ALLOF))::add);
+                    .map(context.getTypeContext()::resolve)
+                    .map(context::createDefinitionReference)
+                    .forEach(allOfArray::add);
+        }
+        if (annotation.anyOf().length > 0) {
+            // since 4.26.0
+            ArrayNode allOfArray = memberAttributes.withArray(context.getKeyword(SchemaKeyword.TAG_ALLOF));
+            ArrayNode anyOfArray = allOfArray.addObject().withArray(context.getKeyword(SchemaKeyword.TAG_ANYOF));
+            Stream.of(annotation.anyOf())
+                    .map(context.getTypeContext()::resolve)
+                    .map(context::createDefinitionReference)
+                    .forEach(anyOfArray::add);
+        }
+        if (annotation.oneOf().length > 0) {
+            // since 4.26.0
+            ArrayNode allOfArray = memberAttributes.withArray(context.getKeyword(SchemaKeyword.TAG_ALLOF));
+            ArrayNode oneOfArray = allOfArray.addObject().withArray(context.getKeyword(SchemaKeyword.TAG_ONEOF));
+            Stream.of(annotation.oneOf())
+                    .map(context.getTypeContext()::resolve)
+                    .map(context::createDefinitionReference)
+                    .forEach(oneOfArray::add);
         }
         if (annotation.minProperties() > 0) {
             memberAttributes.put(context.getKeyword(SchemaKeyword.TAG_PROPERTIES_MIN), annotation.minProperties());

--- a/jsonschema-module-swagger-2/src/test/java/com/github/victools/jsonschema/module/swagger2/IntegrationTest.java
+++ b/jsonschema-module-swagger-2/src/test/java/com/github/victools/jsonschema/module/swagger2/IntegrationTest.java
@@ -132,5 +132,11 @@ public class IntegrationTest {
 
         @Schema(ref = "http://example.com/bar", accessMode = Schema.AccessMode.READ_ONLY)
         private Object bar;
+
+        @Schema(anyOf = {Double.class, Integer.class})
+        private Object anyOfDoubleOrInt;
+
+        @Schema(oneOf = {Boolean.class, String.class})
+        private Object oneOfBooleanOrString;
     }
 }

--- a/jsonschema-module-swagger-2/src/test/resources/com/github/victools/jsonschema/module/swagger2/integration-test-result-Foo.json
+++ b/jsonschema-module-swagger-2/src/test/resources/com/github/victools/jsonschema/module/swagger2/integration-test-result-Foo.json
@@ -15,9 +15,23 @@
     },
     "type": "object",
     "properties": {
+        "anyOfDoubleOrInt": {
+            "anyOf": [{
+                    "type": "number"
+                }, {
+                    "type": "integer"
+                }]
+        },
         "bar": {
             "$ref": "http://example.com/bar",
             "readOnly": true
+        },
+        "oneOfBooleanOrString": {
+            "oneOf": [{
+                    "type": "boolean"
+                }, {
+                    "type": "string"
+                }]
         },
         "person": {
             "$ref": "#/$defs/referenceToPerson",

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.victools</groupId>
     <artifactId>jsonschema-generator-reactor</artifactId>
-    <version>4.25.0</version>
+    <version>4.26.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Java JSON Schema Generator (Reactor)</name>

--- a/slate-docs/source/includes/_swagger-2-module.md
+++ b/slate-docs/source/includes/_swagger-2-module.md
@@ -24,26 +24,28 @@ SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(Sc
 10. From `@Schema(name = …)` on fields/methods, override property names.
 11. From `@Schema(ref = …)` on fields/methods, replace subschema with `"$ref"` to external/separate schema.
 12. From `@Schema(allOf = …)` on fields/methods, include `"allOf"` parts.
-13. From `@Schema(not = …)` on fields/methods, include the indicated `"not"` subschema.
-14. From `@Schema(required = true)` on fields/methods, mark property as `"required"` in the schema containing the property.
-15. From `@Schema(requiredProperties = …)` on fields/methods, derive its `"required"` properties.
-16. From `@Schema(minProperties = …)` on fields/methods, derive its `"minProperties"`.
-17. From `@Schema(maxProperties = …)` on fields/methods, derive its `"maxProperties"`.
-18. From `@Schema(nullable = true)` on fields/methods and potentially array items (if `Option.NULLABLE_ARRAY_ITEMS_ALLOWED` is enabled), include `null` in its `"type"`.
-19. From `@Schema(allowableValues = …)` on fields/methods, derive its `"const"`/`"enum"`.
-20. From `@Schema(defaultValue = …)` on fields/methods, derive its `"default"`.
-21. From `@Schema(accessMode = AccessMode.READ_ONLY)` on fields/methods, to mark them as `"readOnly"`.
-22. From `@Schema(accessMode = AccessMode.WRITE_ONLY)` on fields/methods, to mark them as `"writeOnly"`.
-23. From `@Schema(minLength = …)` on fields/methods, derive its `"minLength"`.
-24. From `@Schema(maxLength = …)` on fields/methods, derive its `"maxLength"`.
-25. From `@Schema(format = …)` on fields/methods, derive its `"format"`.
-26. From `@Schema(pattern = …)` on fields/methods, derive its `"pattern"`.
-27. From `@Schema(multipleOf = …)` on fields/methods, derive its `"multipleOf"`.
-28. From `@Schema(minimum = …, exclusiveMinimum = …)` on fields/methods, derive its `"minimum"`/`"exclusiveMinimum"`.
-29. From `@Schema(maximum = …, exclusiveMaximum = …)` on fields/methods, derive its `"maximum"`/`"exclusiveMaximum"`.
-30. From `@ArraySchema(minItems = …)` on fields/methods, derive its `"minItems"`.
-31. From `@ArraySchema(maxItems = …)` on fields/methods, derive its `"maxItems"`.
-32. From `@ArraySchema(uniqueItems = …)` on fields/methods, derive its `"uniqueItems"`.
+13. From `@Schema(anyOf = …)` on fields/methods, include `"anyOf"` parts.
+14. From `@Schema(oneOf = …)` on fields/methods, include `"oneOf"` parts.
+15. From `@Schema(not = …)` on fields/methods, include the indicated `"not"` subschema.
+16. From `@Schema(required = true)` on fields/methods, mark property as `"required"` in the schema containing the property.
+17. From `@Schema(requiredProperties = …)` on fields/methods, derive its `"required"` properties.
+18. From `@Schema(minProperties = …)` on fields/methods, derive its `"minProperties"`.
+19. From `@Schema(maxProperties = …)` on fields/methods, derive its `"maxProperties"`.
+20. From `@Schema(nullable = true)` on fields/methods, include `null` in its `"type"`.
+21. From `@Schema(allowableValues = …)` on fields/methods, derive its `"const"`/`"enum"`.
+22. From `@Schema(defaultValue = …)` on fields/methods, derive its `"default"`.
+23. From `@Schema(accessMode = AccessMode.READ_ONLY)` on fields/methods, to mark them as `"readOnly"`.
+24. From `@Schema(accessMode = AccessMode.WRITE_ONLY)` on fields/methods, to mark them as `"writeOnly"`.
+25. From `@Schema(minLength = …)` on fields/methods, derive its `"minLength"`.
+26. From `@Schema(maxLength = …)` on fields/methods, derive its `"maxLength"`.
+27. From `@Schema(format = …)` on fields/methods, derive its `"format"`.
+28. From `@Schema(pattern = …)` on fields/methods, derive its `"pattern"`.
+29. From `@Schema(multipleOf = …)` on fields/methods, derive its `"multipleOf"`.
+30. From `@Schema(minimum = …, exclusiveMinimum = …)` on fields/methods, derive its `"minimum"`/`"exclusiveMinimum"`.
+31. From `@Schema(maximum = …, exclusiveMaximum = …)` on fields/methods, derive its `"maximum"`/`"exclusiveMaximum"`.
+32. From `@ArraySchema(minItems = …)` on fields/methods, derive its `"minItems"`.
+33. From `@ArraySchema(maxItems = …)` on fields/methods, derive its `"maxItems"`.
+34. From `@ArraySchema(uniqueItems = …)` on fields/methods, derive its `"uniqueItems"`.
 
 Schema attributes derived from `@Schema`/`@ArraySchema` on fields are also applied to their respective getter methods.
 Schema attributes derived from `@Schema`/`@ArraySchema` on getter methods are also applied to their associated fields.


### PR DESCRIPTION
The `@Schema.allOf` is already supported out-of-the-box by the Swagger 2.0 Module.
Now adding similar support for the `@Schema.anyOf` and `@Schema.oneOf` respectively.

Answers #265.