### PR TITLE
feat: jackson module support @JsonTypeInfo.defaultImpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-module-jackson`
+#### Changed
+- support `@JsonTypeInfo.defaultImpl` in combination with `As.PROPERTY`, to no longer require the type property for the specified default subtype
+
 ### `jsonschema-module-swagger-2`
 #### Added
 - support `@Schema.anyOf` and `@Schema.oneOf` on fields/methods

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
@@ -308,8 +308,10 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
                     .with(context.getKeyword(SchemaKeyword.TAG_PROPERTIES))
                     .with(propertyName)
                     .put(context.getKeyword(SchemaKeyword.TAG_CONST), typeIdentifier);
-            additionalPart.withArray(context.getKeyword(SchemaKeyword.TAG_REQUIRED))
-                    .add(propertyName);
+            if (!javaType.getErasedType().equals(typeInfoAnnotation.defaultImpl())) {
+                additionalPart.withArray(context.getKeyword(SchemaKeyword.TAG_REQUIRED))
+                        .add(propertyName);
+            }
             break;
         default:
             return null;

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionIntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/SubtypeResolutionIntegrationTest.java
@@ -142,7 +142,7 @@ public class SubtypeResolutionIntegrationTest {
 
     private static class TestSubClass2 extends TestSuperClass {
 
-        @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "typeString")
+        @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "typeString", defaultImpl = TestSubClass3.class)
         @JsonSubTypes({
             @JsonSubTypes.Type(value = TestSubClassWithTypeNameAnnotation.class, name = "Sub1"),
             @JsonSubTypes.Type(value = TestSubClass3.class, name = "Sub3")

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-integration-test-result.json
@@ -23,8 +23,7 @@
                                 "typeString": {
                                     "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionIntegrationTest$TestSubClass3"
                                 }
-                            },
-                            "required": ["typeString"]
+                            }
                         }]
                 }
             }


### PR DESCRIPTION
When the Jackson module's built-in subtype resolution encounters a `@JsonTypeInfo´ annotation with the `defaultImpl` attribute on it, then that particular subtype is not required to include the designated type property.

From a schema point of view, the assumption is, that some other properties will make it distinct from different subtypes, in order to avoid "false positives" (e.g., another subtype where the type property was forgotten). That is then the responsibility of the schema creator.

Resolves #278, where this change was suggested by @eleftherias.