### PR TITLE
feat: maven module use classgraph instead of reflections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bump `swagger-annotations` compile dependency version from `2.1.2` to `2.2.3`
 - bump `swagger-core` compile dependency version from `2.1.2` to `2.2.3`
 
+### `jsonschema-maven-plugin`
+#### Changed
+- use `classgraph` dependency for classpath scanning determining entry points for schema generation
+
+#### Removed
+- allow non-public classes as entry points for schema generation
+- `reflections` dependency
+
 ## [4.27.0] - 2022-09-29
 ### `jsonschema-generator`
 #### Added

--- a/jsonschema-generator-parent/pom.xml
+++ b/jsonschema-generator-parent/pom.xml
@@ -127,9 +127,10 @@
         <!-- provided module dependencies -->
         <version.jakarta.validation>3.0.2</version.jakarta.validation>
         <version.javax.validation>2.0.1.Final</version.javax.validation>
-        <version.reflections>0.10.2</version.reflections>
         <version.swagger-1.5>1.6.7</version.swagger-1.5>
         <version.swagger-2>2.2.3</version.swagger-2>
+        <!-- maven plugin runtime dependencies -->
+        <version.classgraph>4.8.149</version.classgraph>
     </properties>
 
     <dependencyManagement>
@@ -172,9 +173,9 @@
                 <version>${version.swagger-2}</version>
             </dependency>
             <dependency>
-                <groupId>org.reflections</groupId>
-                <artifactId>reflections</artifactId>
-                <version>${version.reflections}</version>
+                <groupId>io.github.classgraph</groupId>
+                <artifactId>classgraph</artifactId>
+                <version>${version.classgraph}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/jsonschema-maven-plugin/pom.xml
+++ b/jsonschema-maven-plugin/pom.xml
@@ -67,8 +67,8 @@
             <artifactId>jsonschema-generator</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
         </dependency>
         <!-- Jackson Module dependencies -->
         <dependency>

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/ClasspathType.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/ClasspathType.java
@@ -45,24 +45,24 @@ public enum ClasspathType {
      */
     WITH_ALL_DEPENDENCIES;
 
-    public List<URL> getUrls(MavenProject project) {
-        Collection<String> classPathElements;
+    public Collection<String> getClasspathElements(MavenProject project) {
+        Collection<String> classpathElements;
         try {
             switch (this) {
             case PROJECT_ONLY:
-                classPathElements = Collections.singleton(project.getBuild().getOutputDirectory());
+                classpathElements = Collections.singleton(project.getBuild().getOutputDirectory());
                 break;
             case WITH_COMPILE_DEPENDENCIES:
-                classPathElements = project.getCompileClasspathElements();
+                classpathElements = project.getCompileClasspathElements();
                 break;
             case WITH_RUNTIME_DEPENDENCIES:
-                classPathElements = project.getRuntimeClasspathElements();
+                classpathElements = project.getRuntimeClasspathElements();
                 break;
             case WITH_ALL_DEPENDENCIES:
                 // to remove duplicates
-                classPathElements = new HashSet<>();
-                classPathElements.addAll(project.getRuntimeClasspathElements());
-                classPathElements.addAll(project.getCompileClasspathElements());
+                classpathElements = new HashSet<>();
+                classpathElements.addAll(project.getRuntimeClasspathElements());
+                classpathElements.addAll(project.getCompileClasspathElements());
                 break;
             default:
                 throw new IllegalArgumentException("ClasspathType " + this + " not supported");
@@ -70,9 +70,13 @@ public enum ClasspathType {
         } catch (DependencyResolutionRequiredException e) {
             throw new IllegalStateException("Failed to resolve classpathType elements", e);
         }
+        return classpathElements;
+    }
 
-        List<URL> urls = new ArrayList<>(classPathElements.size());
-        for (String element : classPathElements) {
+    public List<URL> getUrls(MavenProject project) {
+        Collection<String> classpathElements = this.getClasspathElements(project);
+        List<URL> urls = new ArrayList<>(classpathElements.size());
+        for (String element : classpathElements) {
             try {
                 urls.add(new File(element).toURI().toURL());
             } catch (MalformedURLException e) {

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/PotentialSchemaClass.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/PotentialSchemaClass.java
@@ -16,6 +16,8 @@
 
 package com.github.victools.jsonschema.plugin.maven;
 
+import io.github.classgraph.ClassInfo;
+
 /**
  * Wrapper for a class on the classpath for which a schema may be generated.
  */
@@ -26,13 +28,13 @@ public class PotentialSchemaClass implements Comparable<PotentialSchemaClass> {
     private boolean alreadyGenerated;
 
     /**
-     * Constructor expecting the full class name including its package path with "." as separators.
+     * Constructor expecting the collected class info for a single type.
      *
-     * @param fullClassName targeted class's full name
+     * @param classInfo targeted class's info
      */
-    public PotentialSchemaClass(String fullClassName) {
-        this.fullClassName = fullClassName;
-        this.absolutePathToMatch = fullClassName.replace('.', '/');
+    public PotentialSchemaClass(ClassInfo classInfo) {
+        this.fullClassName = classInfo.getName();
+        this.absolutePathToMatch = this.fullClassName.replace('.', '/');
         this.alreadyGenerated = false;
     }
 


### PR DESCRIPTION
Replacing outdated `reflections` library with up-to-date ´classgraph` dependency in the Maven plugin.

Side-effect: non-public types are no longer allowed as entry points for the schema generation – they are still considered within a generated schema though. Therefore this change is deemed acceptable and yields some performance improvement within the Maven plugin.