### PR TITLE
Advanced additional properties definition and improved allOf clean-up behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 - consider annotations on `Map` value types when using `Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES`
+- enhanced schema clean-up at the end: consolidating `allOf` with distinct `properties` (mostly relevant in jackson subtype resolution)
 - bump `slf4j-api` dependency version from `1.7.35` to `2.0.3`
 - bump `jackson-core` dependency version from `2.13.2` to `2.13.4`
 - bump `jackson-databind` dependency version from `2.13.2.2` to `2.13.4.2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### `jsonschema-generator`
+#### Added
+- enable look-up of annotations on a member's type parameter (e.g., a `Map`'s value type)
+- enable providing full custom schema definition to be included in `additionalProperties` or `patternProperties`
+
 #### Changed
 - bump `slf4j-api` dependency version from `1.7.35` to `2.0.3`
 - bump `jackson-core` dependency version from `2.13.2` to `2.13.4`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 - consider annotations on `Map` value types when using `Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES`
 - enhanced schema clean-up at the end: consolidating `allOf` with distinct `properties` (mostly relevant in jackson subtype resolution)
+- enhanced schema clean-up at the end: consolidating `allOf` even with some keywords being present with differing values
 - bump `slf4j-api` dependency version from `1.7.35` to `2.0.3`
 - bump `jackson-core` dependency version from `2.13.2` to `2.13.4`
 - bump `jackson-databind` dependency version from `2.13.2.2` to `2.13.4.2`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - enable providing full custom schema definition to be included in `additionalProperties` or `patternProperties`
 
 #### Changed
+- consider annotations on `Map` value types when using `Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES`
 - bump `slf4j-api` dependency version from `1.7.35` to `2.0.3`
 - bump `jackson-core` dependency version from `2.13.2` to `2.13.4`
 - bump `jackson-databind` dependency version from `2.13.2.2` to `2.13.4.2`

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
@@ -17,11 +17,11 @@
 package com.github.victools.jsonschema.generator;
 
 import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.victools.jsonschema.generator.naming.SchemaDefinitionNamingStrategy;
-import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
@@ -500,49 +500,55 @@ public interface SchemaGeneratorConfig {
      * Determine the "additionalProperties" of an object's field/property.
      *
      * @param field object's field/property to determine "additionalProperties" value for
+     * @param context generation context allowing to let the standard generation take over nested parts of the custom definition
      * @return "additionalProperties" in a JSON Schema (may be {@link Void}) to indicate no additional properties being allowed or may be null)
      */
-    Type resolveAdditionalProperties(FieldScope field);
+    JsonNode resolveAdditionalProperties(FieldScope field, SchemaGenerationContext context);
 
     /**
      * Determine the "additionalProperties" of a method's return value.
      *
      * @param method method for whose return value to determine "additionalProperties" value for
+     * @param context generation context allowing to let the standard generation take over nested parts of the custom definition
      * @return "additionalProperties" in a JSON Schema (may be {@link Void}) to indicate no additional properties being allowed or may be null)
      */
-    Type resolveAdditionalProperties(MethodScope method);
+    JsonNode resolveAdditionalProperties(MethodScope method, SchemaGenerationContext context);
 
     /**
      * Determine the "additionalProperties" of a context-independent type representation.
      *
      * @param scope context-independent type representation to determine "additionalProperties" value for
-     * @return "additionalProperties" in a JSON Schema (may be {@link Void}) to indicate no additional properties being allowed or may be null)
+     * @param context generation context allowing to let the standard generation take over nested parts of the custom definition
+     * @return "additionalProperties" in a JSON Schema (may be null)
      */
-    Type resolveAdditionalPropertiesForType(TypeScope scope);
+    JsonNode resolveAdditionalPropertiesForType(TypeScope scope, SchemaGenerationContext context);
 
     /**
      * Determine the "patternProperties" of an object's field/property.
      *
      * @param field object's field/property to determine "patternProperties" value for
+     * @param context generation context allowing to let the standard generation take over nested parts of the custom definition
      * @return "patternProperties" in a JSON Schema (may be null), the keys representing the patterns and the mapped values their corresponding types
      */
-    Map<String, Type> resolvePatternProperties(FieldScope field);
+    Map<String, JsonNode> resolvePatternProperties(FieldScope field, SchemaGenerationContext context);
 
     /**
      * Determine the "patternProperties" of a method's return value.
      *
      * @param method method for whose return value to determine "patternProperties" value for
+     * @param context generation context allowing to let the standard generation take over nested parts of the custom definition
      * @return "patternProperties" in a JSON Schema (may be null), the keys representing the patterns and the mapped values their corresponding types
      */
-    Map<String, Type> resolvePatternProperties(MethodScope method);
+    Map<String, JsonNode> resolvePatternProperties(MethodScope method, SchemaGenerationContext context);
 
     /**
      * Determine the "patternProperties" of a context-independent type representation.
      *
      * @param scope context-independent type representation to determine "patternProperties" value for
+     * @param context generation context allowing to let the standard generation take over nested parts of the custom definition
      * @return "patternProperties" in a JSON Schema (may be null), the keys representing the patterns and the mapped values their corresponding types
      */
-    Map<String, Type> resolvePatternPropertiesForType(TypeScope scope);
+    Map<String, JsonNode> resolvePatternPropertiesForType(TypeScope scope, SchemaGenerationContext context);
 
     /**
      * Determine the "minLength" of an object's field/property.

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigPart.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigPart.java
@@ -17,6 +17,7 @@
 package com.github.victools.jsonschema.generator;
 
 import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -311,7 +313,17 @@ public class SchemaGeneratorConfigPart<M extends MemberScope<?, ?>> extends Sche
     }
 
     @Override
+    public SchemaGeneratorConfigPart<M> withAdditionalPropertiesResolver(BiFunction<M, SchemaGenerationContext, JsonNode> resolver) {
+        return (SchemaGeneratorConfigPart<M>) super.withAdditionalPropertiesResolver(resolver);
+    }
+
+    @Override
     public SchemaGeneratorConfigPart<M> withPatternPropertiesResolver(ConfigFunction<M, Map<String, Type>> resolver) {
+        return (SchemaGeneratorConfigPart<M>) super.withPatternPropertiesResolver(resolver);
+    }
+
+    @Override
+    public SchemaGeneratorConfigPart<M> withPatternPropertiesResolver(BiFunction<M, SchemaGenerationContext, Map<String, JsonNode>> resolver) {
         return (SchemaGeneratorConfigPart<M>) super.withPatternPropertiesResolver(resolver);
     }
 

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorGeneralConfigPart.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorGeneralConfigPart.java
@@ -16,6 +16,7 @@
 
 package com.github.victools.jsonschema.generator;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.github.victools.jsonschema.generator.impl.PropertySortUtils;
 import com.github.victools.jsonschema.generator.naming.SchemaDefinitionNamingStrategy;
 import java.lang.reflect.Type;
@@ -26,6 +27,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 /**
  * Generic collection of reflection based analysis for populating a JSON Schema targeting a specific type in general.
@@ -214,7 +216,18 @@ public class SchemaGeneratorGeneralConfigPart extends SchemaGeneratorTypeConfigP
     }
 
     @Override
+    public SchemaGeneratorGeneralConfigPart withAdditionalPropertiesResolver(BiFunction<TypeScope, SchemaGenerationContext, JsonNode> resolver) {
+        return (SchemaGeneratorGeneralConfigPart) super.withAdditionalPropertiesResolver(resolver);
+    }
+
+    @Override
     public SchemaGeneratorGeneralConfigPart withPatternPropertiesResolver(ConfigFunction<TypeScope, Map<String, Type>> resolver) {
+        return (SchemaGeneratorGeneralConfigPart) super.withPatternPropertiesResolver(resolver);
+    }
+
+    @Override
+    public SchemaGeneratorGeneralConfigPart withPatternPropertiesResolver(
+            BiFunction<TypeScope, SchemaGenerationContext, Map<String, JsonNode>> resolver) {
         return (SchemaGeneratorGeneralConfigPart) super.withPatternPropertiesResolver(resolver);
     }
 

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/TypeContext.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/TypeContext.java
@@ -23,6 +23,9 @@ import com.fasterxml.classmate.ResolvedTypeWithMembers;
 import com.fasterxml.classmate.TypeResolver;
 import com.fasterxml.classmate.members.ResolvedField;
 import com.fasterxml.classmate.members.ResolvedMethod;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.List;
@@ -192,6 +195,27 @@ public class TypeContext {
             itemType = this.getTypeParameterFor(containerType, Iterable.class, 0);
         }
         return itemType;
+    }
+
+    /**
+     * Return the annotation of the given type from the annotated container's item, if such an annotation is present.
+     *
+     * @param <A> type of annotation
+     * @param annotationClass type of annotation
+     * @param annotatedContainerType annotated container type that is considered if it is an {@link AnnotatedParameterizedType}
+     * @param containerItemIndex parameter index of the desired item on the container type
+     * @return annotation instance (or {@code null} if no annotation of the given type is present)
+     */
+    public <A extends Annotation> A getTypeParameterAnnotation(Class<A> annotationClass, AnnotatedType annotatedContainerType,
+            Integer containerItemIndex) {
+        if (annotatedContainerType instanceof AnnotatedParameterizedType) {
+            AnnotatedType[] typeArguments = ((AnnotatedParameterizedType) annotatedContainerType).getAnnotatedActualTypeArguments();
+            int itemIndex = containerItemIndex == null ? 0 : containerItemIndex;
+            if (typeArguments.length > itemIndex) {
+                return typeArguments[itemIndex].getAnnotation(annotationClass);
+            }
+        }
+        return null;
     }
 
     /**

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
@@ -25,7 +25,6 @@ import com.github.victools.jsonschema.generator.SchemaKeyword;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -63,7 +62,7 @@ public class SchemaCleanUpUtils {
      */
     public void reduceAllOfNodes(List<ObjectNode> jsonSchemas) {
         String allOfTagName = this.config.getKeyword(SchemaKeyword.TAG_ALLOF);
-        Map<String, SchemaKeyword> reverseKeywordMap = EnumSet.allOf(SchemaKeyword.class).stream()
+        Map<String, SchemaKeyword> reverseKeywordMap = SchemaKeyword.getTagStream()
                 .collect(Collectors.toMap(this.config::getKeyword, keyword -> keyword));
         this.finaliseSchemaParts(jsonSchemas, nodeToCheck -> this.mergeAllOfPartsIfPossible(nodeToCheck, allOfTagName, reverseKeywordMap));
     }
@@ -175,75 +174,27 @@ public class SchemaCleanUpUtils {
         if (!(schemaNode instanceof ObjectNode)) {
             return;
         }
-        JsonNode allOfTag = schemaNode.get(allOfTagName);
+        ObjectNode schemaObjectNode = (ObjectNode) schemaNode;
+        JsonNode allOfTag = schemaObjectNode.get(allOfTagName);
         if (!(allOfTag instanceof ArrayNode)) {
             return;
         }
         allOfTag.forEach(part -> this.mergeAllOfPartsIfPossible(part, allOfTagName, reverseKeywordMap));
 
-        List<JsonNode> allOfElements = new ArrayList<>();
-        allOfTag.forEach(allOfElements::add);
-        if (allOfElements.stream().anyMatch(part -> !(part instanceof ObjectNode) && !part.asBoolean())) {
+        List<JsonNode> allParts = new ArrayList<>(1 + allOfTag.size());
+        allParts.add(schemaObjectNode);
+        allOfTag.forEach(allParts::add);
+        Supplier<ObjectNode> successfulMergeResultSupplier = this.mergeSchemas(schemaObjectNode, allParts, reverseKeywordMap);
+        if (successfulMergeResultSupplier == null) {
             return;
-        }
-        List<ObjectNode> parts = allOfElements.stream()
-                .filter(part -> part instanceof ObjectNode)
-                .map(part -> (ObjectNode) part)
-                .collect(Collectors.toList());
-
-        // collect all defined attributes from the separate parts and check whether there are incompatible differences
-        Map<String, List<JsonNode>> fieldsFromAllParts = Stream.concat(Stream.of(schemaNode), parts.stream())
-                .flatMap(part -> StreamSupport.stream(((Iterable<Map.Entry<String, JsonNode>>) () -> part.fields()).spliterator(), false))
-                .collect(Collectors.groupingBy(Map.Entry::getKey, LinkedHashMap::new, Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
-        if ((this.config.getSchemaVersion() == SchemaVersion.DRAFT_6 || this.config.getSchemaVersion() == SchemaVersion.DRAFT_7)
-                && fieldsFromAllParts.containsKey(this.config.getKeyword(SchemaKeyword.TAG_REF))
-                && (schemaNode.size() > 1 || parts.size() > 1)) {
-            // in Draft 7, any other attributes besides the $ref keyword were ignored
-            return;
-        }
-        Map<String, List<JsonNode>> unsupportedTagValues = fieldsFromAllParts.entrySet().stream()
-                .filter(entry -> !reverseKeywordMap.containsKey(entry.getKey()))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, throwingMerger(), LinkedHashMap::new));
-        if (unsupportedTagValues.entrySet().stream().anyMatch(entry -> entry.getValue().size() > 1)) {
-            // unsupported tag with more than one occurrence: be conservative and don't merge
-            return;
-        }
-        Map<SchemaKeyword, List<JsonNode>> supportedTagValues = fieldsFromAllParts.entrySet().stream()
-                .filter(entry -> !unsupportedTagValues.containsKey(entry.getKey()))
-                .collect(Collectors.toMap(entry -> reverseKeywordMap.get(entry.getKey()), Map.Entry::getValue, throwingMerger(), LinkedHashMap::new));
-        if (supportedTagValues.containsKey(SchemaKeyword.TAG_IF)) {
-                // "if"/"then"/"else" tags should remain isolated in their sub-schemas
-            return;
-        }
-        Map<SchemaKeyword, Supplier<JsonNode>> supportedTagValueSuppliers = new LinkedHashMap<>();
-        for (Map.Entry<SchemaKeyword, List<JsonNode>> fieldEntries : supportedTagValues.entrySet()) {
-            SchemaKeyword keyword = fieldEntries.getKey();
-            List<JsonNode> valuesToMerge = fieldEntries.getValue();
-            if (keyword == SchemaKeyword.TAG_ALLOF) {
-                // we can ignore the "allOf" tag in the target node (the one we are trying to remove here)
-                valuesToMerge = valuesToMerge.subList(1, valuesToMerge.size());
-                if (valuesToMerge.isEmpty()) {
-                    // no other "allOf" part left to merge
-                    continue;
-                }
-            }
-            Supplier<JsonNode> mergeResultSupplier = this.getAllOfMergeFunctionFor(keyword, valuesToMerge);
-            if (mergeResultSupplier == null) {
-                // unable to merge given values for the specified keyword; abort merge
-                return;
-            }
-            supportedTagValueSuppliers.put(keyword, mergeResultSupplier);
         }
         // all attributes are either distinct or have equal values in all occurrences
-        ObjectNode schemaObjectNode = (ObjectNode) schemaNode;
         schemaObjectNode.remove(allOfTagName);
-        // for the supported tags, there may be multiple occurrences that requiring individual merging
-        supportedTagValueSuppliers.forEach((keyword, valueSupplier) -> schemaObjectNode.set(this.config.getKeyword(keyword), valueSupplier.get()));
-        // for the unsupported tags, there is only a single occurrence each
-        unsupportedTagValues.forEach((tagName, valueList) -> schemaObjectNode.set(tagName, valueList.get(0)));
+        schemaObjectNode.setAll(successfulMergeResultSupplier.get());
     }
 
-    private Supplier<JsonNode> getAllOfMergeFunctionFor(SchemaKeyword keyword, List<JsonNode> valuesToMerge) {
+    private Supplier<? extends JsonNode> getAllOfMergeFunctionFor(SchemaKeyword keyword, List<JsonNode> valuesToMerge,
+            Map<String, SchemaKeyword> reverseKeywordMap) {
         if (valuesToMerge.size() == 1) {
             // no conflicts, no further checks
             return () -> valuesToMerge.get(0);
@@ -254,8 +205,23 @@ public class SchemaCleanUpUtils {
             return this.mergeArrays(valuesToMerge);
         case TAG_PROPERTIES:
             return this.mergeObjectProperties(valuesToMerge);
+        case TAG_ITEMS:
+        case TAG_ADDITIONAL_PROPERTIES:
+            return this.mergeSchemas(null, valuesToMerge, reverseKeywordMap);
         case TAG_TYPE:
             return this.returnOverlapOfStringsOrStringArrays(valuesToMerge);
+        case TAG_ITEMS_MAX:
+        case TAG_PROPERTIES_MAX:
+        case TAG_MAXIMUM:
+        case TAG_MAXIMUM_EXCLUSIVE:
+        case TAG_LENGTH_MAX:
+            return this.returnMinimumNumericValue(valuesToMerge);
+        case TAG_ITEMS_MIN:
+        case TAG_PROPERTIES_MIN:
+        case TAG_MINIMUM:
+        case TAG_MINIMUM_EXCLUSIVE:
+        case TAG_LENGTH_MIN:
+            return this.returnMaximumNumericValue(valuesToMerge);
         default:
             return this.returnOneIfAllEqual(valuesToMerge);
         }
@@ -295,6 +261,89 @@ public class SchemaCleanUpUtils {
             }
         }
         return () -> mergedObjectNode;
+    }
+
+    /**
+     * Determine whether a given list of sub-schema nodes can be merged into a single schema node. If yes, providing a supplier that performs the
+     * actual consolidation once called.
+     *
+     * @param mainNodeIncludingAllOf the node containing the "allOf" tag to be merged (may be {@code null} if all nodes have the same weight)
+     * @param nodes full list of nodes to consider merging (including optional "mainNodeIncludingAllOf")
+     * @param reverseKeywordMap look-up map from tag's name in given node to the known keyword it represents (passed in for improved performance)
+     * @return supplier of the successfully merged schemas (into a new node) or {@code null} if merging the given nodes is not easily possible
+     */
+    private Supplier<ObjectNode> mergeSchemas(ObjectNode mainNodeIncludingAllOf, List<JsonNode> nodes, Map<String, SchemaKeyword> reverseKeywordMap) {
+        if (nodes.stream().anyMatch(part -> !(part instanceof ObjectNode) && !(part.isBoolean() && part.asBoolean()))) {
+            return null;
+        }
+        List<ObjectNode> parts = nodes.stream()
+                .filter(part -> part instanceof ObjectNode)
+                .map(part -> (ObjectNode) part)
+                .collect(Collectors.toList());
+
+        // collect all defined attributes from the separate parts and check whether there are incompatible differences
+        Map<String, List<JsonNode>> fieldsFromAllParts = parts.stream()
+                .flatMap(part -> StreamSupport.stream(((Iterable<Map.Entry<String, JsonNode>>) () -> part.fields()).spliterator(), false))
+                .collect(Collectors.groupingBy(Map.Entry::getKey, LinkedHashMap::new, Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+        if ((this.config.getSchemaVersion() == SchemaVersion.DRAFT_6 || this.config.getSchemaVersion() == SchemaVersion.DRAFT_7)
+                && fieldsFromAllParts.containsKey(this.config.getKeyword(SchemaKeyword.TAG_REF))
+                && (mainNodeIncludingAllOf == null ? (parts.size() > 1) : (mainNodeIncludingAllOf.size() > 1 || parts.size() > 2))) {
+            // in Draft 7, any other attributes besides the $ref keyword were ignored
+            return null;
+        }
+        Map<String, List<JsonNode>> unsupportedTagValues = fieldsFromAllParts.entrySet().stream()
+                .filter(entry -> !reverseKeywordMap.containsKey(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, throwingMerger(), LinkedHashMap::new));
+        if (unsupportedTagValues.entrySet().stream().anyMatch(entry -> entry.getValue().size() > 1)) {
+            // unsupported tag with more than one occurrence: be conservative and don't merge
+            return null;
+        }
+        Map<SchemaKeyword, Supplier<? extends JsonNode>> supportedTagValueSuppliers = this.collectSupportedTagValueSuppliers(fieldsFromAllParts,
+                reverseKeywordMap, mainNodeIncludingAllOf);
+        if (supportedTagValueSuppliers == null) {
+            // unable to merge the values for some keyword; abort merge
+            return null;
+        }
+        // all attributes are either distinct or have equal values in all occurrences
+        return () -> {
+            ObjectNode mergedNode = this.config.createObjectNode();
+            // for the supported tags, there may be multiple occurrences that requiring individual merging
+            supportedTagValueSuppliers.forEach((keyword, valueSupplier) -> mergedNode.set(this.config.getKeyword(keyword), valueSupplier.get()));
+            // for the unsupported tags, there is only a single occurrence each
+            unsupportedTagValues.forEach((tagName, valueList) -> mergedNode.set(tagName, valueList.get(0)));
+            return mergedNode;
+        };
+    }
+
+    private Map<SchemaKeyword, Supplier<? extends JsonNode>> collectSupportedTagValueSuppliers(Map<String, List<JsonNode>> fieldsFromAllParts,
+            Map<String, SchemaKeyword> reverseKeywordMap, ObjectNode mainNodeIncludingAllOf) {
+        Map<SchemaKeyword, List<JsonNode>> supportedTagValues = fieldsFromAllParts.entrySet().stream()
+                .filter(entry -> reverseKeywordMap.containsKey(entry.getKey()))
+                .collect(Collectors.toMap(entry -> reverseKeywordMap.get(entry.getKey()), Map.Entry::getValue, throwingMerger(), LinkedHashMap::new));
+        if (supportedTagValues.containsKey(SchemaKeyword.TAG_IF)) {
+            // "if"/"then"/"else" tags should remain isolated in their sub-schemas
+            return null;
+        }
+        Map<SchemaKeyword, Supplier<? extends JsonNode>> supportedTagValueSuppliers = new LinkedHashMap<>();
+        for (Map.Entry<SchemaKeyword, List<JsonNode>> fieldEntries : supportedTagValues.entrySet()) {
+            SchemaKeyword keyword = fieldEntries.getKey();
+            List<JsonNode> valuesToMerge = fieldEntries.getValue();
+            if (keyword == SchemaKeyword.TAG_ALLOF && mainNodeIncludingAllOf != null) {
+                // we can ignore the "allOf" tag in the target node (the one we are trying to remove here)
+                valuesToMerge = valuesToMerge.subList(1, valuesToMerge.size());
+                if (valuesToMerge.isEmpty()) {
+                    // no other "allOf" part left to merge
+                    continue;
+                }
+            }
+            Supplier<? extends JsonNode> mergeResultSupplier = this.getAllOfMergeFunctionFor(keyword, valuesToMerge, reverseKeywordMap);
+            if (mergeResultSupplier == null) {
+                // unable to merge given values for the specified keyword; abort merge
+                return null;
+            }
+            supportedTagValueSuppliers.put(keyword, mergeResultSupplier);
+        }
+        return supportedTagValueSuppliers;
     }
 
     private Supplier<JsonNode> returnOverlapOfStringsOrStringArrays(List<JsonNode> nodes) {
@@ -337,9 +386,24 @@ public class SchemaCleanUpUtils {
         return null;
     }
 
+    private Supplier<JsonNode> returnMinimumNumericValue(List<JsonNode> nodes) {
+        if (nodes.stream().allMatch(node -> node.isNumber())) {
+            return () -> nodes.stream().reduce((a, b) -> a.asDouble() < b.asDouble() ? a : b).get();
+        }
+        return null;
+    }
+
+    private Supplier<JsonNode> returnMaximumNumericValue(List<JsonNode> nodes) {
+        if (nodes.stream().allMatch(node -> node.isNumber())) {
+            return () -> nodes.stream().reduce((a, b) -> a.asDouble() < b.asDouble() ? b : a).get();
+        }
+        return null;
+    }
+
     private Supplier<JsonNode> returnOneIfAllEqual(List<JsonNode> nodes) {
-        if (nodes.subList(1, nodes.size()).stream().allMatch(nodes.get(0)::equals)) {
-            return () -> nodes.get(0);
+        JsonNode firstNode = nodes.get(0);
+        if (nodes.subList(1, nodes.size()).stream().allMatch(firstNode::equals)) {
+            return () -> firstNode;
         }
         return null;
     }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
@@ -19,14 +19,21 @@ package com.github.victools.jsonschema.generator.impl;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
 import com.github.victools.jsonschema.generator.SchemaKeyword;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -48,23 +55,23 @@ public class SchemaCleanUpUtils {
     }
 
     /**
-     * Remove and merge {@link SchemaKeyword#TAG_ALLOF} parts when there are no conflicts between the sub-schemas.
-     * <br>
-     * This makes for more readable schemas being generated but has the side-effect that manually added {@link SchemaKeyword#TAG_ALLOF} (e.g. from a
-     * custom definition or attribute overrides) may be removed as well if it isn't strictly speaking necessary.
+     * Remove and merge {@link SchemaKeyword#TAG_ALLOF} parts when there are no conflicts between the sub-schemas. This makes for more readable
+     * schemas being generated but has the side-effect that any manually added {@link SchemaKeyword#TAG_ALLOF} (e.g. through a custom definition of
+     * attribute overrides) may be removed as well if it isn't strictly speaking necessary.
      *
      * @param jsonSchemas generated schemas that may contain unnecessary {@link SchemaKeyword#TAG_ALLOF} nodes
      */
     public void reduceAllOfNodes(List<ObjectNode> jsonSchemas) {
         String allOfTagName = this.config.getKeyword(SchemaKeyword.TAG_ALLOF);
-        this.finaliseSchemaParts(jsonSchemas, nodeToCheck -> this.mergeAllOfPartsIfPossible(nodeToCheck, allOfTagName));
+        Map<String, SchemaKeyword> reverseKeywordMap = EnumSet.allOf(SchemaKeyword.class).stream()
+                .collect(Collectors.toMap(this.config::getKeyword, keyword -> keyword));
+        this.finaliseSchemaParts(jsonSchemas, nodeToCheck -> this.mergeAllOfPartsIfPossible(nodeToCheck, allOfTagName, reverseKeywordMap));
     }
 
     /**
-     * Reduce nested {@link SchemaKeyword#TAG_ANYOF} parts when one contains an entry with only another {@link SchemaKeyword#TAG_ANYOF} inside.
-     * <br>
-     * This makes for more readable schemas being generated but has the side-effect that manually added {@link SchemaKeyword#TAG_ANYOF} (e.g. from a
-     * custom definition or attribute overrides) may be removed as well if it isn't strictly speaking necessary.
+     * Reduce nested {@link SchemaKeyword#TAG_ANYOF} parts when one contains an entry with only another {@link SchemaKeyword#TAG_ANYOF} inside. This
+     * makes for more readable schemas being generated but has the side-effect that any manually added {@link SchemaKeyword#TAG_ANYOF} (e.g. through a
+     * custom definition of attribute overrides) may be removed as well if it isn't strictly speaking necessary.
      *
      * @param jsonSchemas generated schemas that may contain unnecessary nested {@link SchemaKeyword#TAG_ANYOF} nodes
      */
@@ -162,8 +169,9 @@ public class SchemaCleanUpUtils {
      *
      * @param schemaNode single node representing a sub-schema to consolidate contained {@link SchemaKeyword#TAG_ALLOF} for (if present)
      * @param allOfTagName name of the {@link SchemaKeyword#TAG_ALLOF} in the designated JSON Schema version
+     * @param reverseKeywordMap mapping from actual tag name in generated schema to underlying {@link SchemaKeyword}
      */
-    private void mergeAllOfPartsIfPossible(JsonNode schemaNode, String allOfTagName) {
+    private void mergeAllOfPartsIfPossible(JsonNode schemaNode, String allOfTagName, Map<String, SchemaKeyword> reverseKeywordMap) {
         if (!(schemaNode instanceof ObjectNode)) {
             return;
         }
@@ -171,7 +179,7 @@ public class SchemaCleanUpUtils {
         if (!(allOfTag instanceof ArrayNode)) {
             return;
         }
-        allOfTag.forEach(part -> this.mergeAllOfPartsIfPossible(part, allOfTagName));
+        allOfTag.forEach(part -> this.mergeAllOfPartsIfPossible(part, allOfTagName, reverseKeywordMap));
 
         List<JsonNode> allOfElements = new ArrayList<>();
         allOfTag.forEach(allOfElements::add);
@@ -182,45 +190,158 @@ public class SchemaCleanUpUtils {
                 .filter(part -> part instanceof ObjectNode)
                 .map(part -> (ObjectNode) part)
                 .collect(Collectors.toList());
+
         // collect all defined attributes from the separate parts and check whether there are incompatible differences
         Map<String, List<JsonNode>> fieldsFromAllParts = Stream.concat(Stream.of(schemaNode), parts.stream())
                 .flatMap(part -> StreamSupport.stream(((Iterable<Map.Entry<String, JsonNode>>) () -> part.fields()).spliterator(), false))
-                .collect(Collectors.groupingBy(Map.Entry::getKey, Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+                .collect(Collectors.groupingBy(Map.Entry::getKey, LinkedHashMap::new, Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
         if ((this.config.getSchemaVersion() == SchemaVersion.DRAFT_6 || this.config.getSchemaVersion() == SchemaVersion.DRAFT_7)
                 && fieldsFromAllParts.containsKey(this.config.getKeyword(SchemaKeyword.TAG_REF))
                 && (schemaNode.size() > 1 || parts.size() > 1)) {
             // in Draft 7, any other attributes besides the $ref keyword were ignored
             return;
         }
-        String ifTagName = this.config.getKeyword(SchemaKeyword.TAG_IF);
-        for (Map.Entry<String, List<JsonNode>> fieldEntries : fieldsFromAllParts.entrySet()) {
-            if (ifTagName.equals(fieldEntries.getKey())) {
+        Map<String, List<JsonNode>> unsupportedTagValues = fieldsFromAllParts.entrySet().stream()
+                .filter(entry -> !reverseKeywordMap.containsKey(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, throwingMerger(), LinkedHashMap::new));
+        if (unsupportedTagValues.entrySet().stream().anyMatch(entry -> entry.getValue().size() > 1)) {
+            // unsupported tag with more than one occurrence: be conservative and don't merge
+            return;
+        }
+        Map<SchemaKeyword, List<JsonNode>> supportedTagValues = fieldsFromAllParts.entrySet().stream()
+                .filter(entry -> !unsupportedTagValues.containsKey(entry.getKey()))
+                .collect(Collectors.toMap(entry -> reverseKeywordMap.get(entry.getKey()), Map.Entry::getValue, throwingMerger(), LinkedHashMap::new));
+        if (supportedTagValues.containsKey(SchemaKeyword.TAG_IF)) {
                 // "if"/"then"/"else" tags should remain isolated in their sub-schemas
-                return;
-            }
-            if (fieldEntries.getValue().size() == 1) {
-                // no conflicts, no further checks
-                continue;
-            }
-            int offset;
-            if (!allOfTagName.equals(fieldEntries.getKey())) {
-                offset = 0;
-            } else if (fieldEntries.getValue().size() == 2) {
+            return;
+        }
+        Map<SchemaKeyword, Supplier<JsonNode>> supportedTagValueSuppliers = new LinkedHashMap<>();
+        for (Map.Entry<SchemaKeyword, List<JsonNode>> fieldEntries : supportedTagValues.entrySet()) {
+            SchemaKeyword keyword = fieldEntries.getKey();
+            List<JsonNode> valuesToMerge = fieldEntries.getValue();
+            if (keyword == SchemaKeyword.TAG_ALLOF) {
                 // we can ignore the "allOf" tag in the target node (the one we are trying to remove here)
-                continue;
-            } else {
-                offset = 1;
+                valuesToMerge = valuesToMerge.subList(1, valuesToMerge.size());
+                if (valuesToMerge.isEmpty()) {
+                    // no other "allOf" part left to merge
+                    continue;
+                }
             }
-            if (!fieldEntries.getValue().stream().skip(offset + 1).allMatch(fieldEntries.getValue().get(offset)::equals)) {
-                // different values for the same tag: be conservative for now and not merge anything
-                // later, we may want to decide based on the tag how to merge them (e.g. take the highest "minLength" and the lowest "maximum")
+            Supplier<JsonNode> mergeResultSupplier = this.getAllOfMergeFunctionFor(keyword, valuesToMerge);
+            if (mergeResultSupplier == null) {
+                // unable to merge given values for the specified keyword; abort merge
                 return;
             }
+            supportedTagValueSuppliers.put(keyword, mergeResultSupplier);
         }
         // all attributes are either distinct or have equal values in all occurrences
         ObjectNode schemaObjectNode = (ObjectNode) schemaNode;
         schemaObjectNode.remove(allOfTagName);
-        parts.forEach(schemaObjectNode::setAll);
+        // for the supported tags, there may be multiple occurrences that requiring individual merging
+        supportedTagValueSuppliers.forEach((keyword, valueSupplier) -> schemaObjectNode.set(this.config.getKeyword(keyword), valueSupplier.get()));
+        // for the unsupported tags, there is only a single occurrence each
+        unsupportedTagValues.forEach((tagName, valueList) -> schemaObjectNode.set(tagName, valueList.get(0)));
+    }
+
+    private Supplier<JsonNode> getAllOfMergeFunctionFor(SchemaKeyword keyword, List<JsonNode> valuesToMerge) {
+        if (valuesToMerge.size() == 1) {
+            // no conflicts, no further checks
+            return () -> valuesToMerge.get(0);
+        }
+        switch (keyword) {
+        case TAG_ALLOF:
+        case TAG_REQUIRED:
+            return this.mergeArrays(valuesToMerge);
+        case TAG_PROPERTIES:
+            return this.mergeObjectProperties(valuesToMerge);
+        case TAG_TYPE:
+            return this.returnOverlapOfStringsOrStringArrays(valuesToMerge);
+        default:
+            return this.returnOneIfAllEqual(valuesToMerge);
+        }
+    }
+
+    private Supplier<JsonNode> mergeArrays(List<JsonNode> arrayNodesToMerge) {
+        if (!arrayNodesToMerge.stream().allMatch(JsonNode::isArray)) {
+            // at least one value is not an array as expected, abort merge
+            return null;
+        }
+        return () -> {
+            ArrayNode mergedArrayNode = this.config.createArrayNode();
+            arrayNodesToMerge.forEach(node -> node.forEach(mergedArrayNode::add));
+            return mergedArrayNode;
+        };
+    }
+
+    private Supplier<JsonNode> mergeObjectProperties(List<JsonNode> objectNodesToMerge) {
+        if (!objectNodesToMerge.stream().allMatch(JsonNode::isObject)) {
+            // at least one value is not an object as expected, abort merge
+            return null;
+        }
+        ObjectNode mergedObjectNode = this.config.createObjectNode();
+        for (JsonNode singleObjectNode : objectNodesToMerge) {
+            Iterator<Map.Entry<String, JsonNode>> it = singleObjectNode.fields();
+            while (it.hasNext()) {
+                Map.Entry<String, JsonNode> singleField = it.next();
+                if (!mergedObjectNode.has(singleField.getKey())) {
+                    mergedObjectNode.set(singleField.getKey(), singleField.getValue());
+                } else if (mergedObjectNode.get(singleField.getKey()).equals(singleField.getValue())) {
+                    // preserve equal existing node
+                    continue;
+                } else {
+                    // cannot consolidate two occurrences of the same property; abort merge (in the future: may want to be smarter here)
+                    return null;
+                }
+            }
+        }
+        return () -> mergedObjectNode;
+    }
+
+    private Supplier<JsonNode> returnOverlapOfStringsOrStringArrays(List<JsonNode> nodes) {
+        List<String> encounteredValues = this.getStringValuesFromStringOrStringArray(nodes.get(0));
+        if (encounteredValues == null) {
+            return null;
+        }
+        for (JsonNode nextNode : nodes.subList(1, nodes.size())) {
+            List<String> nextValues = this.getStringValuesFromStringOrStringArray(nextNode);
+            if (nextValues == null) {
+                // invalid node; abort merge
+                return null;
+            }
+            encounteredValues.retainAll(nextValues);
+            if (encounteredValues.isEmpty()) {
+                // invalid merge result: no valid value remained; abort merge
+                return null;
+            }
+        }
+        if (encounteredValues.size() == 1) {
+            return () -> new TextNode(encounteredValues.get(0));
+        }
+        return () -> this.config.createArrayNode()
+                .addAll(encounteredValues.stream().map(TextNode::new).collect(Collectors.toList()));
+    }
+
+    private List<String> getStringValuesFromStringOrStringArray(JsonNode node) {
+        if (node.isArray()) {
+            List<String> result = new ArrayList<>();
+            node.forEach(arrayItem -> result.add(arrayItem.asText(null)));
+            if (result.contains(null)) {
+                return null;
+            }
+            return result;
+        }
+        if (node.isTextual()) {
+            return Collections.singletonList(node.asText());
+        }
+        // neither array nor text node; abort merge
+        return null;
+    }
+
+    private Supplier<JsonNode> returnOneIfAllEqual(List<JsonNode> nodes) {
+        if (nodes.subList(1, nodes.size()).stream().allMatch(nodes.get(0)::equals)) {
+            return () -> nodes.get(0);
+        }
+        return null;
     }
 
     /**
@@ -294,5 +415,17 @@ public class SchemaCleanUpUtils {
                 .replaceAll(",", ".")
                 // removing white-spaces and any other remaining invalid characters
                 .replaceAll("[^a-zA-Z0-9\\.\\-_]+", "");
+    }
+
+    /**
+     * Helper function, that returns a BinaryOperator for use in Collectors.toMap() that assumes that there are no duplicate keys.
+     *
+     * @param <T> value type
+     * @return merge function that throws an IllegalStateException when invoked
+     */
+    private static <T> BinaryOperator<T> throwingMerger() {
+        return (u,v) -> {
+            throw new IllegalStateException("Duplicate key " + u);
+        };
     }
 }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
@@ -484,10 +484,12 @@ public class SchemaCleanUpUtils {
     /**
      * Helper function, that represents a BinaryOperator for use in Collectors.toMap() that assumes that there are no duplicate keys.
      *
-     * @param <T> value type
-     * @return merge function that throws an IllegalStateException when invoked
+     * @param <T> key value type
+     * @param one first key occurrence
+     * @param two second key occurrence
+     * @return nothing, as this always throws an IllegalStateException when invoked
      */
-    private static <T> T throwingMerger(T a, T b) {
-        throw new IllegalStateException("Duplicate key " + a);
+    private static <T> T throwingMerger(T one, T two) {
+        throw new IllegalStateException("Duplicate key " + one);
     }
 }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
@@ -17,6 +17,7 @@
 package com.github.victools.jsonschema.generator.impl;
 
 import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -38,7 +39,6 @@ import com.github.victools.jsonschema.generator.SchemaVersion;
 import com.github.victools.jsonschema.generator.TypeAttributeOverrideV2;
 import com.github.victools.jsonschema.generator.TypeScope;
 import com.github.victools.jsonschema.generator.naming.SchemaDefinitionNamingStrategy;
-import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
@@ -420,33 +420,33 @@ public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
     }
 
     @Override
-    public Type resolveAdditionalProperties(FieldScope field) {
-        return this.fieldConfigPart.resolveAdditionalProperties(field);
+    public JsonNode resolveAdditionalProperties(FieldScope field, SchemaGenerationContext context) {
+        return this.fieldConfigPart.resolveAdditionalProperties(field, context);
     }
 
     @Override
-    public Type resolveAdditionalProperties(MethodScope method) {
-        return this.methodConfigPart.resolveAdditionalProperties(method);
+    public JsonNode resolveAdditionalProperties(MethodScope method, SchemaGenerationContext context) {
+        return this.methodConfigPart.resolveAdditionalProperties(method, context);
     }
 
     @Override
-    public Type resolveAdditionalPropertiesForType(TypeScope scope) {
-        return this.typesInGeneralConfigPart.resolveAdditionalProperties(scope);
+    public JsonNode resolveAdditionalPropertiesForType(TypeScope scope, SchemaGenerationContext context) {
+        return this.typesInGeneralConfigPart.resolveAdditionalProperties(scope, context);
     }
 
     @Override
-    public Map<String, Type> resolvePatternProperties(FieldScope field) {
-        return this.fieldConfigPart.resolvePatternProperties(field);
+    public Map<String, JsonNode> resolvePatternProperties(FieldScope field, SchemaGenerationContext context) {
+        return this.fieldConfigPart.resolvePatternProperties(field, context);
     }
 
     @Override
-    public Map<String, Type> resolvePatternProperties(MethodScope method) {
-        return this.methodConfigPart.resolvePatternProperties(method);
+    public Map<String, JsonNode> resolvePatternProperties(MethodScope method, SchemaGenerationContext context) {
+        return this.methodConfigPart.resolvePatternProperties(method, context);
     }
 
     @Override
-    public Map<String, Type> resolvePatternPropertiesForType(TypeScope scope) {
-        return this.typesInGeneralConfigPart.resolvePatternProperties(scope);
+    public Map<String, JsonNode> resolvePatternPropertiesForType(TypeScope scope, SchemaGenerationContext context) {
+        return this.typesInGeneralConfigPart.resolvePatternProperties(scope, context);
     }
 
     @Override

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/AdditionalPropertiesModule.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/AdditionalPropertiesModule.java
@@ -61,7 +61,7 @@ public class AdditionalPropertiesModule implements Module {
         // within a Map<Key, Value> allow additionalProperties of the Value type
         // if no type parameters are defined, this will result in additionalProperties to be omitted (by way of returning Object.class)
         ResolvedType valueType = member.getTypeParameterFor(Map.class, 1);
-        if (valueType.getErasedType() == Object.class) {
+        if (valueType == null || valueType.getErasedType() == Object.class) {
             return null;
         }
         MemberScope<?, ?> mapValueScope = member.asFakeContainerItemScope(Map.class, 1);

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaBuilderTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaBuilderTest.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.victools.jsonschema.generator.impl.TypeContextFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * Test for the {@link SchemaBuilder}.
@@ -70,8 +68,7 @@ public class SchemaBuilderTest {
         result.with("components")
                 .set("schemas", instance.collectDefinitions("components/schemas"));
 
-        JSONAssert.assertEquals('\n' + result.toString() + '\n',
-                TestUtils.loadResource(this.getClass(), "openapi.json"), result.toString(), JSONCompareMode.STRICT);
+        TestUtils.assertGeneratedSchema(result, this.getClass(), "openapi.json");
     }
 
     private static class TestClass1 {

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorComplexTypesTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorComplexTypesTest.java
@@ -37,8 +37,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * Test for {@link SchemaGenerator} class.
@@ -157,8 +155,7 @@ public class SchemaGeneratorComplexTypesTest {
                 Assertions.assertEquals(key, new URI(key).toASCIIString());
             }
         }
-        JSONAssert.assertEquals('\n' + result.toString() + '\n',
-                TestUtils.loadResource(this.getClass(), caseTitle + ".json"), result.toString(), JSONCompareMode.STRICT);
+        TestUtils.assertGeneratedSchema(result, this.getClass(), caseTitle + ".json");
     }
 
     @Test

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigPartTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigPartTest.java
@@ -182,12 +182,6 @@ public class SchemaGeneratorConfigPartTest {
     }
 
     @Test
-    public void testAdditionalProperties() {
-        this.testFirstDefinedValueConfig(String.class, Void.TYPE,
-                this.instance::withAdditionalPropertiesResolver, this.instance::resolveAdditionalProperties);
-    }
-
-    @Test
     public void testStringMinLength() {
         this.testFirstDefinedValueConfig(1, 2,
                 this.instance::withStringMinLengthResolver, this.instance::resolveStringMinLength);

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorCustomDefinitionsTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorCustomDefinitionsTest.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * Test for {@link SchemaGenerator} class.
@@ -167,9 +165,7 @@ public class SchemaGeneratorCustomDefinitionsTest {
                 });
         SchemaGenerator generator = new SchemaGenerator(configBuilder.build());
         JsonNode result = generator.generateSchema(TestDirectCircularClass.class);
-        JSONAssert.assertEquals('\n' + result.toString() + '\n',
-                TestUtils.loadResource(this.getClass(), "multiple-definitions-one-type-" + schemaVersion.name() + ".json"),
-                result.toString(), JSONCompareMode.STRICT);
+        TestUtils.assertGeneratedSchema(result, this.getClass(), "multiple-definitions-one-type-" + schemaVersion.name() + ".json");
     }
 
     @ParameterizedTest
@@ -192,9 +188,7 @@ public class SchemaGeneratorCustomDefinitionsTest {
                 .withCustomDefinitionProvider(customDefinitionProvider);
         SchemaGenerator generator = new SchemaGenerator(configBuilder.build());
         JsonNode result = generator.generateSchema(TestCircularClass1.class);
-        JSONAssert.assertEquals('\n' + result.toString() + '\n',
-                TestUtils.loadResource(this.getClass(), "circular-custom-definition-" + schemaVersion.name() + ".json"),
-                result.toString(), JSONCompareMode.STRICT);
+        TestUtils.assertGeneratedSchema(result, this.getClass(), "circular-custom-definition-" + schemaVersion.name() + ".json");
     }
 
     @ParameterizedTest
@@ -220,9 +214,7 @@ public class SchemaGeneratorCustomDefinitionsTest {
                 .withCustomDefinitionProvider(customPropertyDefinitionProvider);
         SchemaGenerator generator = new SchemaGenerator(configBuilder.build());
         JsonNode result = generator.generateSchema(TestDirectCircularClass.class);
-        JSONAssert.assertEquals('\n' + result.toString() + '\n',
-                TestUtils.loadResource(this.getClass(), "custom-property-definition-" + schemaVersion.name() + ".json"),
-                result.toString(), JSONCompareMode.STRICT);
+        TestUtils.assertGeneratedSchema(result, this.getClass(), "custom-property-definition-" + schemaVersion.name() + ".json");
     }
 
     private static class TestDirectCircularClass {

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSubtypesTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSubtypesTest.java
@@ -27,8 +27,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * Test for {@link SchemaGenerator} class.
@@ -61,8 +59,7 @@ public class SchemaGeneratorSubtypesTest {
         SchemaGenerator generator = new SchemaGenerator(configBuilder.build());
 
         JsonNode result = generator.generateSchema(TestClassWithSuperTypeReferences.class);
-        JSONAssert.assertEquals('\n' + result.toString() + '\n', TestUtils.loadResource(SchemaGeneratorSubtypesTest.class,
-                "testclass-withsupertypereferences-" + caseTitle + ".json"), result.toString(), JSONCompareMode.STRICT);
+        TestUtils.assertGeneratedSchema(result, SchemaGeneratorSubtypesTest.class, "testclass-withsupertypereferences-" + caseTitle + ".json");
     }
 
     private List<ResolvedType> determineTargetTypeOverrides(FieldScope field) {

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/TestUtils.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/TestUtils.java
@@ -58,7 +58,7 @@ public abstract class TestUtils {
      * @return file contents
      * @throws IOException when the file loading failed
      */
-    public static String loadResource(Class<?> testClass, String resourcePath) throws IOException {
+    private static String loadResource(Class<?> testClass, String resourcePath) throws IOException {
         StringBuilder stringBuilder = new StringBuilder();
         try (InputStream inputStream = testClass.getResourceAsStream(resourcePath);
                 Scanner scanner = new Scanner(inputStream, StandardCharsets.UTF_8.name())) {

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/TestUtils.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/TestUtils.java
@@ -16,10 +16,14 @@
 
 package com.github.victools.jsonschema.generator;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Scanner;
+import org.json.JSONException;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * Common helper functions within tests.
@@ -28,6 +32,22 @@ public abstract class TestUtils {
 
     private TestUtils() {
         // not intended for sub-typing
+    }
+
+    /**
+     * Assert that the given schema node is equal to the contents of a prepared file. In case of a mismatch, print the result and compared file name.
+     *
+     * @param generatedSchema schema generation test result to compare
+     * @param testClass test class requesting a file to be loaded
+     * @param resourcePath relative path to the target file
+     * @throws IOException when the file loading failed
+     * @throws JSONException when the JSON comparison failed
+     */
+    public static void assertGeneratedSchema(JsonNode generatedSchema, Class<?> testClass, String resourcePath)
+            throws IOException, JSONException {
+        String schemaString = generatedSchema.toString();
+        JSONAssert.assertEquals('\n' + testClass.getPackage().getName() + ": " + resourcePath + '\n' + schemaString + '\n',
+                TestUtils.loadResource(testClass, resourcePath), schemaString, JSONCompareMode.STRICT);
     }
 
     /**

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/impl/module/SimpleTypeModuleTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/impl/module/SimpleTypeModuleTest.java
@@ -16,6 +16,7 @@
 
 package com.github.victools.jsonschema.generator.impl.module;
 
+import com.github.victools.jsonschema.generator.ConfigFunction;
 import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2;
 import com.github.victools.jsonschema.generator.FieldScope;
 import com.github.victools.jsonschema.generator.MethodScope;
@@ -69,8 +70,8 @@ public class SimpleTypeModuleTest {
         Mockito.verifyNoMoreInteractions(methodConfigPart);
         Mockito.verify(this.builder, Mockito.times(2)).forMethods();
 
-        Mockito.verify(this.typeConfigPart).withAdditionalPropertiesResolver(Mockito.any());
-        Mockito.verify(this.typeConfigPart).withPatternPropertiesResolver(Mockito.any());
+        Mockito.verify(this.typeConfigPart).withAdditionalPropertiesResolver(Mockito.any(ConfigFunction.class));
+        Mockito.verify(this.typeConfigPart).withPatternPropertiesResolver(Mockito.any(ConfigFunction.class));
         Mockito.verify(this.typeConfigPart).withCustomDefinitionProvider(Mockito.any(CustomDefinitionProviderV2.class));
         Mockito.verifyNoMoreInteractions(this.typeConfigPart);
         Mockito.verify(this.builder).forTypesInGeneral();

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/impl/module/additional-property-with-subtype.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/impl/module/additional-property-with-subtype.json
@@ -1,16 +1,28 @@
 {
-  "type" : "object",
-  "properties" : {
-    "map" : {
-      "type" : "object",
-      "additionalProperties" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
-          }
+    "$defs": {
+        "B": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
         }
-      }
+    },
+    "type": "object",
+    "properties": {
+        "map": {
+            "allOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/B"
+                    }
+                }, {
+                    "additionalProperties": {
+                        "$ref": "#/$defs/B",
+                        "description": "annotated super value"
+                    }
+                }]
+        }
     }
-  }
 }

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/impl/module/additional-property-with-subtype.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/impl/module/additional-property-with-subtype.json
@@ -12,17 +12,11 @@
     "type": "object",
     "properties": {
         "map": {
-            "allOf": [{
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/$defs/B"
-                    }
-                }, {
-                    "additionalProperties": {
-                        "$ref": "#/$defs/B",
-                        "description": "annotated super value"
-                    }
-                }]
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/B",
+                "description": "annotated super value"
+            }
         }
     }
 }

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-simple-integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-simple-integration-test-result.json
@@ -2,40 +2,28 @@
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "$defs": {
         "TestSubClassA": {
-            "allOf": [{
-                    "type": "object",
-                    "properties": {
-                        "aProperty": {
-                            "type": "string"
-                        }
-                    }
-                }, {
-                    "type": "object",
-                    "properties": {
-                        "@type": {
-                            "const": "SubClassA"
-                        }
-                    },
-                    "required": ["@type"]
-                }]
+            "type": "object",
+            "properties": {
+                "aProperty": {
+                    "type": "string"
+                },
+                "@type": {
+                    "const": "SubClassA"
+                }
+            },
+            "required": ["@type"]
         },
         "TestSubClassB": {
-            "allOf": [{
-                    "type": "object",
-                    "properties": {
-                        "bProperty": {
-                            "type": "integer"
-                        }
-                    }
-                }, {
-                    "type": "object",
-                    "properties": {
-                        "@type": {
-                            "const": "SubClassB"
-                        }
-                    },
-                    "required": ["@type"]
-                }]
+            "type": "object",
+            "properties": {
+                "bProperty": {
+                    "type": "integer"
+                },
+                "@type": {
+                    "const": "SubClassB"
+                }
+            },
+            "required": ["@type"]
         },
         "TestSuperClass": {
             "anyOf": [{

--- a/jsonschema-module-jakarta-validation/src/test/resources/com/github/victools/jsonschema/module/jakarta/validation/integration-test-result.json
+++ b/jsonschema-module-jakarta-validation/src/test/resources/com/github/victools/jsonschema/module/jakarta/validation/integration-test-result.json
@@ -26,11 +26,18 @@
             }
         },
         "notEmptyMap": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "integer"
-            },
-            "minProperties": 1
+            "allOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    }
+                }, {
+                    "additionalProperties": {
+                        "type": "integer",
+                        "minimum": 13
+                    },
+                    "minProperties": 1
+                }]
         },
         "notEmptyPatternText": {
             "type": "string",
@@ -90,12 +97,19 @@
             }
         },
         "sizeRangeMap": {
-            "type": "object",
-            "additionalProperties": {
-                "type": "string"
-            },
-            "minProperties": 3,
-            "maxProperties": 25
+            "allOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }, {
+                    "additionalProperties": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "minProperties": 3,
+                    "maxProperties": 25
+                }]
         },
         "sizeRangeText": {
             "type": "string",

--- a/jsonschema-module-jakarta-validation/src/test/resources/com/github/victools/jsonschema/module/jakarta/validation/integration-test-result.json
+++ b/jsonschema-module-jakarta-validation/src/test/resources/com/github/victools/jsonschema/module/jakarta/validation/integration-test-result.json
@@ -26,18 +26,12 @@
             }
         },
         "notEmptyMap": {
-            "allOf": [{
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "integer"
-                    }
-                }, {
-                    "additionalProperties": {
-                        "type": "integer",
-                        "minimum": 13
-                    },
-                    "minProperties": 1
-                }]
+            "type": "object",
+            "additionalProperties": {
+                "type": "integer",
+                "minimum": 13
+            },
+            "minProperties": 1
         },
         "notEmptyPatternText": {
             "type": "string",
@@ -97,19 +91,13 @@
             }
         },
         "sizeRangeMap": {
-            "allOf": [{
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
-                    }
-                }, {
-                    "additionalProperties": {
-                        "type": "string",
-                        "minLength": 1
-                    },
-                    "minProperties": 3,
-                    "maxProperties": 25
-                }]
+            "type": "object",
+            "additionalProperties": {
+                "type": "string",
+                "minLength": 1
+            },
+            "minProperties": 3,
+            "maxProperties": 25
         },
         "sizeRangeText": {
             "type": "string",


### PR DESCRIPTION
1. Enabling identification of "container items" that are not necessarily `Iterable`, e.g, when looking at a `Map`'s values only.
2. Introducing enhanced definition of `additionalProperties` and `patternProperties`.
3. Utilising enhanced `additionalProperties` definition in `Option,ADDITIONAL_PROPERTIES_FROM_MAP_VALUES`
    - Closes #287.
4. Introducing enhanced `allOf` clean-up to allow merging schemas with differing `additionalProperties` (made necessary by the above changes).
5. Introducing enhanced `allOf` clean-up to allow merging schemas with different `properties` subsets.
    - Closes #183.