### PR TITLE
Support Jackson @JsonidentityReference(alwaysAsId = true) considering @JsonIdentityInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bump `jackson-core` dependency version from `2.13.2` to `2.13.4`
 - bump `jackson-databind` dependency version from `2.13.2.2` to `2.13.4.2`
 
+#### Fixed
+- custom property definition containing only a definition reference/placeholder is being ignored
+
 ### `jsonschema-module-jackson`
 #### Added
 - new `JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID` to respect `@JsonIdentityReference(alwaysAsId=true)` annotations (with `@JsonIdentityInfo`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - enable look-up of annotations on a member's type parameter (e.g., a `Map`'s value type)
 - enable providing full custom schema definition to be included in `additionalProperties` or `patternProperties`
+- new function `TypeContext.getTypeWithAnnotation()` for finding also super type of interface with certain type annotation
+- new function `TypeContext.getTypeAnnotationConsideringHierarchy()´ for searching type annotations also on super types and interfaces
 
 #### Changed
 - consider annotations on `Map` value types when using `Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bump `jackson-core` dependency version from `2.13.2` to `2.13.4`
 - bump `jackson-databind` dependency version from `2.13.2.2` to `2.13.4.2`
 
+### `jsonschema-module-jackson`
+#### Added
+- new `JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID` to respect `@JsonIdentityReference(alwaysAsId=true)` annotations (with `@JsonIdentityInfo`)
+
 ### `jsonschema-module-jakarta
 #### Added
 - set `minProperties`/`maxProperties` for `Map` types with `@NotEmpty` or `@Size` annotation

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SubtypeResolver.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SubtypeResolver.java
@@ -40,7 +40,7 @@ public interface SubtypeResolver {
      *
      * @param declaredType declared type (i.e. without type parameter information)
      * @param context generation context (including a reference to the {@code TypeContext} for deriving a {@link ResolvedType} from a {@link Class})
-     * @return list of subtypes to represent as separate schemas; returning
+     * @return list of subtypes to represent as separate schemas (may return {@code null})
      * @see SchemaGeneratorConfigPart#withTargetTypeOverrideResolver(ConfigFunction)
      */
     List<ResolvedType> findSubtypes(ResolvedType declaredType, SchemaGenerationContext context);

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImpl.java
@@ -735,7 +735,12 @@ public class SchemaGenerationContextImpl implements SchemaGenerationContext {
             ObjectNode collectedAttributes, CustomPropertyDefinitionProvider<M> ignoredDefinitionProvider) {
         final CustomDefinition customDefinition = this.generatorConfig.getCustomDefinition(scope, this, ignoredDefinitionProvider);
         if (customDefinition != null && customDefinition.isMeantToBeInline()) {
-            targetNode.setAll(customDefinition.getValue());
+            if (customDefinition.getValue().isEmpty()) {
+                targetNode.withArray(this.getKeyword(SchemaKeyword.TAG_ALLOF))
+                        .add(customDefinition.getValue());
+            } else {
+                targetNode.setAll(customDefinition.getValue());
+            }
             if (customDefinition.shouldIncludeAttributes()) {
                 AttributeCollector.mergeMissingAttributes(targetNode, collectedAttributes);
                 Set<String> allowedSchemaTypes = this.collectAllowedSchemaTypes(targetNode);

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/custom-property-definition-DRAFT_2019_09.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/custom-property-definition-DRAFT_2019_09.json
@@ -7,7 +7,15 @@
             "title": "custom title",
             "description": "field description"
         },
-        "self": {
+        "selfCustomRefNoAttributes": {
+            "$ref": "#"
+        },
+        "selfCustomRefWithAttributes": {
+            "description": "field description",
+            "title": "type title",
+            "$ref": "#"
+        },
+        "selfStandardRef": {
             "$ref": "#",
             "description": "field description"
         },

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/custom-property-definition-DRAFT_2020_12.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/custom-property-definition-DRAFT_2020_12.json
@@ -7,7 +7,15 @@
             "title": "custom title",
             "description": "field description"
         },
-        "self": {
+        "selfCustomRefNoAttributes": {
+            "$ref": "#"
+        },
+        "selfCustomRefWithAttributes": {
+            "description": "field description",
+            "title": "type title",
+            "$ref": "#"
+        },
+        "selfStandardRef": {
             "$ref": "#",
             "description": "field description"
         },

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/custom-property-definition-DRAFT_6.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/custom-property-definition-DRAFT_6.json
@@ -7,7 +7,17 @@
             "title": "custom title",
             "description": "field description"
         },
-        "self": {
+        "selfCustomRefNoAttributes": {
+            "$ref": "#"
+        },
+        "selfCustomRefWithAttributes": {
+            "allOf": [{
+                    "$ref": "#"
+                }],
+            "description": "field description",
+            "title": "type title"
+        },
+        "selfStandardRef": {
             "allOf": [{
                     "$ref": "#"
                 }, {

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/custom-property-definition-DRAFT_7.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/custom-property-definition-DRAFT_7.json
@@ -7,7 +7,17 @@
             "title": "custom title",
             "description": "field description"
         },
-        "self": {
+        "selfCustomRefNoAttributes": {
+            "$ref": "#"
+        },
+        "selfCustomRefWithAttributes": {
+            "allOf": [{
+                    "$ref": "#"
+                }],
+            "description": "field description",
+            "title": "type title"
+        },
+        "selfStandardRef": {
             "allOf": [{
                     "$ref": "#"
                 }, {

--- a/jsonschema-module-jackson/README.md
+++ b/jsonschema-module-jackson/README.md
@@ -19,6 +19,7 @@ Module for the [jsonschema-generator](../jsonschema-generator) – deriving JSON
     * Considering `@JsonTypeInfo.use` with values `Id.CLASS`, `Id.NAME`
 12. Consider `@JsonProperty.access` for marking a field/method as `readOnly` or `writeOnly`
 13. Optionally: ignore all methods but those with a `@JsonProperty` annotation, if the `JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS` was provided (i.e. this is an "opt-in").
+14. Optionally: respect `@JsonIdentityReference(alwaysAsId=true)` annotation if there is a corresponding `@JsonIdentityInfo` annotation on the type and the `JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID` as provided (i.e., this is an "opt-in")
 
 Schema attributes derived from validation annotations on getter methods are also applied to their associated fields.
 

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -104,6 +104,12 @@ public class JacksonModule implements Module {
         if (this.options.contains(JacksonOption.RESPECT_JSONPROPERTY_ORDER)) {
             generalConfigPart.withPropertySorter(new JsonPropertySorter(true));
         }
+        if (this.options.contains(JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID)) {
+            JsonIdentityReferenceDefinitionProvider identityReferenceDefinitionProvider = new JsonIdentityReferenceDefinitionProvider();
+            generalConfigPart.withCustomDefinitionProvider(identityReferenceDefinitionProvider);
+            fieldConfigPart.withCustomDefinitionProvider(identityReferenceDefinitionProvider::provideCustomPropertySchemaDefinition);
+            methodConfigPart.withCustomDefinitionProvider(identityReferenceDefinitionProvider::provideCustomPropertySchemaDefinition);
+        }
 
         boolean lookUpSubtypes = !this.options.contains(JacksonOption.SKIP_SUBTYPE_LOOKUP);
         boolean includeTypeInfoTransform = !this.options.contains(JacksonOption.IGNORE_TYPE_INFO_TRANSFORM);

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
@@ -85,5 +85,11 @@ public enum JacksonOption {
      *
      * @since 4.18.0
      */
-    RESPECT_JSONPROPERTY_REQUIRED
+    RESPECT_JSONPROPERTY_REQUIRED,
+    /**
+     * Use this option to consider {@code @JsonIdentityReference(alwaysAsId = true)} annotations on fields/methods or the type itself.
+     *
+     * @since 4.28.0
+     */
+    JSONIDENTITY_REFERENCE_ALWAYS_AS_ID;
 }

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonIdentityReferenceDefinitionProvider.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonIdentityReferenceDefinitionProvider.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2022 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.jackson;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.members.ResolvedField;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerator;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.CustomDefinition;
+import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2;
+import com.github.victools.jsonschema.generator.CustomPropertyDefinition;
+import com.github.victools.jsonschema.generator.MemberScope;
+import com.github.victools.jsonschema.generator.SchemaGenerationContext;
+import com.github.victools.jsonschema.generator.SchemaKeyword;
+import com.github.victools.jsonschema.generator.TypeContext;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Implementation of the {@link CustomDefinitionProviderV2} interface for handling types with the {@code @JsonIdentityReference(alwaysAsid = true)}
+ identityReferenceAnnotation.
+ */
+public class JsonIdentityReferenceDefinitionProvider implements CustomDefinitionProviderV2 {
+
+    @Override
+    public CustomDefinition provideCustomSchemaDefinition(ResolvedType javaType, SchemaGenerationContext context) {
+        return this.getIdentityReferenceType(javaType, context.getTypeContext())
+                .map(context::createDefinitionReference)
+                .map(CustomDefinition::new)
+                .orElse(null);
+    }
+
+    /**
+     * Implementation of the {@code CustomPropertyDefinitionProvider} interface that can be used for both fields and methods.
+     *
+     * @param scope field/method on which to check for the {@code @JsonIdentityReference} annotation
+     * @param context generation context enabling the standard schema generation for the identity property's value type
+     * @return created custom definition (may be {@code null})
+     */
+    public CustomPropertyDefinition provideCustomPropertySchemaDefinition(MemberScope<?, ?> scope, SchemaGenerationContext context) {
+        return this.getIdentityReferenceType(scope)
+                .map(idType -> this.createWrappedDefinitionReference(idType, context))
+                .map(CustomPropertyDefinition::new)
+                .orElse(null);
+    }
+
+    /**
+     * Create a schema node containing an "allOf" property that wraps a single schema reference/placeholder to ensure its correct inclusion.
+     *
+     * @param targetType type for which to generate a schema reference/placeholder
+     * @param context generation context enabling the standard schema generation for the identity property's value type
+     * @return wrapper schema with the "allOf" array holding the single reference/placeholder
+     */
+    private ObjectNode createWrappedDefinitionReference(ResolvedType targetType, SchemaGenerationContext context) {
+        ObjectNode wrapperNode = context.getGeneratorConfig().createObjectNode();
+        wrapperNode.withArray(context.getKeyword(SchemaKeyword.TAG_ALLOF))
+                .add(context.createDefinitionReference(targetType));
+        return wrapperNode;
+    }
+
+    /**
+     * If applicable, determine the type of the identity reference that should replace the given actual type, if the
+     * {@code @JsonIdentityReference(alwaysAsId = true)} annotation is present as well as a corresponding {@code @JsonIdentityInfo} annotation on the
+     * type itself.
+     *
+     * @param javaType reference type that may be replaced by a reference to its identity property
+     * @param typeContext type context providing convenience methods, e.g., for the annotation or member look-up
+     * @return designated type of the applicable identity reference (may be empty)
+     */
+    public Optional<ResolvedType> getIdentityReferenceType(ResolvedType javaType, TypeContext typeContext) {
+        JsonIdentityReference referenceAnnotation = javaType.getErasedType().getAnnotation(JsonIdentityReference.class);
+        return this.getIdentityReferenceType(referenceAnnotation, javaType, typeContext);
+    }
+
+    /**
+     * If applicable, determine the type of the identity reference that should replace the given field/method's type, if the
+     * {@code @JsonIdentityReference(alwaysAsId = true)} annotation is present as well as a corresponding {@code @JsonIdentityInfo} annotation on the
+     * type itself.
+     *
+     * @param scope field/method that may be replaced by a reference to its identity property
+     * @return designated type of the applicable identity reference (may be empty)
+     */
+    public Optional<ResolvedType> getIdentityReferenceType(MemberScope<?, ?> scope) {
+        JsonIdentityReference referenceAnnotation = scope.getContainerItemAnnotationConsideringFieldAndGetterIfSupported(JsonIdentityReference.class);
+        if (referenceAnnotation == null) {
+            referenceAnnotation = scope.getAnnotationConsideringFieldAndGetter(JsonIdentityReference.class);
+        }
+        return this.getIdentityReferenceType(referenceAnnotation, scope.getType(), scope.getContext());
+    }
+
+    /**
+     * If applicable, determine the type of the identity reference that should replace the given actual type, if the
+     * {@code @JsonIdentityReference(alwaysAsId = true)} annotation is present as well as a corresponding {@code @JsonIdentityInfo} annotation on the
+     * type itself.
+     *
+     * @param referenceAnnotation the applicable {@code @JsonidentityReference} annotation in the given context (may be {@code null})
+     * @param javaType reference type that may be replaced by a reference to its identity property
+     * @param typeContext type context providing convenience methods, e.g., for the annotation or member look-up
+     * @return designated type of the applicable identity reference (may be empty)
+     */
+    private Optional<ResolvedType> getIdentityReferenceType(JsonIdentityReference referenceAnnotation, ResolvedType javaType,
+            TypeContext typeContext) {
+        if (referenceAnnotation == null || !referenceAnnotation.alwaysAsId()) {
+            // no replacement if no @JsonIdentityReference annotation is present or it has "alwaysAsId=false"
+            return Optional.empty();
+        }
+        // additionally, the type itself must have a @JsonIdentityInfo annotation
+        ResolvedType typeWithIdentityInfoAnnotation = typeContext.getTypeWithAnnotation(javaType, JsonIdentityInfo.class);
+        if (typeWithIdentityInfoAnnotation == null) {
+            // otherwise, the @JsonIdentityReference annotation is simply ignored
+            return Optional.empty();
+        }
+        JsonIdentityInfo identityInfoAnnotation = typeWithIdentityInfoAnnotation.getErasedType().getAnnotation(JsonIdentityInfo.class);
+        // @JsonIdentityInfo annotation declares generator with specific identity type
+        ResolvedType identityTypeFromGenerator = typeContext.getTypeParameterFor(typeContext.resolve(identityInfoAnnotation.generator()),
+                ObjectIdGenerator.class, 0);
+        if (identityTypeFromGenerator.getErasedType() == Object.class) {
+            // the identity may be derived from a property
+            String idPropertyName = identityInfoAnnotation.property();
+            ResolvedField[] eligibleFields = typeContext.resolveWithMembers(typeWithIdentityInfoAnnotation).getMemberFields();
+            Optional<ResolvedType> identityTypeFromProperty = Stream.of(eligibleFields)
+                    .filter(field -> field.getName().equals(idPropertyName))
+                    .map(field -> field.getType())
+                    .findFirst();
+            if (identityTypeFromProperty.isPresent()) {
+                return identityTypeFromProperty;
+            }
+        }
+        return Optional.of(identityTypeFromGenerator);
+    }
+}

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
@@ -17,9 +17,12 @@
 package com.github.victools.jsonschema.module.jackson;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.OptionPreset;
@@ -48,7 +51,7 @@ public class IntegrationTest {
     @Test
     public void testIntegration() throws Exception {
         JacksonModule module = new JacksonModule(JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE, JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY,
-                JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS);
+                JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS, JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID);
         SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_7, OptionPreset.PLAIN_JSON)
                 .with(Option.NULLABLE_ARRAY_ITEMS_ALLOWED)
                 .with(Option.NONSTATIC_NONVOID_NONGETTER_METHODS, Option.FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS)
@@ -85,6 +88,9 @@ public class IntegrationTest {
         @JsonProperty(value = "fieldWithOverriddenName", access = JsonProperty.Access.WRITE_ONLY)
         public boolean originalFieldName;
 
+        @JsonIdentityReference(alwaysAsId = true)
+        public TestTypeWithObjectId referenceByObjectId;
+
         public TestEnum enumValueHandledByStandardOption;
 
         public TestEnumWithJsonValueAnnotation enumValueWithJsonValueAnnotation;
@@ -118,5 +124,15 @@ public class IntegrationTest {
     static enum TestEnumWithJsonPropertyAnnotations {
         @JsonProperty("x_property") X,
         @JsonProperty Y;
+    }
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+    static class TestTypeWithObjectId {
+        IdType id;
+
+        class IdType {
+            public String version;
+            public long value;
+        }
     }
 }

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
@@ -153,6 +153,23 @@ public class JacksonModuleTest {
         Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart, this.typesInGeneralConfigPart);
     }
 
+    @Test
+    public void testApplyToConfigBuilderWithIdentityReferenceOption() {
+        new JacksonModule(JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.verifyCommonConfigurations(true);
+
+        Mockito.verify(this.typesInGeneralConfigPart).withSubtypeResolver(Mockito.any());
+        Mockito.verify(this.typesInGeneralConfigPart, Mockito.times(2)).withCustomDefinitionProvider(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withTargetTypeOverridesResolver(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withCustomDefinitionProvider(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withTargetTypeOverridesResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withCustomDefinitionProvider(Mockito.any());
+
+        Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart, this.typesInGeneralConfigPart);
+    }
+
     private void verifyCommonConfigurations(boolean considerNamingStrategy) {
         Mockito.verify(this.configBuilder).getObjectMapper();
         Mockito.verify(this.configBuilder).forFields();

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
@@ -163,9 +163,9 @@ public class JacksonModuleTest {
         Mockito.verify(this.typesInGeneralConfigPart).withSubtypeResolver(Mockito.any());
         Mockito.verify(this.typesInGeneralConfigPart, Mockito.times(2)).withCustomDefinitionProvider(Mockito.any());
         Mockito.verify(this.fieldConfigPart).withTargetTypeOverridesResolver(Mockito.any());
-        Mockito.verify(this.fieldConfigPart).withCustomDefinitionProvider(Mockito.any());
+        Mockito.verify(this.fieldConfigPart, Mockito.times(2)).withCustomDefinitionProvider(Mockito.any());
         Mockito.verify(this.methodConfigPart).withTargetTypeOverridesResolver(Mockito.any());
-        Mockito.verify(this.methodConfigPart).withCustomDefinitionProvider(Mockito.any());
+        Mockito.verify(this.methodConfigPart, Mockito.times(2)).withCustomDefinitionProvider(Mockito.any());
 
         Mockito.verifyNoMoreInteractions(this.configBuilder, this.fieldConfigPart, this.methodConfigPart, this.typesInGeneralConfigPart);
     }

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonIdentityReferenceDefinitionProviderTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonIdentityReferenceDefinitionProviderTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2022 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.jackson;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.github.victools.jsonschema.generator.FieldScope;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.generator.TypeContext;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Test for the {@link JsonIdentityReferenceDefinitionProvider}.
+ */
+public class JsonIdentityReferenceDefinitionProviderTest extends AbstractTypeAwareTest {
+
+    private final JsonIdentityReferenceDefinitionProvider provider = new JsonIdentityReferenceDefinitionProvider();
+
+    public JsonIdentityReferenceDefinitionProviderTest() {
+        super(TestTypeWithReferences.class);
+    }
+
+    @BeforeEach
+    public void setUp() {
+        this.prepareContextForVersion(SchemaVersion.DRAFT_2020_12);
+    }
+
+    static Stream<Arguments> parametersForTestGetIdentityReferenceType_byType() {
+        return Stream.of(
+            Arguments.of(TestTypeReferencedAsInteger.class, Integer.class),
+            Arguments.of(TestTypeReferencedAsString.class, String.class),
+            Arguments.of(TestTypeReferencedAsUuid.class, UUID.class),
+            Arguments.of(TestTypeReferencedByLongId.class, Long.class),
+            Arguments.of(TestTypeReferencedByObjectId.class, TestTypeReferencedByObjectId.IdType.class),
+            Arguments.of(TestTypeWithObjectIdRequiringReferenceAnnotation.class, null),
+            Arguments.of(JsonIdentityReferenceDefinitionProviderTest.class, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersForTestGetIdentityReferenceType_byType")
+    public void testGetIdentityReferenceType_byType(Class<?> testType, Class<?> expectedErasedResultType) {
+        TypeContext typeContext = this.getContext().getTypeContext();
+        ResolvedType targetType = typeContext.resolve(testType);
+        Optional<ResolvedType> result = this.provider.getIdentityReferenceType(targetType, typeContext);
+        Assertions.assertNotNull(result);
+        if (expectedErasedResultType == null) {
+            Assertions.assertFalse(result.isPresent());
+        } else {
+            Assertions.assertTrue(result.isPresent());
+            Assertions.assertEquals(expectedErasedResultType, result.get().getErasedType());
+        }
+    }
+
+    static Stream<Arguments> parametersForTestGetIdentityReferenceType_byField() {
+        return Stream.of(
+            Arguments.of("integerReference", Integer.class),
+            Arguments.of("integerReferenceWithoutAnnotation", null),
+            Arguments.of("stringReference", String.class),
+            Arguments.of("uuidReference", UUID.class),
+            Arguments.of("longReference", Long.class),
+            Arguments.of("objectReference", TestTypeReferencedByObjectId.IdType.class),
+            Arguments.of("objectReferenceWithAnnotation", TestTypeWithObjectIdRequiringReferenceAnnotation.IdType.class),
+            Arguments.of("objectReferenceWithoutAnnotation", null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersForTestGetIdentityReferenceType_byField")
+    public void testGetIdentityReferenceType_byField(String fieldName, Class<?> expectedErasedResultType) {
+        FieldScope targetField = this.getTestClassField(fieldName);
+        Optional<ResolvedType> result = this.provider.getIdentityReferenceType(targetField);
+        Assertions.assertNotNull(result);
+        if (expectedErasedResultType == null) {
+            Assertions.assertFalse(result.isPresent());
+        } else {
+            Assertions.assertTrue(result.isPresent());
+            Assertions.assertEquals(expectedErasedResultType, result.get().getErasedType());
+        }
+    }
+
+    private static class TestTypeWithReferences {
+
+        @JsonIdentityReference(alwaysAsId = true)
+        private TestTypeReferencedAsInteger integerReference;
+        // the generator is expected to ask once more by the type alone, which will handle this case in the end
+        private TestTypeReferencedAsInteger integerReferenceWithoutAnnotation;
+        @JsonIdentityReference(alwaysAsId = true)
+        private TestTypeReferencedAsString stringReference;
+        @JsonIdentityReference(alwaysAsId = true)
+        private TestTypeReferencedAsUuid uuidReference;
+        @JsonIdentityReference(alwaysAsId = true)
+        private TestTypeReferencedByLongId longReference;
+        @JsonIdentityReference(alwaysAsId = true)
+        private TestTypeReferencedByObjectId objectReference;
+        @JsonIdentityReference(alwaysAsId = true)
+        private TestTypeWithObjectIdRequiringReferenceAnnotation objectReferenceWithAnnotation;
+        private TestTypeWithObjectIdRequiringReferenceAnnotation objectReferenceWithoutAnnotation;
+        
+    }
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class)
+    @JsonIdentityReference(alwaysAsId = true)
+    private static class TestTypeReferencedAsInteger {
+    }
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.StringIdGenerator.class)
+    @JsonIdentityReference(alwaysAsId = true)
+    private static class TestTypeReferencedAsString {
+    }
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.UUIDGenerator.class)
+    @JsonIdentityReference(alwaysAsId = true)
+    private static class TestTypeReferencedAsUuid {
+    }
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+    @JsonIdentityReference(alwaysAsId = true)
+    private static class TestTypeReferencedByLongId {
+        private Long id;
+    }
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+    @JsonIdentityReference(alwaysAsId = true)
+    private static class TestTypeReferencedByObjectId {
+        private IdType id;
+
+        private class IdType {
+        }
+    }
+
+    @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")
+    private static class TestTypeWithObjectIdRequiringReferenceAnnotation {
+        private IdType id;
+
+        private class IdType {
+        }
+    }
+}

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolverLookUpTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolverLookUpTest.java
@@ -17,12 +17,16 @@
 package com.github.victools.jsonschema.module.jackson;
 
 import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import com.github.victools.jsonschema.generator.TypeContext;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
@@ -35,7 +39,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class JsonSubTypesResolverLookUpTest extends AbstractTypeAwareTest {
 
-    private final JsonSubTypesResolver instance = new JsonSubTypesResolver();
+    private final JsonSubTypesResolver instance = new JsonSubTypesResolver(Collections.singleton(JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID));
 
     public JsonSubTypesResolverLookUpTest() {
         super(TestSuperClassWithNameProperty.class);
@@ -73,6 +77,7 @@ public class JsonSubTypesResolverLookUpTest extends AbstractTypeAwareTest {
     static Stream<Arguments> parametersForTestFindTargetTypeOverridesForField() {
         return Stream.of(
             Arguments.of("supertypeNoAnnotation", null),
+            Arguments.of("supertypeWithIdentityReference", null),
             Arguments.of("supertypeWithAnnotationOnField", Arrays.asList(TestSubClass1.class, TestSubClass2.class)),
             Arguments.of("supertypeWithAnnotationOnGetter", Arrays.asList(TestSubClass2.class, TestSubClass3.class)),
             Arguments.of("supertypeWithAnnotationOnFieldAndGetter", Arrays.asList(TestSubClass1.class, TestSubClass2.class))
@@ -90,6 +95,7 @@ public class JsonSubTypesResolverLookUpTest extends AbstractTypeAwareTest {
     static Stream<Arguments> parametersForTestFindTargetTypeOverridesForMethod() {
         return Stream.of(
             Arguments.of("getSupertypeNoAnnotation", null),
+            Arguments.of("getSupertypeWithIdentityReference", null),
             Arguments.of("getSupertypeWithAnnotationOnField", Arrays.asList(TestSubClass1.class, TestSubClass2.class)),
             Arguments.of("getSupertypeWithAnnotationOnGetter", Arrays.asList(TestSubClass2.class, TestSubClass3.class)),
             Arguments.of("getSupertypeWithAnnotationOnFieldAndGetter", Arrays.asList(TestSubClass2.class, TestSubClass3.class))
@@ -110,9 +116,15 @@ public class JsonSubTypesResolverLookUpTest extends AbstractTypeAwareTest {
         @JsonSubTypes.Type(TestSubClass2.class),
         @JsonSubTypes.Type(TestSubClass3.class)
     })
+    @JsonIdentityInfo(generator = ObjectIdGenerators.UUIDGenerator.class)
     private static class TestSuperClassWithNameProperty {
 
         public TestSuperClassWithNameProperty supertypeNoAnnotation;
+        @JsonSubTypes({
+            @JsonSubTypes.Type(TestSubClass1.class),
+            @JsonSubTypes.Type(TestSubClass2.class)
+        })
+        public TestSuperClassWithNameProperty supertypeWithIdentityReference;
         @JsonSubTypes({
             @JsonSubTypes.Type(TestSubClass1.class),
             @JsonSubTypes.Type(TestSubClass2.class)
@@ -127,6 +139,11 @@ public class JsonSubTypesResolverLookUpTest extends AbstractTypeAwareTest {
 
         public TestSuperClassWithNameProperty getSupertypeNoAnnotation() {
             return this.supertypeNoAnnotation;
+        }
+
+        @JsonIdentityReference(alwaysAsId = true)
+        public TestSuperClassWithNameProperty getSupertypeWithIdentityReference() {
+            return supertypeWithIdentityReference;
         }
 
         public TestSuperClassWithNameProperty getSupertypeWithAnnotationOnField() {

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
@@ -26,6 +26,17 @@
         "fieldWithOverriddenName": {
             "type": "boolean",
             "writeOnly": true
+        },
+        "referenceByObjectId": {
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "integer"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
         }
     },
     "description": "test description"

--- a/slate-docs/source/includes/_jackson-module.md
+++ b/slate-docs/source/includes/_jackson-module.md
@@ -30,6 +30,7 @@ SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(Sc
     * Considering `@JsonTypeInfo.use` with values `Id.CLASS`, `Id.NAME`
 12. Consider `@JsonProperty.access` for marking a field/method as `readOnly` or `writeOnly`
 13. Optionally: ignore all methods but those with a `@JsonProperty` annotation, if the `JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS` was provided (i.e. this is an "opt-in").
+14. Optionally: respect `@JsonIdentityReference(alwaysAsId=true)` annotation if there is a corresponding `@JsonIdentityInfo` annotation on the type and the `JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID` as provided (i.e., this is an "opt-in")
 
 Schema attributes derived from annotations on getter methods are also applied to their associated fields.
 


### PR DESCRIPTION
Closes #112.

Only considering `@JsonIdentityReference(alwaysAsId = true)` as the simpler scenario.