### PR TITLE
fix: Maven Plugin Class Filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-maven-plugin`
+#### Fixed
+- regression: filtering of considered classes for schema generation stopped working (after migration to `classgraph` in 4.28.0)
 
 ## [4.28.0] - 2022-10-31
 ### `jsonschema-generator`

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
@@ -166,9 +166,9 @@ public class SchemaGeneratorMojoTest extends AbstractMojoTestCase {
         Assertions.assertTrue(resultFileA.exists());
         resultFileA.deleteOnExit();
 
+        // explicitly excluded, although it is in the target
         File resultFileB = new File(generationLocation,"TestClassB-schema.json");
-        Assertions.assertTrue(resultFileB.exists());
-        resultFileB.deleteOnExit();
+        Assertions.assertFalse(resultFileB.exists());
 
         File resultFileC = new File(generationLocation,"TestClassC-schema.json");
         Assertions.assertTrue(resultFileC.exists());
@@ -179,11 +179,6 @@ public class SchemaGeneratorMojoTest extends AbstractMojoTestCase {
         Assertions.assertTrue(referenceFileA.exists());
         Assertions.assertTrue(FileUtils.contentEqualsIgnoreEOL(resultFileA, referenceFileA, CHARSET_NAME),
                 "Generated schema for TestClassA is not equal to the expected reference.");
-
-        File referenceFileB = new File(testCaseLocation, "TestClassB-reference.json");
-        Assertions.assertTrue(referenceFileB.exists());
-        Assertions.assertTrue(FileUtils.contentEqualsIgnoreEOL(resultFileB, referenceFileB, CHARSET_NAME),
-                "Generated schema for TestClassB is not equal to the expected reference.");
 
         File referenceFileC = new File(testCaseLocation, "TestClassC-reference.json");
         Assertions.assertTrue(referenceFileC.exists());

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/PackageName-pom.xml
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/PackageName-pom.xml
@@ -7,6 +7,7 @@
                 <configuration>
                     <packageNames>com.github.victools.jsonschema.plugin.maven.testpackage</packageNames>
                     <schemaFilePath>target/generated-test-sources/PackageName</schemaFilePath>
+                    <excludeClassNames>com.github.victools.jsonschema.plugin.maven.testpackage.TestClassB</excludeClassNames>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
With the migration from `reflections` to `classgraph` in the last release (4.28.0), a regression was introduced in the Maven Plugin.
The exclusion of certain classes was not working anymore (assuming it was working before).

Fixing this here now and adjusting a unit test to show-case corrected behaviour.