### PR TITLE
chore: Maven Plugin clean-up

### DIFF
--- a/jsonschema-generator-parent/pom.xml
+++ b/jsonschema-generator-parent/pom.xml
@@ -118,7 +118,7 @@
         <maven.plugin.version.enforcer>3.2.1</maven.plugin.version.enforcer>
         <maven.plugin.version.jacoco>0.8.8</maven.plugin.version.jacoco>
         <maven.plugin.version.javadoc>3.4.1</maven.plugin.version.javadoc>
-        <maven.plugin.version.moditect>1.0.0.RC2</maven.plugin.version.moditect>
+        <maven.plugin.version.moditect>1.0.0.RC3</maven.plugin.version.moditect>
         <maven.plugin.version.release>2.5.3</maven.plugin.version.release>
         <maven.plugin.version.source>3.2.1</maven.plugin.version.source>
         <maven.plugin.version.surefire>3.0.0-M7</maven.plugin.version.surefire>

--- a/jsonschema-maven-plugin/pom.xml
+++ b/jsonschema-maven-plugin/pom.xml
@@ -139,7 +139,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>${maven.tools.version}</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/GlobHandler.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/GlobHandler.java
@@ -16,6 +16,7 @@
 
 package com.github.victools.jsonschema.plugin.maven;
 
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 /**
@@ -24,13 +25,24 @@ import java.util.regex.Pattern;
 public class GlobHandler {
 
     /**
+     * Generate predicate to check the given input for filtering classes on the classpath.
+     *
+     * @param input either absolute value (with "." as package separator) or glob pattern (with "/" as package separator)
+     * @param forPackage whether the given input identifies a package
+     * @return predicate to filter classes on classpath by
+     */
+    public static Predicate<String> createClassOrPackageNameFilter(String input, boolean forPackage) {
+        return GlobHandler.createClassOrPackageNamePattern(input, forPackage).asMatchPredicate();
+    }
+
+    /**
      * Generate regular expression from the given input for filtering classes on the classpath.
      *
      * @param input either absolute value (with "." as package separator) or glob pattern (with "/" as package separator)
      * @param forPackage whether the given input identifies a package
      * @return regular expression to filter classes on classpath by
      */
-    public static Pattern createClassOrPackageNameFilter(String input, boolean forPackage) {
+    public static Pattern createClassOrPackageNamePattern(String input, boolean forPackage) {
         String inputRegex;
         if (input.chars().anyMatch(c -> c == '/' || c == '*' || c == '?' || c == '+' || c == '[' || c == '{' || c == '\\')) {
             // convert glob pattern into regular expression

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/testpackage/sub/TestClassC.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/testpackage/sub/TestClassC.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.github.victools.jsonschema.plugin.maven.testpackage.subpackage;
+package com.github.victools.jsonschema.plugin.maven.testpackage.sub;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
 


### PR DESCRIPTION
Avoid unnecessary use of `Pattern.compile(".*")` when matching with all given classes.