### PR TITLE
chore: Add setup for examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-generator`
+#### Added
+- introduce configuration option for `dependentRequired` keyword
+
+#### Changed
+- enable `allOf` clean-up when any of the following keywords are contained: `dependentRequired`/`dependentSchemas`/`prefixItems`/`unevaluatedItems`/`unevaluatedProperties`
 
 ### `jsonschema-examples`
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### `jsonschema-examples`
+#### Added
+- new collection of examples (and implicit integration test) holding various examples (e.g., ones created in response to issues/discussions on Github)
 
 ## [4.29.0] - 2023-03-13
 ### `jsonschema-generator`

--- a/jsonschema-examples/pom.xml
+++ b/jsonschema-examples/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.victools</groupId>
+        <artifactId>jsonschema-generator-parent</artifactId>
+        <version>4.30.0-SNAPSHOT</version>
+        <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
+    </parent>
+    <artifactId>jsonschema-wxamples</artifactId>
+
+    <name>Java JSON Schema Generator - Examples</name>
+    <description>Examples show-casing some of the Java JSON Schema Generator's capabilities</description>
+    <url>https://github.com/victools/jsonschema-generator</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-generator</artifactId>
+        </dependency>
+        <!-- Jackson Module dependencies -->
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-jackson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <!-- JavaXValidation Module dependencies -->
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-javax-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <!-- JakartaValidation Module dependencies -->
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-jakarta-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+        <!-- Swagger 1.5 Module dependencies -->
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-swagger-1.5</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+        <!-- Swagger 2 Module dependencies -->
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-swagger-2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/IfThenElseExample.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/IfThenElseExample.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2023 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.examples;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGenerationContext;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaKeyword;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.generator.TypeAttributeOverrideV2;
+import com.github.victools.jsonschema.generator.TypeScope;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.stream.Stream;
+
+/**
+ * Example created in response to <a href="https://github.com/victools/jsonschema-generator/discussions/328">#328</a>.
+ * <br/>
+ * Creating "if"/"then"/"else" blocks via custom annotations, leveraging the Swagger @Schema annotation.
+ */
+public class IfThenElseExample implements SchemaGenerationExampleInterface {
+
+    @Override
+    public JsonNode generateSchema() {
+        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON);
+        configBuilder.forTypesInGeneral().withTypeAttributeOverride(new SchemaConditionAttributeOverride());
+        SchemaGeneratorConfig config = configBuilder.build();
+        SchemaGenerator generator = new SchemaGenerator(config);
+        return generator.generateSchema(TestType.class);
+    }
+
+    static class SchemaConditionAttributeOverride implements TypeAttributeOverrideV2 {
+
+        @Override
+        public void overrideTypeAttributes(ObjectNode schemaNode, TypeScope scope, SchemaGenerationContext context) {
+            SchemaCondition annotation = scope.getContext().getTypeAnnotationConsideringHierarchy(scope.getType(), SchemaCondition.class);
+            if (annotation == null) {
+                return;
+            }
+            ObjectNode conditionParentNode;
+            if (schemaNode.has(context.getKeyword(SchemaKeyword.TAG_IF))
+                    || schemaNode.has(context.getKeyword(SchemaKeyword.TAG_THEN))
+                    || schemaNode.has(context.getKeyword(SchemaKeyword.TAG_ELSE))) {
+                // add via allOf to avoid conflicts
+                conditionParentNode = schemaNode.withArray(context.getKeyword(SchemaKeyword.TAG_ALLOF)).addObject();
+            } else {
+                conditionParentNode = schemaNode;
+            }
+
+            this.populate(conditionParentNode.putObject(context.getKeyword(SchemaKeyword.TAG_IF)), annotation.ifFulFilled(), context);
+            if (annotation.thenExpect().length > 0) {
+                ObjectNode thenNode = conditionParentNode.putObject(context.getKeyword(SchemaKeyword.TAG_THEN));
+                Stream.of(annotation.thenExpect()).forEach(thenCondition -> this.populate(thenNode, thenCondition, context));
+            }
+            if (annotation.elseExpect().length > 0) {
+                ObjectNode elseNode = conditionParentNode.putObject(context.getKeyword(SchemaKeyword.TAG_ELSE));
+                Stream.of(annotation.elseExpect()).forEach(elseCondition -> this.populate(elseNode, elseCondition, context));
+            }
+        }
+
+        private void populate(ObjectNode node, SchemaProperty propertyAnnotation, SchemaGenerationContext context) {
+            // mark reference property as required
+            node.withArray(context.getKeyword(SchemaKeyword.TAG_REQUIRED)).add(propertyAnnotation.name());
+            // check additional requirement
+            ObjectNode propertyNode = this.withObject(
+                    this.withObject(node, context.getKeyword(SchemaKeyword.TAG_PROPERTIES)),
+                    propertyAnnotation.name());
+            if (!"".equals(propertyAnnotation.constValue())) {
+                propertyNode.put(context.getKeyword(SchemaKeyword.TAG_CONST), propertyAnnotation.constValue());
+            } else if (!"".equals(propertyAnnotation.pattern())) {
+                propertyNode.put(context.getKeyword(SchemaKeyword.TAG_PATTERN), propertyAnnotation.pattern());
+            }
+        }
+
+        private ObjectNode withObject(ObjectNode node, String keyword) {
+            return node.has(keyword) ? (ObjectNode) node.get(keyword) : node.putObject(keyword);
+        }
+    }
+
+    @SchemaCondition(
+            ifFulFilled = @SchemaProperty(name = "country", constValue = "US"),
+            thenExpect = @SchemaProperty(name = "postalCode", pattern = "^\\d{5}(?:[-\\s]\\d{4})?$"),
+            elseExpect = @SchemaProperty(name = "postalCode", pattern = "^[-\\s\\d]+$")
+    )
+    static class TestType {
+
+        String country;
+        String postalCode;
+    }
+
+    @Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SchemaCondition {
+        SchemaProperty ifFulFilled();
+        SchemaProperty[] thenExpect() default {};
+        SchemaProperty[] elseExpect() default {};
+    }
+
+    @Target({ElementType.ANNOTATION_TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface SchemaProperty {
+        String name();
+        String constValue() default "";
+        String pattern() default "";
+    }
+}

--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/IfThenElseExample.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/IfThenElseExample.java
@@ -85,9 +85,9 @@ public class IfThenElseExample implements SchemaGenerationExampleInterface {
             ObjectNode propertyNode = this.withObject(
                     this.withObject(node, context.getKeyword(SchemaKeyword.TAG_PROPERTIES)),
                     propertyAnnotation.name());
-            if (!"".equals(propertyAnnotation.constValue())) {
+            if (!Objects.equals(propertyAnnotation.constValue(), "")) {
                 propertyNode.put(context.getKeyword(SchemaKeyword.TAG_CONST), propertyAnnotation.constValue());
-            } else if (!"".equals(propertyAnnotation.pattern())) {
+            } else if (!Objects.equals(propertyAnnotation.pattern(), "")) {
                 propertyNode.put(context.getKeyword(SchemaKeyword.TAG_PATTERN), propertyAnnotation.pattern());
             }
         }

--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/IfThenElseExample.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/IfThenElseExample.java
@@ -31,6 +31,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**

--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/SchemaGenerationExampleInterface.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/SchemaGenerationExampleInterface.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.examples;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Common interface for schema generation examples, in order to allow generic testing of all examples.
+ */
+public interface SchemaGenerationExampleInterface {
+
+    /**
+     * Generate a JSON schema.
+     *
+     * @return generated schema (typically as ObjectNode)
+     */
+    JsonNode generateSchema();
+}

--- a/jsonschema-examples/src/test/java/com/github/victools/jsonschema/examples/ExampleTest.java
+++ b/jsonschema-examples/src/test/java/com/github/victools/jsonschema/examples/ExampleTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.examples;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.Scanner;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+
+public class ExampleTest {
+
+    @ParameterizedTest
+    @ValueSource(classes = {
+            IfThenElseExample.class
+    })
+    public void testExample(Class<? extends SchemaGenerationExampleInterface> exampleType) throws Exception {
+        SchemaGenerationExampleInterface exampleImplementation = exampleType.getDeclaredConstructor().newInstance();
+        JsonNode result = exampleImplementation.generateSchema();
+        String rawJsonSchema = result.toPrettyString();
+        JSONAssert.assertEquals('\n' + rawJsonSchema + '\n',
+                loadResource(exampleType.getSimpleName() + "-result.json"), rawJsonSchema,
+                JSONCompareMode.STRICT);
+    }
+
+    private static String loadResource(String resourcePath) throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+        try (InputStream inputStream = Objects.requireNonNull(ExampleTest.class.getResourceAsStream(resourcePath));
+             Scanner scanner = new Scanner(inputStream, StandardCharsets.UTF_8.name())) {
+            while (scanner.hasNext()) {
+                stringBuilder.append(scanner.nextLine()).append('\n');
+            }
+        }
+        return stringBuilder.toString();
+    }
+}

--- a/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/IfThenElseExample-result.json
+++ b/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/IfThenElseExample-result.json
@@ -1,0 +1,36 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "type" : "object",
+  "properties" : {
+    "country" : {
+      "type" : "string"
+    },
+    "postalCode" : {
+      "type" : "string"
+    }
+  },
+  "if" : {
+    "required" : [ "country" ],
+    "properties" : {
+      "country" : {
+        "const" : "US"
+      }
+    }
+  },
+  "then" : {
+    "required" : [ "postalCode" ],
+    "properties" : {
+      "postalCode" : {
+        "pattern" : "^\\d{5}(?:[-\\s]\\d{4})?$"
+      }
+    }
+  },
+  "else" : {
+    "required" : [ "postalCode" ],
+    "properties" : {
+      "postalCode" : {
+        "pattern" : "^[-\\s\\d]+$"
+      }
+    }
+  }
+}

--- a/jsonschema-examples/src/test/resources/logback.xml
+++ b/jsonschema-examples/src/test/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="warn">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaBuilderTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaBuilderTest.java
@@ -54,7 +54,7 @@ public class SchemaBuilderTest {
                 .putObject("content").putObject("application/json")
                 .set("schema", instance.createSchemaReference(TestClass1.class));
         testPathPost.putObject("responses").putObject("200")
-                .put("description", "succesful POST")
+                .put("description", "successful POST")
                 .putObject("content").putObject("application/json")
                 .set("schema", instance.createSchemaReference(TestClass2.class));
         ObjectNode testPathPut = testPath.putObject("put");
@@ -62,7 +62,7 @@ public class SchemaBuilderTest {
                 .putObject("content").putObject("application/json")
                 .set("schema", instance.createSchemaReference(TestClass3.class));
         testPathPut.putObject("responses").putObject("201")
-                .put("description", "succesful PUT")
+                .put("description", "successful PUT")
                 .putObject("content").putObject("application/json")
                 .set("schema", instance.createSchemaReference(TestClass3.class));
 

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/openapi.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/openapi.json
@@ -23,7 +23,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "succesful POST",
+                        "description": "successful POST",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -46,7 +46,7 @@
                 },
                 "responses": {
                     "201": {
-                        "description": "succesful PUT",
+                        "description": "successful PUT",
                         "content": {
                             "application/json": {
                                 "schema": {

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <module>jsonschema-module-swagger-1.5</module>
         <module>jsonschema-module-swagger-2</module>
         <module>jsonschema-maven-plugin</module>
+        <module>jsonschema-examples</module>
     </modules>
 
     <build>


### PR DESCRIPTION
- adding a new test module, where various examples can be collected and used as additional integration tests
- first example: custom annotations used to generate `if`/`then`/`else` blocks in a schema