### PR TITLE
chore(example): Add examples for external refs

### DIFF
--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/ExternalRefAnnotationExample.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/ExternalRefAnnotationExample.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.examples;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.CustomDefinition;
+import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGenerationContext;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaKeyword;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.module.swagger2.Swagger2Module;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Example created in response to <a href="https://github.com/victools/jsonschema-generator/issues/319">#319</a>.
+ * <br/>
+ * Based on Swagger2 {@code @Schema} annotations, allowing to reference "external" files.
+ */
+public class ExternalRefAnnotationExample implements SchemaGenerationExampleInterface {
+
+    @Override
+    public ObjectNode generateSchema() {
+        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_7, OptionPreset.PLAIN_JSON);
+        configBuilder.with(new Swagger2Module());
+        // add "$schema" property in Example.class' schema
+        configBuilder.forTypesInGeneral().withTypeAttributeOverride((schema, scope, context) -> {
+            if (scope.getType().getErasedType() == Example.class) {
+                ((ObjectNode) schema.putIfAbsent(context.getKeyword(SchemaKeyword.TAG_PROPERTIES), schema.objectNode()))
+                        .set(context.getKeyword(SchemaKeyword.TAG_SCHEMA),
+                                context.createStandardDefinition(context.getTypeContext().resolve(String.class), null));
+            }
+        });
+        // add external "$ref", if one is referenced by @Schema(ref = "...")
+        configBuilder.forTypesInGeneral().withCustomDefinitionProvider(new SchemaRefDefinitionProvider());
+        SchemaGeneratorConfig config = configBuilder.build();
+        SchemaGenerator generator = new SchemaGenerator(config);
+        return generator.generateSchema(Example.class);
+    }
+
+    private static class SchemaRefDefinitionProvider implements CustomDefinitionProviderV2 {
+
+        private Class<?> mainType;
+
+        @Override
+        public CustomDefinition provideCustomSchemaDefinition(ResolvedType javaType, SchemaGenerationContext context) {
+            Class<?> erasedType = javaType.getErasedType();
+            if (this.mainType == null) {
+                this.mainType = erasedType;
+            }
+            if (this.mainType == erasedType) {
+                // avoid external ref to the "main" schema being generated
+                return null;
+            }
+            // look-up external reference from @Schema(ref = "...")
+            return Optional.ofNullable(erasedType.getAnnotation(Schema.class))
+                    .map(Schema::ref)
+                    .filter(ref -> !ref.isEmpty())
+                    .map(ref -> context.getGeneratorConfig().createObjectNode()
+                            .put(context.getKeyword(SchemaKeyword.TAG_REF), ref))
+                    .map(schema -> new CustomDefinition(schema,
+                            CustomDefinition.INLINE_DEFINITION,
+                            CustomDefinition.INCLUDING_ATTRIBUTES))
+                    .orElse(null);
+        }
+
+        @Override
+        public void resetAfterSchemaGenerationFinished() {
+            this.mainType = null;
+        }
+    }
+
+    class Example {
+        @Schema(description = "alpha")
+        private String alpha;
+        @Schema(ref = "./BetaSchema.json")
+        private Object beta;
+        @Schema(description = "sigma")
+        private Double sigma;
+        @ArraySchema(schema = @Schema(oneOf = {Theta.class, Tau.class}))
+        private List<Omega> omega;
+    }
+
+    class Omega {
+    }
+
+    @Schema(
+            title = "Theta",
+            description = "Theta",
+            additionalProperties = Schema.AdditionalPropertiesValue.FALSE,
+            ref = "./ThetaSchema.json")
+    class Theta extends Omega {
+    }
+
+    // Implementation omitted for brevity
+    @Schema(
+            title = "Tau",
+            description = "Tau",
+            additionalProperties = Schema.AdditionalPropertiesValue.FALSE,
+            ref = "./TauSchema.json")
+    class Tau extends Omega {
+    }
+}

--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/ExternalRefAnnotationExample.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/ExternalRefAnnotationExample.java
@@ -91,7 +91,7 @@ public class ExternalRefAnnotationExample implements SchemaGenerationExampleInte
         }
     }
 
-    class Example {
+    static class Example {
         @Schema(description = "alpha")
         private String alpha;
         @Schema(ref = "./BetaSchema.json")
@@ -102,7 +102,7 @@ public class ExternalRefAnnotationExample implements SchemaGenerationExampleInte
         private List<Omega> omega;
     }
 
-    class Omega {
+    static class Omega {
     }
 
     @Schema(
@@ -110,7 +110,7 @@ public class ExternalRefAnnotationExample implements SchemaGenerationExampleInte
             description = "Theta",
             additionalProperties = Schema.AdditionalPropertiesValue.FALSE,
             ref = "./ThetaSchema.json")
-    class Theta extends Omega {
+    static class Theta extends Omega {
     }
 
     // Implementation omitted for brevity
@@ -119,6 +119,6 @@ public class ExternalRefAnnotationExample implements SchemaGenerationExampleInte
             description = "Tau",
             additionalProperties = Schema.AdditionalPropertiesValue.FALSE,
             ref = "./TauSchema.json")
-    class Tau extends Omega {
+    static class Tau extends Omega {
     }
 }

--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/ExternalRefPackageExample.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/ExternalRefPackageExample.java
@@ -51,10 +51,12 @@ public class ExternalRefPackageExample implements SchemaGenerationExampleInterfa
 
         private static final String PACKAGE_FOR_EXTERNAL_REFS = "com.github.victools.jsonschema.example";
         private static final String EXTERNAL_REF_PREFIX = "http://foo.bar/";
+        private static final String EXTERNAL_REF_SUFFIX = ".json";
 
         @Override
         public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
-            SchemaRefDefinitionProvider definitionProvider = new SchemaRefDefinitionProvider(PACKAGE_FOR_EXTERNAL_REFS, EXTERNAL_REF_PREFIX);
+            SchemaRefDefinitionProvider definitionProvider = new SchemaRefDefinitionProvider(PACKAGE_FOR_EXTERNAL_REFS,
+                    EXTERNAL_REF_PREFIX, EXTERNAL_REF_SUFFIX);
             builder.forTypesInGeneral()
                     .withCustomDefinitionProvider(definitionProvider)
                     .withIdResolver(scope -> definitionProvider.isMainType(scope.getType())
@@ -65,11 +67,13 @@ public class ExternalRefPackageExample implements SchemaGenerationExampleInterfa
 
             private final String packageForExternalRefs;
             private final String externalRefPrefix;
+            private final String externalRefSuffix;
             private Class<?> mainType;
 
-            SchemaRefDefinitionProvider(String packageForExternalRefs, String externalRefPrefix) {
+            SchemaRefDefinitionProvider(String packageForExternalRefs, String externalRefPrefix, String externalRefSuffix) {
                 this.packageForExternalRefs = packageForExternalRefs;
                 this.externalRefPrefix = externalRefPrefix;
+                this.externalRefSuffix = externalRefSuffix;
             }
 
             @Override
@@ -92,7 +96,7 @@ public class ExternalRefPackageExample implements SchemaGenerationExampleInterfa
             }
 
             String getExternalRef(ResolvedType javaType) {
-                return this.externalRefPrefix + javaType.getErasedType().getName();
+                return this.externalRefPrefix + javaType.getErasedType().getName() + this.externalRefSuffix;
             }
 
             @Override

--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/ExternalRefPackageExample.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/ExternalRefPackageExample.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.examples;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.CustomDefinition;
+import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2;
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGenerationContext;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaKeyword;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+
+/**
+ * Example created in response to <a href="https://github.com/victools/jsonschema-generator/issues/248">#248</a>.
+ * <br/>
+ * For use via the Maven plugin where schemas for all types in a given package will be generated and should reference each other.
+ */
+public class ExternalRefPackageExample implements SchemaGenerationExampleInterface {
+
+    @Override
+    public ObjectNode generateSchema() {
+        SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .with(new ModuleImpl())
+                .build();
+        return new SchemaGenerator(config).generateSchema(Example.class);
+    }
+
+    /**
+     * Wrapped as module with zero-parameter constructor for use via the Maven plugin.
+     */
+    public static class ModuleImpl implements Module {
+
+        private static final String PACKAGE_FOR_EXTERNAL_REFS = "com.github.victools.jsonschema.example";
+        private static final String EXTERNAL_REF_PREFIX = "http://foo.bar/";
+
+        @Override
+        public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+            SchemaRefDefinitionProvider definitionProvider = new SchemaRefDefinitionProvider(PACKAGE_FOR_EXTERNAL_REFS, EXTERNAL_REF_PREFIX);
+            builder.forTypesInGeneral()
+                    .withCustomDefinitionProvider(definitionProvider)
+                    .withIdResolver(scope -> definitionProvider.isMainType(scope.getType())
+                            ? definitionProvider.getExternalRef(scope.getType()) : null);
+        }
+
+        static class SchemaRefDefinitionProvider implements CustomDefinitionProviderV2 {
+
+            private final String packageForExternalRefs;
+            private final String externalRefPrefix;
+            private Class<?> mainType;
+
+            SchemaRefDefinitionProvider(String packageForExternalRefs, String externalRefPrefix) {
+                this.packageForExternalRefs = packageForExternalRefs;
+                this.externalRefPrefix = externalRefPrefix;
+            }
+
+            @Override
+            public CustomDefinition provideCustomSchemaDefinition(ResolvedType javaType, SchemaGenerationContext context) {
+                Class<?> erasedType = javaType.getErasedType();
+                if (this.mainType == null) {
+                    this.mainType = erasedType;
+                } else if (!this.isMainType(javaType)
+                        && erasedType.getPackage() != null
+                        && erasedType.getPackage().getName().startsWith(this.packageForExternalRefs)) {
+                    ObjectNode schema = context.getGeneratorConfig().createObjectNode()
+                            .put(context.getKeyword(SchemaKeyword.TAG_REF), this.getExternalRef(javaType));
+                    return new CustomDefinition(schema, CustomDefinition.INLINE_DEFINITION, CustomDefinition.INCLUDING_ATTRIBUTES);
+                }
+                return null;
+            }
+
+            boolean isMainType(ResolvedType javaType) {
+                return this.mainType == javaType.getErasedType();
+            }
+
+            String getExternalRef(ResolvedType javaType) {
+                return this.externalRefPrefix + javaType.getErasedType().getName();
+            }
+
+            @Override
+            public void resetAfterSchemaGenerationFinished() {
+                this.mainType = null;
+            }
+        }
+    }
+
+    static class Example {
+        public String text;
+        public Foo foo;
+        public Bar bar;
+    }
+
+    static class Foo {
+    }
+
+    static class Bar {
+    }
+}

--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/IfThenElseExample.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/IfThenElseExample.java
@@ -16,7 +16,6 @@
 
 package com.github.victools.jsonschema.examples;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerationContext;
@@ -42,7 +41,7 @@ import java.util.stream.Stream;
 public class IfThenElseExample implements SchemaGenerationExampleInterface {
 
     @Override
-    public JsonNode generateSchema() {
+    public ObjectNode generateSchema() {
         SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON);
         configBuilder.forTypesInGeneral().withTypeAttributeOverride(new SchemaConditionAttributeOverride());
         SchemaGeneratorConfig config = configBuilder.build();

--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/SchemaGenerationExampleInterface.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/SchemaGenerationExampleInterface.java
@@ -17,6 +17,7 @@
 package com.github.victools.jsonschema.examples;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Common interface for schema generation examples, in order to allow generic testing of all examples.
@@ -26,7 +27,7 @@ public interface SchemaGenerationExampleInterface {
     /**
      * Generate a JSON schema.
      *
-     * @return generated schema (typically as ObjectNode)
+     * @return generated schema
      */
-    JsonNode generateSchema();
+    ObjectNode generateSchema();
 }

--- a/jsonschema-examples/src/test/java/com/github/victools/jsonschema/examples/ExampleTest.java
+++ b/jsonschema-examples/src/test/java/com/github/victools/jsonschema/examples/ExampleTest.java
@@ -31,6 +31,8 @@ public class ExampleTest {
 
     @ParameterizedTest
     @ValueSource(classes = {
+            ExternalRefAnnotationExample.class,
+            ExternalRefPackageExample.class,
             IfThenElseExample.class
     })
     public void testExample(Class<? extends SchemaGenerationExampleInterface> exampleType) throws Exception {

--- a/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/ExternalRefAnnotationExample-result.json
+++ b/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/ExternalRefAnnotationExample-result.json
@@ -1,0 +1,35 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object",
+  "properties" : {
+    "alpha" : {
+      "type" : "string",
+      "description" : "alpha"
+    },
+    "beta" : {
+      "$ref" : "./BetaSchema.json"
+    },
+    "omega" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "oneOf" : [ {
+          "$ref" : "./ThetaSchema.json",
+          "title" : "Theta",
+          "description" : "Theta"
+        }, {
+          "$ref" : "./TauSchema.json",
+          "title" : "Tau",
+          "description" : "Tau"
+        } ]
+      }
+    },
+    "sigma" : {
+      "type" : "number",
+      "description" : "sigma"
+    },
+    "$schema" : {
+      "type" : "string"
+    }
+  }
+}

--- a/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/ExternalRefPackageExample-result.json
+++ b/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/ExternalRefPackageExample-result.json
@@ -3,14 +3,14 @@
   "type" : "object",
   "properties" : {
     "bar" : {
-      "$ref" : "http://foo.bar/com.github.victools.jsonschema.examples.ExternalRefPackageExample$Bar"
+      "$ref" : "http://foo.bar/com.github.victools.jsonschema.examples.ExternalRefPackageExample$Bar.json"
     },
     "foo" : {
-      "$ref" : "http://foo.bar/com.github.victools.jsonschema.examples.ExternalRefPackageExample$Foo"
+      "$ref" : "http://foo.bar/com.github.victools.jsonschema.examples.ExternalRefPackageExample$Foo.json"
     },
     "text" : {
       "type" : "string"
     }
   },
-  "$id" : "http://foo.bar/com.github.victools.jsonschema.examples.ExternalRefPackageExample$Example"
+  "$id" : "http://foo.bar/com.github.victools.jsonschema.examples.ExternalRefPackageExample$Example.json"
 }

--- a/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/ExternalRefPackageExample-result.json
+++ b/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/ExternalRefPackageExample-result.json
@@ -1,0 +1,16 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "type" : "object",
+  "properties" : {
+    "bar" : {
+      "$ref" : "http://foo.bar/com.github.victools.jsonschema.examples.ExternalRefPackageExample$Bar"
+    },
+    "foo" : {
+      "$ref" : "http://foo.bar/com.github.victools.jsonschema.examples.ExternalRefPackageExample$Foo"
+    },
+    "text" : {
+      "type" : "string"
+    }
+  },
+  "$id" : "http://foo.bar/com.github.victools.jsonschema.examples.ExternalRefPackageExample$Example"
+}


### PR DESCRIPTION
Two more entries for the new "examples" folder:
- assigning an external `$ref` based on an annotation
- for use in Maven plugin: apply `$ref` to all types in a specific package (and its subpackages) and `$id` on the "main" schema