### PR TITLE
feat: Introduce Option.STRICT_TYPE_INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `jsonschema-generator`
 #### Added
 - introduce configuration option for `dependentRequired` keyword
+- introduce new `Option.STRICT_TYPE_INFO` for implying the `type` of sub-schemas based on their contained attributes (note: implied "type" array always contains "null")
 
 #### Changed
 - enable `allOf` clean-up when any of the following keywords are contained: `dependentRequired`/`dependentSchemas`/`prefixItems`/`unevaluatedItems`/`unevaluatedProperties`
+- extend consideration of sub-schemas for `allOf` clean-up to more recognized keywords
 
 ### `jsonschema-examples`
 #### Added

--- a/jsonschema-examples/pom.xml
+++ b/jsonschema-examples/pom.xml
@@ -8,7 +8,8 @@
         <version>4.30.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
-    <artifactId>jsonschema-wxamples</artifactId>
+    <artifactId>jsonschema-examples</artifactId>
+    <packaging>pom</packaging>
 
     <name>Java JSON Schema Generator - Examples</name>
     <description>Examples show-casing some of the Java JSON Schema Generator's capabilities</description>

--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/StrictTypeInfoExample.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/StrictTypeInfoExample.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.examples;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.Option;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+
+/**
+ * Example created in response to <a href="https://github.com/victools/jsonschema-generator/discussions/333">#333</a>.
+ * <br/>
+ * Ensuring "type" inclusion on "allOf" parts holding collected attributes, e.g., "additionalProperties".
+ */
+public class StrictTypeInfoExample implements SchemaGenerationExampleInterface {
+
+    @Override
+    public ObjectNode generateSchema() {
+        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_7, OptionPreset.PLAIN_JSON);
+        configBuilder.with(Option.STRICT_TYPE_INFO, Option.DEFINITIONS_FOR_ALL_OBJECTS);
+        configBuilder.forFields()
+                .withAdditionalPropertiesResolver(field -> field.getType().getErasedType() == NestedType.class ? Void.class : null);
+        SchemaGeneratorConfig config = configBuilder.build();
+        SchemaGenerator generator = new SchemaGenerator(config);
+        return generator.generateSchema(Example.class);
+    }
+
+    static class Example {
+
+        private NestedType alpha;
+    }
+
+    static class NestedType {
+        private NestedType beta;
+    }
+}

--- a/jsonschema-examples/src/test/java/com/github/victools/jsonschema/examples/ExampleTest.java
+++ b/jsonschema-examples/src/test/java/com/github/victools/jsonschema/examples/ExampleTest.java
@@ -33,7 +33,8 @@ public class ExampleTest {
     @ValueSource(classes = {
             ExternalRefAnnotationExample.class,
             ExternalRefPackageExample.class,
-            IfThenElseExample.class
+            IfThenElseExample.class,
+            StrictTypeInfoExample.class
     })
     public void testExample(Class<? extends SchemaGenerationExampleInterface> exampleType) throws Exception {
         SchemaGenerationExampleInterface exampleImplementation = exampleType.getDeclaredConstructor().newInstance();

--- a/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/StrictTypeInfoExample-result.json
+++ b/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/StrictTypeInfoExample-result.json
@@ -1,0 +1,29 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "definitions" : {
+    "NestedType" : {
+      "type" : "object",
+      "properties" : {
+        "beta" : {
+          "allOf" : [ {
+            "$ref" : "#/definitions/NestedType"
+          }, {
+            "additionalProperties" : false,
+            "type" : [ "object", "null" ]
+          } ]
+        }
+      }
+    }
+  },
+  "type" : "object",
+  "properties" : {
+    "alpha" : {
+      "allOf" : [ {
+        "$ref" : "#/definitions/NestedType"
+      }, {
+        "additionalProperties" : false,
+        "type" : [ "object", "null" ]
+      } ]
+    }
+  }
+}

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/Option.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/Option.java
@@ -302,7 +302,14 @@ public enum Option {
      *
      * @since 4.6.0
      */
-    ALLOF_CLEANUP_AT_THE_END(null, null);
+    ALLOF_CLEANUP_AT_THE_END(null, null),
+    /**
+     * Whether at the end of the schema generation, all sub-schemas without an explicit "type" indication should be augmented by the implied "type"
+     * based on the other tags in the respective schema.
+     *
+     * @since 4.30.0
+     */
+    STRICT_TYPE_INFO(null, null);
 
     /**
      * Optional: the module realising the setting/option if it is enabled.

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
@@ -187,6 +187,9 @@ public class SchemaBuilder {
             cleanUpUtils.reduceAllOfNodes(this.schemaNodes);
         }
         cleanUpUtils.reduceAnyOfNodes(this.schemaNodes);
+        if (this.config.shouldIncludeStrictTypeInfo()) {
+            cleanUpUtils.setStrictTypeInfo(this.schemaNodes, true);
+        }
     }
 
     /**

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
@@ -113,6 +113,13 @@ public interface SchemaGeneratorConfig extends StatefulConfig {
     boolean shouldCleanupUnnecessaryAllOfElements();
 
     /**
+     * Determine whether sub schemas should get the {@link SchemaKeyword#TAG_TYPE} added implicitly based on other contained tags, if it is missing.
+     *
+     * @return whether to try and imply the {@link SchemaKeyword#TAG_TYPE} from other contained tags in the schema
+     */
+    boolean shouldIncludeStrictTypeInfo();
+
+    /**
      * Determine whether static fields should be included in the generated schema.
      *
      * @return whether to include static fields

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
@@ -16,29 +16,32 @@
 
 package com.github.victools.jsonschema.generator;
 
-import java.util.EnumSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * JSON Schema properties and their values.
  */
 public enum SchemaKeyword {
-    TAG_SCHEMA("$schema", EnumSet.of(TagContent.NON_SCHEMA)),
-    TAG_SCHEMA_VALUE(SchemaVersion::getIdentifier, EnumSet.noneOf(TagContent.class), EnumSet.noneOf(SchemaType.class)),
-    TAG_ID("$id", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_SCHEMA("$schema", Collections.singletonList(TagContent.NON_SCHEMA)),
+    TAG_SCHEMA_VALUE(SchemaVersion::getIdentifier, Collections.emptyList(), Collections.emptyList()),
+    TAG_ID("$id", Collections.singletonList(TagContent.NON_SCHEMA)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
-    TAG_ANCHOR("$anchor", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_ANCHOR("$anchor", Collections.singletonList(TagContent.NON_SCHEMA)),
     TAG_DEFINITIONS(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7 ? "definitions" : "$defs",
-            EnumSet.of(TagContent.NAMED_SCHEMAS), EnumSet.noneOf(SchemaType.class)),
+            Collections.singletonList(TagContent.NAMED_SCHEMAS), Collections.emptyList()),
     /**
      * Before {@link SchemaVersion#DRAFT_2019_09} all other properties in the same sub-schema besides this one were ignored.
      */
-    TAG_REF("$ref", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_REF("$ref", Collections.singletonList(TagContent.NON_SCHEMA)),
     TAG_REF_MAIN("#"),
     /**
      * Common prefix of all standard {@link #TAG_REF} values.
@@ -47,9 +50,9 @@ public enum SchemaKeyword {
      */
     @Deprecated
     TAG_REF_PREFIX(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7 ? "#/definitions/" : "#/$defs/",
-            EnumSet.noneOf(TagContent.class), EnumSet.noneOf(SchemaType.class)),
+            Collections.emptyList(), Collections.emptyList()),
 
-    TAG_TYPE("type", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_TYPE("type", Collections.singletonList(TagContent.NON_SCHEMA)),
     TAG_TYPE_NULL(SchemaType.NULL.getSchemaKeywordValue()),
     TAG_TYPE_ARRAY(SchemaType.ARRAY.getSchemaKeywordValue()),
     TAG_TYPE_OBJECT(SchemaType.OBJECT.getSchemaKeywordValue()),
@@ -58,87 +61,87 @@ public enum SchemaKeyword {
     TAG_TYPE_INTEGER(SchemaType.INTEGER.getSchemaKeywordValue()),
     TAG_TYPE_NUMBER(SchemaType.NUMBER.getSchemaKeywordValue()),
 
-    TAG_PROPERTIES("properties", EnumSet.of(TagContent.NAMED_SCHEMAS), EnumSet.of(SchemaType.OBJECT)),
+    TAG_PROPERTIES("properties", Collections.singletonList(TagContent.NAMED_SCHEMAS), Collections.singletonList(SchemaType.OBJECT)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
-    TAG_UNEVALUATED_PROPERTIES("unevaluatedProperties", EnumSet.of(TagContent.SCHEMA), EnumSet.of(SchemaType.OBJECT)),
-    TAG_ITEMS("items", EnumSet.of(TagContent.SCHEMA, TagContent.ARRAY_OF_SCHEMAS), EnumSet.of(SchemaType.ARRAY)),
+    TAG_UNEVALUATED_PROPERTIES("unevaluatedProperties", Collections.singletonList(TagContent.SCHEMA), Collections.singletonList(SchemaType.OBJECT)),
+    TAG_ITEMS("items", Arrays.asList(TagContent.SCHEMA, TagContent.ARRAY_OF_SCHEMAS), Collections.singletonList(SchemaType.ARRAY)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
     TAG_PREFIX_ITEMS(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7 ? "items" : "prefixItems",
-            EnumSet.of(TagContent.ARRAY_OF_SCHEMAS), EnumSet.of(SchemaType.ARRAY)),
+            Collections.singletonList(TagContent.ARRAY_OF_SCHEMAS), Collections.singletonList(SchemaType.ARRAY)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
-    TAG_UNEVALUATED_ITEMS("unevaluatedItems", EnumSet.of(TagContent.SCHEMA), EnumSet.of(SchemaType.ARRAY)),
-    TAG_REQUIRED("required", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.OBJECT)),
+    TAG_UNEVALUATED_ITEMS("unevaluatedItems", Collections.singletonList(TagContent.SCHEMA), Collections.singletonList(SchemaType.ARRAY)),
+    TAG_REQUIRED("required", Collections.singletonList(TagContent.NON_SCHEMA), Collections.singletonList(SchemaType.OBJECT)),
     /**
      * Prior to {@link SchemaVersion#DRAFT_2019_09}, this had the same name as {@link #TAG_DEPENDENT_REQUIRED}.
      */
     TAG_DEPENDENT_SCHEMAS(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7
-            ? "dependencies" : "dependentSchemas", EnumSet.of(TagContent.NAMED_SCHEMAS), EnumSet.of(SchemaType.OBJECT)),
+            ? "dependencies" : "dependentSchemas", Collections.singletonList(TagContent.NAMED_SCHEMAS), Collections.singletonList(SchemaType.OBJECT)),
     /**
      * Prior to {@link SchemaVersion#DRAFT_2019_09}, this had the same name as {@link #TAG_DEPENDENT_SCHEMAS}.
      */
     TAG_DEPENDENT_REQUIRED(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7
-            ? "dependencies" : "dependentRequired", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.OBJECT)),
-    TAG_ADDITIONAL_PROPERTIES("additionalProperties", EnumSet.of(TagContent.SCHEMA), EnumSet.of(SchemaType.OBJECT)),
-    TAG_PATTERN_PROPERTIES("patternProperties", EnumSet.of(TagContent.NAMED_SCHEMAS), EnumSet.of(SchemaType.OBJECT)),
-    TAG_PROPERTIES_MIN("minProperties", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.OBJECT)),
-    TAG_PROPERTIES_MAX("maxProperties", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.OBJECT)),
+            ? "dependencies" : "dependentRequired", Collections.singletonList(TagContent.NON_SCHEMA), Collections.singletonList(SchemaType.OBJECT)),
+    TAG_ADDITIONAL_PROPERTIES("additionalProperties", Collections.singletonList(TagContent.SCHEMA), Collections.singletonList(SchemaType.OBJECT)),
+    TAG_PATTERN_PROPERTIES("patternProperties", Collections.singletonList(TagContent.NAMED_SCHEMAS), Collections.singletonList(SchemaType.OBJECT)),
+    TAG_PROPERTIES_MIN("minProperties", Collections.singletonList(TagContent.NON_SCHEMA), Collections.singletonList(SchemaType.OBJECT)),
+    TAG_PROPERTIES_MAX("maxProperties", Collections.singletonList(TagContent.NON_SCHEMA), Collections.singletonList(SchemaType.OBJECT)),
 
-    TAG_ALLOF("allOf", EnumSet.of(TagContent.ARRAY_OF_SCHEMAS)),
-    TAG_ANYOF("anyOf", EnumSet.of(TagContent.ARRAY_OF_SCHEMAS)),
-    TAG_ONEOF("oneOf", EnumSet.of(TagContent.ARRAY_OF_SCHEMAS)),
-    TAG_NOT("not", EnumSet.of(TagContent.SCHEMA)),
+    TAG_ALLOF("allOf", Collections.singletonList(TagContent.ARRAY_OF_SCHEMAS)),
+    TAG_ANYOF("anyOf", Collections.singletonList(TagContent.ARRAY_OF_SCHEMAS)),
+    TAG_ONEOF("oneOf", Collections.singletonList(TagContent.ARRAY_OF_SCHEMAS)),
+    TAG_NOT("not", Collections.singletonList(TagContent.SCHEMA)),
 
-    TAG_TITLE("title", EnumSet.of(TagContent.NON_SCHEMA)),
-    TAG_DESCRIPTION("description", EnumSet.of(TagContent.NON_SCHEMA)),
-    TAG_CONST("const", EnumSet.of(TagContent.NON_SCHEMA)),
-    TAG_ENUM("enum", EnumSet.of(TagContent.NON_SCHEMA)),
-    TAG_DEFAULT("default", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_TITLE("title", Collections.singletonList(TagContent.NON_SCHEMA)),
+    TAG_DESCRIPTION("description", Collections.singletonList(TagContent.NON_SCHEMA)),
+    TAG_CONST("const", Collections.singletonList(TagContent.NON_SCHEMA)),
+    TAG_ENUM("enum", Collections.singletonList(TagContent.NON_SCHEMA)),
+    TAG_DEFAULT("default", Collections.singletonList(TagContent.NON_SCHEMA)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_READ_ONLY("readOnly", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_READ_ONLY("readOnly", Collections.singletonList(TagContent.NON_SCHEMA)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_WRITE_ONLY("writeOnly", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_WRITE_ONLY("writeOnly", Collections.singletonList(TagContent.NON_SCHEMA)),
 
-    TAG_LENGTH_MIN("minLength", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.STRING)),
-    TAG_LENGTH_MAX("maxLength", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.STRING)),
-    TAG_FORMAT("format", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.STRING)),
-    TAG_PATTERN("pattern", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.STRING)),
+    TAG_LENGTH_MIN("minLength", Collections.singletonList(TagContent.NON_SCHEMA), Collections.singletonList(SchemaType.STRING)),
+    TAG_LENGTH_MAX("maxLength", Collections.singletonList(TagContent.NON_SCHEMA), Collections.singletonList(SchemaType.STRING)),
+    TAG_FORMAT("format", Collections.singletonList(TagContent.NON_SCHEMA), Collections.singletonList(SchemaType.STRING)),
+    TAG_PATTERN("pattern", Collections.singletonList(TagContent.NON_SCHEMA), Collections.singletonList(SchemaType.STRING)),
 
-    TAG_MINIMUM("minimum", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.INTEGER, SchemaType.NUMBER)),
-    TAG_MINIMUM_EXCLUSIVE("exclusiveMinimum", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.INTEGER, SchemaType.NUMBER)),
-    TAG_MAXIMUM("maximum", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.INTEGER, SchemaType.NUMBER)),
-    TAG_MAXIMUM_EXCLUSIVE("exclusiveMaximum", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.INTEGER, SchemaType.NUMBER)),
-    TAG_MULTIPLE_OF("multipleOf", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.INTEGER, SchemaType.NUMBER)),
+    TAG_MINIMUM("minimum", Collections.singletonList(TagContent.NON_SCHEMA), Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER)),
+    TAG_MINIMUM_EXCLUSIVE("exclusiveMinimum", Collections.singletonList(TagContent.NON_SCHEMA), Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER)),
+    TAG_MAXIMUM("maximum", Collections.singletonList(TagContent.NON_SCHEMA), Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER)),
+    TAG_MAXIMUM_EXCLUSIVE("exclusiveMaximum", Collections.singletonList(TagContent.NON_SCHEMA), Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER)),
+    TAG_MULTIPLE_OF("multipleOf", Collections.singletonList(TagContent.NON_SCHEMA), Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER)),
 
-    TAG_ITEMS_MIN("minItems", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.ARRAY)),
-    TAG_ITEMS_MAX("maxItems", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.ARRAY)),
-    TAG_ITEMS_UNIQUE("uniqueItems", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.ARRAY)),
+    TAG_ITEMS_MIN("minItems", Collections.singletonList(TagContent.NON_SCHEMA), Collections.singletonList(SchemaType.ARRAY)),
+    TAG_ITEMS_MAX("maxItems", Collections.singletonList(TagContent.NON_SCHEMA), Collections.singletonList(SchemaType.ARRAY)),
+    TAG_ITEMS_UNIQUE("uniqueItems", Collections.singletonList(TagContent.NON_SCHEMA), Collections.singletonList(SchemaType.ARRAY)),
 
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_IF("if", EnumSet.of(TagContent.SCHEMA)),
+    TAG_IF("if", Collections.singletonList(TagContent.SCHEMA)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_THEN("then", EnumSet.of(TagContent.SCHEMA)),
+    TAG_THEN("then", Collections.singletonList(TagContent.SCHEMA)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_ELSE("else", EnumSet.of(TagContent.SCHEMA));
+    TAG_ELSE("else", Collections.singletonList(TagContent.SCHEMA));
 
     private final Function<SchemaVersion, String> valueProvider;
-    private final EnumSet<TagContent> contentTypes;
-    private final EnumSet<SchemaType> impliedTypes;
+    private final List<TagContent> contentTypes;
+    private final List<SchemaType> impliedTypes;
 
     /**
      * Constructor.
@@ -146,7 +149,7 @@ public enum SchemaKeyword {
      * @param fixedValue single value applying regardless of schema version
      */
     SchemaKeyword(String fixedValue) {
-        this(fixedValue, EnumSet.noneOf(TagContent.class), EnumSet.noneOf(SchemaType.class));
+        this(fixedValue, Collections.emptyList(), Collections.emptyList());
     }
 
     /**
@@ -155,8 +158,8 @@ public enum SchemaKeyword {
      * @param fixedValue single value applying regardless of schema version
      * @param contentTypes what kind of values can be expected under this keyword (empty when this keyword represents such a value)
      */
-    SchemaKeyword(String fixedValue, EnumSet<TagContent> contentTypes) {
-        this(_version -> fixedValue, contentTypes, EnumSet.noneOf(SchemaType.class));
+    SchemaKeyword(String fixedValue, List<TagContent> contentTypes) {
+        this(_version -> fixedValue, contentTypes, Collections.emptyList());
     }
 
     /**
@@ -166,7 +169,7 @@ public enum SchemaKeyword {
      * @param contentTypes what kind of values can be expected under this keyword (empty when this keyword represents such a value)
      * @param impliedTypes values of the {@link #TAG_TYPE} being implied by the presence of this keyword in a schema
      */
-    SchemaKeyword(String fixedValue, EnumSet<TagContent> contentTypes, EnumSet<SchemaType> impliedTypes) {
+    SchemaKeyword(String fixedValue, List<TagContent> contentTypes, List<SchemaType> impliedTypes) {
         this(_version -> fixedValue, contentTypes, impliedTypes);
     }
 
@@ -177,10 +180,10 @@ public enum SchemaKeyword {
      * @param contentTypes what kind of values can be expected under this keyword (empty when this keyword represents such a value)
      * @param impliedTypes values of the {@link #TAG_TYPE} being implied by the presence of this keyword in a schema
      */
-    SchemaKeyword(Function<SchemaVersion, String> valueProvider, EnumSet<TagContent> contentTypes, EnumSet<SchemaType> impliedTypes) {
+    SchemaKeyword(Function<SchemaVersion, String> valueProvider, List<TagContent> contentTypes, List<SchemaType> impliedTypes) {
         this.valueProvider = valueProvider;
-        this.contentTypes = contentTypes;
-        this.impliedTypes = impliedTypes;
+        this.contentTypes = Collections.unmodifiableList(contentTypes);
+        this.impliedTypes = Collections.unmodifiableList(impliedTypes);
     }
 
     /**
@@ -188,7 +191,7 @@ public enum SchemaKeyword {
      *
      * @return implied type values or an empty list if this keyword is not type specific
      */
-    public EnumSet<SchemaType> getImpliedTypes() {
+    public List<SchemaType> getImpliedTypes() {
         return this.impliedTypes;
     }
 
@@ -220,7 +223,7 @@ public enum SchemaKeyword {
      * @return mapping of schema tag/property name to its corresponding tag
      */
     public static Map<String, SchemaKeyword> getReverseTagMap(SchemaVersion version, Predicate<SchemaKeyword> filter) {
-        return EnumSet.allOf(SchemaKeyword.class).stream()
+        return Stream.of(SchemaKeyword.values())
                 .filter(keyword -> !keyword.contentTypes.isEmpty() && filter.test(keyword))
                 .collect(Collectors.toMap(keyword -> keyword.forVersion(version), keyword -> keyword,
                         // when two keywords are mapped to the same tag name, stick to the first (as per declaration order in this enum)

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
@@ -165,7 +165,7 @@ public enum SchemaKeyword {
     SchemaKeyword(Function<SchemaVersion, String> valueProvider, List<SchemaType> impliedTypes, TagContent... contentTypes) {
         this.valueProvider = valueProvider;
         this.impliedTypes = Collections.unmodifiableList(impliedTypes);
-        this.contentTypes = Arrays.asList(contentTypes);
+        this.contentTypes = Collections.unmodifiableList(Arrays.asList(contentTypes));
     }
 
     /**

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -144,8 +143,8 @@ public enum SchemaKeyword {
      * Store enum members as suppliers, in order to ensure immutability.
      */
     private final Function<SchemaVersion, String> valueProvider;
-    private final Supplier<List<TagContent>> contentTypesProvider;
-    private final Supplier<List<SchemaType>> impliedTypesProvider;
+    private final List<TagContent> contentTypes;
+    private final List<SchemaType> impliedTypes;
 
     /**
      * Constructor.
@@ -186,10 +185,8 @@ public enum SchemaKeyword {
      */
     SchemaKeyword(Function<SchemaVersion, String> valueProvider, List<TagContent> contentTypes, List<SchemaType> impliedTypes) {
         this.valueProvider = valueProvider;
-        List<TagContent> unmodifiableTagContents = Collections.unmodifiableList(contentTypes);
-        this.contentTypesProvider = () -> unmodifiableTagContents;
-        List<SchemaType> unmodifiableImpliedTypes = Collections.unmodifiableList(impliedTypes);
-        this.impliedTypesProvider = () -> unmodifiableImpliedTypes;
+        this.contentTypes = Collections.unmodifiableList(contentTypes);
+        this.impliedTypes = Collections.unmodifiableList(impliedTypes);
     }
 
     /**
@@ -208,7 +205,7 @@ public enum SchemaKeyword {
      * @return implied type values or an empty list if this keyword is not type specific
      */
     public List<SchemaType> getImpliedTypes() {
-        return this.impliedTypesProvider.get();
+        return this.impliedTypes;
     }
 
     /**
@@ -218,7 +215,7 @@ public enum SchemaKeyword {
      * @return whether the given tag content type is supported by this keyword
      */
     public boolean supportsContentType(TagContent contentType) {
-        return this.contentTypesProvider.get().contains(contentType);
+        return this.contentTypes.contains(contentType);
     }
 
     /**
@@ -230,7 +227,7 @@ public enum SchemaKeyword {
      */
     public static Map<String, SchemaKeyword> getReverseTagMap(SchemaVersion version, Predicate<SchemaKeyword> filter) {
         return Stream.of(SchemaKeyword.values())
-                .filter(keyword -> !keyword.contentTypesProvider.get().isEmpty() && filter.test(keyword))
+                .filter(keyword -> !keyword.contentTypes.isEmpty() && filter.test(keyword))
                 .collect(Collectors.toMap(keyword -> keyword.forVersion(version), keyword -> keyword,
                         // when two keywords are mapped to the same tag name, stick to the first (as per declaration order in this enum)
                         (k1, k2) -> k1));

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
@@ -16,34 +16,30 @@
 
 package com.github.victools.jsonschema.generator;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * JSON Schema properties and their values.
  */
 public enum SchemaKeyword {
-    TAG_SCHEMA("$schema", Collections.emptyList(), TagContent.NON_SCHEMA),
-    TAG_SCHEMA_VALUE(SchemaVersion::getIdentifier, Collections.emptyList()),
-    TAG_ID("$id", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_SCHEMA("$schema", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_SCHEMA_VALUE(SchemaVersion::getIdentifier, EnumSet.noneOf(TagContent.class), EnumSet.noneOf(SchemaType.class)),
+    TAG_ID("$id", EnumSet.of(TagContent.NON_SCHEMA)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
-    TAG_ANCHOR("$anchor", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_ANCHOR("$anchor", EnumSet.of(TagContent.NON_SCHEMA)),
     TAG_DEFINITIONS(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7 ? "definitions" : "$defs",
-            Collections.emptyList(), TagContent.NAMED_SCHEMAS),
+            EnumSet.of(TagContent.NAMED_SCHEMAS), EnumSet.noneOf(SchemaType.class)),
     /**
      * Before {@link SchemaVersion#DRAFT_2019_09} all other properties in the same sub-schema besides this one were ignored.
      */
-    TAG_REF("$ref", Collections.emptyList(), TagContent.NON_SCHEMA),
-    TAG_REF_MAIN("#", Collections.emptyList()),
+    TAG_REF("$ref", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_REF_MAIN("#"),
     /**
      * Common prefix of all standard {@link #TAG_REF} values.
      *
@@ -51,121 +47,140 @@ public enum SchemaKeyword {
      */
     @Deprecated
     TAG_REF_PREFIX(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7 ? "#/definitions/" : "#/$defs/",
-            Collections.emptyList()),
+            EnumSet.noneOf(TagContent.class), EnumSet.noneOf(SchemaType.class)),
 
-    TAG_TYPE("type", Collections.emptyList(), TagContent.NON_SCHEMA),
-    TAG_TYPE_NULL(SchemaType.NULL.getSchemaKeywordValue(), Collections.emptyList()),
-    TAG_TYPE_ARRAY(SchemaType.ARRAY.getSchemaKeywordValue(), Collections.emptyList()),
-    TAG_TYPE_OBJECT(SchemaType.OBJECT.getSchemaKeywordValue(), Collections.emptyList()),
-    TAG_TYPE_BOOLEAN(SchemaType.BOOLEAN.getSchemaKeywordValue(), Collections.emptyList()),
-    TAG_TYPE_STRING(SchemaType.STRING.getSchemaKeywordValue(), Collections.emptyList()),
-    TAG_TYPE_INTEGER(SchemaType.INTEGER.getSchemaKeywordValue(), Collections.emptyList()),
-    TAG_TYPE_NUMBER(SchemaType.NUMBER.getSchemaKeywordValue(), Collections.emptyList()),
+    TAG_TYPE("type", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_TYPE_NULL(SchemaType.NULL.getSchemaKeywordValue()),
+    TAG_TYPE_ARRAY(SchemaType.ARRAY.getSchemaKeywordValue()),
+    TAG_TYPE_OBJECT(SchemaType.OBJECT.getSchemaKeywordValue()),
+    TAG_TYPE_BOOLEAN(SchemaType.BOOLEAN.getSchemaKeywordValue()),
+    TAG_TYPE_STRING(SchemaType.STRING.getSchemaKeywordValue()),
+    TAG_TYPE_INTEGER(SchemaType.INTEGER.getSchemaKeywordValue()),
+    TAG_TYPE_NUMBER(SchemaType.NUMBER.getSchemaKeywordValue()),
 
-    TAG_PROPERTIES("properties", Collections.singletonList(SchemaType.OBJECT), TagContent.NAMED_SCHEMAS),
+    TAG_PROPERTIES("properties", EnumSet.of(TagContent.NAMED_SCHEMAS), EnumSet.of(SchemaType.OBJECT)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
-    TAG_UNEVALUATED_PROPERTIES("unevaluatedProperties", Collections.singletonList(SchemaType.OBJECT), TagContent.SCHEMA),
-    TAG_ITEMS("items", Collections.singletonList(SchemaType.ARRAY), TagContent.SCHEMA, TagContent.ARRAY_OF_SCHEMAS),
+    TAG_UNEVALUATED_PROPERTIES("unevaluatedProperties", EnumSet.of(TagContent.SCHEMA), EnumSet.of(SchemaType.OBJECT)),
+    TAG_ITEMS("items", EnumSet.of(TagContent.SCHEMA, TagContent.ARRAY_OF_SCHEMAS), EnumSet.of(SchemaType.ARRAY)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
     TAG_PREFIX_ITEMS(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7 ? "items" : "prefixItems",
-            Collections.singletonList(SchemaType.ARRAY), TagContent.ARRAY_OF_SCHEMAS),
+            EnumSet.of(TagContent.ARRAY_OF_SCHEMAS), EnumSet.of(SchemaType.ARRAY)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
-    TAG_UNEVALUATED_ITEMS("unevaluatedItems", Collections.singletonList(SchemaType.ARRAY), TagContent.SCHEMA),
-    TAG_REQUIRED("required", Collections.singletonList(SchemaType.OBJECT), TagContent.NON_SCHEMA),
+    TAG_UNEVALUATED_ITEMS("unevaluatedItems", EnumSet.of(TagContent.SCHEMA), EnumSet.of(SchemaType.ARRAY)),
+    TAG_REQUIRED("required", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.OBJECT)),
     /**
      * Prior to {@link SchemaVersion#DRAFT_2019_09}, this had the same name as {@link #TAG_DEPENDENT_REQUIRED}.
      */
     TAG_DEPENDENT_SCHEMAS(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7
-            ? "dependencies" : "dependentSchemas", Collections.singletonList(SchemaType.OBJECT), TagContent.NAMED_SCHEMAS),
+            ? "dependencies" : "dependentSchemas", EnumSet.of(TagContent.NAMED_SCHEMAS), EnumSet.of(SchemaType.OBJECT)),
     /**
      * Prior to {@link SchemaVersion#DRAFT_2019_09}, this had the same name as {@link #TAG_DEPENDENT_SCHEMAS}.
      */
     TAG_DEPENDENT_REQUIRED(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7
-            ? "dependencies" : "dependentRequired", Collections.singletonList(SchemaType.OBJECT), TagContent.NON_SCHEMA),
-    TAG_ADDITIONAL_PROPERTIES("additionalProperties", Collections.singletonList(SchemaType.OBJECT), TagContent.SCHEMA),
-    TAG_PATTERN_PROPERTIES("patternProperties", Collections.singletonList(SchemaType.OBJECT), TagContent.NAMED_SCHEMAS),
-    TAG_PROPERTIES_MIN("minProperties", Collections.singletonList(SchemaType.OBJECT), TagContent.NON_SCHEMA),
-    TAG_PROPERTIES_MAX("maxProperties", Collections.singletonList(SchemaType.OBJECT), TagContent.NON_SCHEMA),
+            ? "dependencies" : "dependentRequired", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.OBJECT)),
+    TAG_ADDITIONAL_PROPERTIES("additionalProperties", EnumSet.of(TagContent.SCHEMA), EnumSet.of(SchemaType.OBJECT)),
+    TAG_PATTERN_PROPERTIES("patternProperties", EnumSet.of(TagContent.NAMED_SCHEMAS), EnumSet.of(SchemaType.OBJECT)),
+    TAG_PROPERTIES_MIN("minProperties", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.OBJECT)),
+    TAG_PROPERTIES_MAX("maxProperties", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.OBJECT)),
 
-    TAG_ALLOF("allOf", Collections.emptyList(), TagContent.ARRAY_OF_SCHEMAS),
-    TAG_ANYOF("anyOf", Collections.emptyList(), TagContent.ARRAY_OF_SCHEMAS),
-    TAG_ONEOF("oneOf", Collections.emptyList(), TagContent.ARRAY_OF_SCHEMAS),
-    TAG_NOT("not", Collections.emptyList(), TagContent.SCHEMA),
+    TAG_ALLOF("allOf", EnumSet.of(TagContent.ARRAY_OF_SCHEMAS)),
+    TAG_ANYOF("anyOf", EnumSet.of(TagContent.ARRAY_OF_SCHEMAS)),
+    TAG_ONEOF("oneOf", EnumSet.of(TagContent.ARRAY_OF_SCHEMAS)),
+    TAG_NOT("not", EnumSet.of(TagContent.SCHEMA)),
 
-    TAG_TITLE("title", Collections.emptyList(), TagContent.NON_SCHEMA),
-    TAG_DESCRIPTION("description", Collections.emptyList(), TagContent.NON_SCHEMA),
-    TAG_CONST("const", Collections.emptyList(), TagContent.NON_SCHEMA),
-    TAG_ENUM("enum", Collections.emptyList(), TagContent.NON_SCHEMA),
-    TAG_DEFAULT("default", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_TITLE("title", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_DESCRIPTION("description", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_CONST("const", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_ENUM("enum", EnumSet.of(TagContent.NON_SCHEMA)),
+    TAG_DEFAULT("default", EnumSet.of(TagContent.NON_SCHEMA)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_READ_ONLY("readOnly", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_READ_ONLY("readOnly", EnumSet.of(TagContent.NON_SCHEMA)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_WRITE_ONLY("writeOnly", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_WRITE_ONLY("writeOnly", EnumSet.of(TagContent.NON_SCHEMA)),
 
-    TAG_LENGTH_MIN("minLength", Collections.singletonList(SchemaType.STRING), TagContent.NON_SCHEMA),
-    TAG_LENGTH_MAX("maxLength", Collections.singletonList(SchemaType.STRING), TagContent.NON_SCHEMA),
-    TAG_FORMAT("format", Collections.singletonList(SchemaType.STRING), TagContent.NON_SCHEMA),
-    TAG_PATTERN("pattern", Collections.singletonList(SchemaType.STRING), TagContent.NON_SCHEMA),
+    TAG_LENGTH_MIN("minLength", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.STRING)),
+    TAG_LENGTH_MAX("maxLength", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.STRING)),
+    TAG_FORMAT("format", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.STRING)),
+    TAG_PATTERN("pattern", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.STRING)),
 
-    TAG_MINIMUM("minimum", Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER), TagContent.NON_SCHEMA),
-    TAG_MINIMUM_EXCLUSIVE("exclusiveMinimum", Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER), TagContent.NON_SCHEMA),
-    TAG_MAXIMUM("maximum", Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER), TagContent.NON_SCHEMA),
-    TAG_MAXIMUM_EXCLUSIVE("exclusiveMaximum", Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER), TagContent.NON_SCHEMA),
-    TAG_MULTIPLE_OF("multipleOf", Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER), TagContent.NON_SCHEMA),
+    TAG_MINIMUM("minimum", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.INTEGER, SchemaType.NUMBER)),
+    TAG_MINIMUM_EXCLUSIVE("exclusiveMinimum", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.INTEGER, SchemaType.NUMBER)),
+    TAG_MAXIMUM("maximum", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.INTEGER, SchemaType.NUMBER)),
+    TAG_MAXIMUM_EXCLUSIVE("exclusiveMaximum", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.INTEGER, SchemaType.NUMBER)),
+    TAG_MULTIPLE_OF("multipleOf", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.INTEGER, SchemaType.NUMBER)),
 
-    TAG_ITEMS_MIN("minItems", Collections.singletonList(SchemaType.ARRAY), TagContent.NON_SCHEMA),
-    TAG_ITEMS_MAX("maxItems", Collections.singletonList(SchemaType.ARRAY), TagContent.NON_SCHEMA),
-    TAG_ITEMS_UNIQUE("uniqueItems", Collections.singletonList(SchemaType.ARRAY), TagContent.NON_SCHEMA),
+    TAG_ITEMS_MIN("minItems", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.ARRAY)),
+    TAG_ITEMS_MAX("maxItems", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.ARRAY)),
+    TAG_ITEMS_UNIQUE("uniqueItems", EnumSet.of(TagContent.NON_SCHEMA), EnumSet.of(SchemaType.ARRAY)),
 
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_IF("if", Collections.emptyList(), TagContent.SCHEMA),
+    TAG_IF("if", EnumSet.of(TagContent.SCHEMA)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_THEN("then", Collections.emptyList(), TagContent.SCHEMA),
+    TAG_THEN("then", EnumSet.of(TagContent.SCHEMA)),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_ELSE("else", Collections.emptyList(), TagContent.SCHEMA);
+    TAG_ELSE("else", EnumSet.of(TagContent.SCHEMA));
 
     private final Function<SchemaVersion, String> valueProvider;
-    private final List<SchemaType> impliedTypes;
-    private final List<TagContent> contentTypes;
+    private final EnumSet<TagContent> contentTypes;
+    private final EnumSet<SchemaType> impliedTypes;
 
     /**
      * Constructor.
      *
      * @param fixedValue single value applying regardless of schema version
-     * @param impliedTypes values of the {@link #TAG_TYPE} being implied by the presence of this keyword in a schema
+     */
+    SchemaKeyword(String fixedValue) {
+        this(fixedValue, EnumSet.noneOf(TagContent.class), EnumSet.noneOf(SchemaType.class));
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param fixedValue single value applying regardless of schema version
      * @param contentTypes what kind of values can be expected under this keyword (empty when this keyword represents such a value)
      */
-    SchemaKeyword(String fixedValue, List<SchemaType> impliedTypes, TagContent... contentTypes) {
-        this(_version -> fixedValue, impliedTypes, contentTypes);
+    SchemaKeyword(String fixedValue, EnumSet<TagContent> contentTypes) {
+        this(_version -> fixedValue, contentTypes, EnumSet.noneOf(SchemaType.class));
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param fixedValue single value applying regardless of schema version
+     * @param contentTypes what kind of values can be expected under this keyword (empty when this keyword represents such a value)
+     * @param impliedTypes values of the {@link #TAG_TYPE} being implied by the presence of this keyword in a schema
+     */
+    SchemaKeyword(String fixedValue, EnumSet<TagContent> contentTypes, EnumSet<SchemaType> impliedTypes) {
+        this(_version -> fixedValue, contentTypes, impliedTypes);
     }
 
     /**
      * Constructor.
      *
      * @param valueProvider dynamic value provider that may return different values base on specific JSON Schema versions
-     * @param impliedTypes values of the {@link #TAG_TYPE} being implied by the presence of this keyword in a schema
      * @param contentTypes what kind of values can be expected under this keyword (empty when this keyword represents such a value)
+     * @param impliedTypes values of the {@link #TAG_TYPE} being implied by the presence of this keyword in a schema
      */
-    SchemaKeyword(Function<SchemaVersion, String> valueProvider, List<SchemaType> impliedTypes, TagContent... contentTypes) {
+    SchemaKeyword(Function<SchemaVersion, String> valueProvider, EnumSet<TagContent> contentTypes, EnumSet<SchemaType> impliedTypes) {
         this.valueProvider = valueProvider;
-        this.impliedTypes = Collections.unmodifiableList(impliedTypes);
-        this.contentTypes = Collections.unmodifiableList(Arrays.asList(contentTypes));
+        this.contentTypes = contentTypes;
+        this.impliedTypes = impliedTypes;
     }
 
     /**
@@ -173,7 +188,7 @@ public enum SchemaKeyword {
      *
      * @return implied type values or an empty list if this keyword is not type specific
      */
-    public List<SchemaType> getImpliedTypes() {
+    public EnumSet<SchemaType> getImpliedTypes() {
         return this.impliedTypes;
     }
 

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaKeyword.java
@@ -16,143 +16,175 @@
 
 package com.github.victools.jsonschema.generator;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * JSON Schema properties and their values.
  */
 public enum SchemaKeyword {
-    TAG_SCHEMA("$schema", Type.TAG),
-    TAG_SCHEMA_VALUE(SchemaVersion::getIdentifier, Type.VALUE),
-    TAG_ID("$id", Type.TAG),
+    TAG_SCHEMA("$schema", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_SCHEMA_VALUE(SchemaVersion::getIdentifier, Collections.emptyList()),
+    TAG_ID("$id", Collections.emptyList(), TagContent.NON_SCHEMA),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
-    TAG_ANCHOR("$anchor", Type.TAG),
-    TAG_DEFINITIONS(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7 ? "definitions" : "$defs", Type.TAG),
+    TAG_ANCHOR("$anchor", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_DEFINITIONS(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7 ? "definitions" : "$defs",
+            Collections.emptyList(), TagContent.NAMED_SCHEMAS),
     /**
      * Before {@link SchemaVersion#DRAFT_2019_09} all other properties in the same sub-schema besides this one were ignored.
      */
-    TAG_REF("$ref", Type.TAG),
-    TAG_REF_MAIN("#", Type.VALUE),
+    TAG_REF("$ref", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_REF_MAIN("#", Collections.emptyList()),
     /**
      * Common prefix of all standard {@link #TAG_REF} values.
      *
      * @deprecated is now implicitly created based on {@link SchemaKeyword#TAG_DEFINITIONS} or an explicit alternative definitions path
      */
     @Deprecated
-    TAG_REF_PREFIX(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7 ? "#/definitions/" : "#/$defs/", Type.VALUE),
+    TAG_REF_PREFIX(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7 ? "#/definitions/" : "#/$defs/",
+            Collections.emptyList()),
 
-    TAG_TYPE("type", Type.TAG),
-    TAG_TYPE_NULL("null", Type.VALUE),
-    TAG_TYPE_ARRAY("array", Type.VALUE),
-    TAG_TYPE_OBJECT("object", Type.VALUE),
-    TAG_TYPE_BOOLEAN("boolean", Type.VALUE),
-    TAG_TYPE_STRING("string", Type.VALUE),
-    TAG_TYPE_INTEGER("integer", Type.VALUE),
-    TAG_TYPE_NUMBER("number", Type.VALUE),
+    TAG_TYPE("type", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_TYPE_NULL(SchemaType.NULL.getSchemaKeywordValue(), Collections.emptyList()),
+    TAG_TYPE_ARRAY(SchemaType.ARRAY.getSchemaKeywordValue(), Collections.emptyList()),
+    TAG_TYPE_OBJECT(SchemaType.OBJECT.getSchemaKeywordValue(), Collections.emptyList()),
+    TAG_TYPE_BOOLEAN(SchemaType.BOOLEAN.getSchemaKeywordValue(), Collections.emptyList()),
+    TAG_TYPE_STRING(SchemaType.STRING.getSchemaKeywordValue(), Collections.emptyList()),
+    TAG_TYPE_INTEGER(SchemaType.INTEGER.getSchemaKeywordValue(), Collections.emptyList()),
+    TAG_TYPE_NUMBER(SchemaType.NUMBER.getSchemaKeywordValue(), Collections.emptyList()),
 
-    TAG_PROPERTIES("properties", Type.TAG),
+    TAG_PROPERTIES("properties", Collections.singletonList(SchemaType.OBJECT), TagContent.NAMED_SCHEMAS),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
-    TAG_UNEVALUATED_PROPERTIES("unevaluatedProperties", Type.TAG),
-    TAG_ITEMS("items", Type.TAG),
+    TAG_UNEVALUATED_PROPERTIES("unevaluatedProperties", Collections.singletonList(SchemaType.OBJECT), TagContent.SCHEMA),
+    TAG_ITEMS("items", Collections.singletonList(SchemaType.ARRAY), TagContent.SCHEMA, TagContent.ARRAY_OF_SCHEMAS),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
-    TAG_PREFIX_ITEMS("prefixItems", Type.TAG),
+    TAG_PREFIX_ITEMS(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7 ? "items" : "prefixItems",
+            Collections.singletonList(SchemaType.ARRAY), TagContent.ARRAY_OF_SCHEMAS),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_2019_09}.
      */
-    TAG_UNEVALUATED_ITEMS("unevaluatedItems", Type.TAG),
-    TAG_REQUIRED("required", Type.TAG),
-    /**
-     * Prior to {@link SchemaVersion#DRAFT_2019_09}, this had the same name as {@link #TAG_DEPENDENT_SCHEMAS}.
-     */
-    TAG_DEPENDENT_REQUIRED(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7
-            ? "dependencies" : "dependentRequired", Type.TAG),
+    TAG_UNEVALUATED_ITEMS("unevaluatedItems", Collections.singletonList(SchemaType.ARRAY), TagContent.SCHEMA),
+    TAG_REQUIRED("required", Collections.singletonList(SchemaType.OBJECT), TagContent.NON_SCHEMA),
     /**
      * Prior to {@link SchemaVersion#DRAFT_2019_09}, this had the same name as {@link #TAG_DEPENDENT_REQUIRED}.
      */
     TAG_DEPENDENT_SCHEMAS(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7
-            ? "dependencies" : "dependentSchemas", Type.TAG),
-    TAG_ADDITIONAL_PROPERTIES("additionalProperties", Type.TAG),
-    TAG_PATTERN_PROPERTIES("patternProperties", Type.TAG),
-    TAG_PROPERTIES_MIN("minProperties", Type.TAG),
-    TAG_PROPERTIES_MAX("maxProperties", Type.TAG),
+            ? "dependencies" : "dependentSchemas", Collections.singletonList(SchemaType.OBJECT), TagContent.NAMED_SCHEMAS),
+    /**
+     * Prior to {@link SchemaVersion#DRAFT_2019_09}, this had the same name as {@link #TAG_DEPENDENT_SCHEMAS}.
+     */
+    TAG_DEPENDENT_REQUIRED(version -> version == SchemaVersion.DRAFT_6 || version == SchemaVersion.DRAFT_7
+            ? "dependencies" : "dependentRequired", Collections.singletonList(SchemaType.OBJECT), TagContent.NON_SCHEMA),
+    TAG_ADDITIONAL_PROPERTIES("additionalProperties", Collections.singletonList(SchemaType.OBJECT), TagContent.SCHEMA),
+    TAG_PATTERN_PROPERTIES("patternProperties", Collections.singletonList(SchemaType.OBJECT), TagContent.NAMED_SCHEMAS),
+    TAG_PROPERTIES_MIN("minProperties", Collections.singletonList(SchemaType.OBJECT), TagContent.NON_SCHEMA),
+    TAG_PROPERTIES_MAX("maxProperties", Collections.singletonList(SchemaType.OBJECT), TagContent.NON_SCHEMA),
 
-    TAG_ALLOF("allOf", Type.TAG),
-    TAG_ANYOF("anyOf", Type.TAG),
-    TAG_ONEOF("oneOf", Type.TAG),
-    TAG_NOT("not", Type.TAG),
+    TAG_ALLOF("allOf", Collections.emptyList(), TagContent.ARRAY_OF_SCHEMAS),
+    TAG_ANYOF("anyOf", Collections.emptyList(), TagContent.ARRAY_OF_SCHEMAS),
+    TAG_ONEOF("oneOf", Collections.emptyList(), TagContent.ARRAY_OF_SCHEMAS),
+    TAG_NOT("not", Collections.emptyList(), TagContent.SCHEMA),
 
-    TAG_TITLE("title", Type.TAG),
-    TAG_DESCRIPTION("description", Type.TAG),
-    TAG_CONST("const", Type.TAG),
-    TAG_ENUM("enum", Type.TAG),
-    TAG_DEFAULT("default", Type.TAG),
+    TAG_TITLE("title", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_DESCRIPTION("description", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_CONST("const", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_ENUM("enum", Collections.emptyList(), TagContent.NON_SCHEMA),
+    TAG_DEFAULT("default", Collections.emptyList(), TagContent.NON_SCHEMA),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_READ_ONLY("readOnly", Type.TAG),
+    TAG_READ_ONLY("readOnly", Collections.emptyList(), TagContent.NON_SCHEMA),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_WRITE_ONLY("writeOnly", Type.TAG),
+    TAG_WRITE_ONLY("writeOnly", Collections.emptyList(), TagContent.NON_SCHEMA),
 
-    TAG_LENGTH_MIN("minLength", Type.TAG),
-    TAG_LENGTH_MAX("maxLength", Type.TAG),
-    TAG_FORMAT("format", Type.TAG),
-    TAG_PATTERN("pattern", Type.TAG),
+    TAG_LENGTH_MIN("minLength", Collections.singletonList(SchemaType.STRING), TagContent.NON_SCHEMA),
+    TAG_LENGTH_MAX("maxLength", Collections.singletonList(SchemaType.STRING), TagContent.NON_SCHEMA),
+    TAG_FORMAT("format", Collections.singletonList(SchemaType.STRING), TagContent.NON_SCHEMA),
+    TAG_PATTERN("pattern", Collections.singletonList(SchemaType.STRING), TagContent.NON_SCHEMA),
 
-    TAG_MINIMUM("minimum", Type.TAG),
-    TAG_MINIMUM_EXCLUSIVE("exclusiveMinimum", Type.TAG),
-    TAG_MAXIMUM("maximum", Type.TAG),
-    TAG_MAXIMUM_EXCLUSIVE("exclusiveMaximum", Type.TAG),
-    TAG_MULTIPLE_OF("multipleOf", Type.TAG),
+    TAG_MINIMUM("minimum", Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER), TagContent.NON_SCHEMA),
+    TAG_MINIMUM_EXCLUSIVE("exclusiveMinimum", Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER), TagContent.NON_SCHEMA),
+    TAG_MAXIMUM("maximum", Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER), TagContent.NON_SCHEMA),
+    TAG_MAXIMUM_EXCLUSIVE("exclusiveMaximum", Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER), TagContent.NON_SCHEMA),
+    TAG_MULTIPLE_OF("multipleOf", Arrays.asList(SchemaType.INTEGER, SchemaType.NUMBER), TagContent.NON_SCHEMA),
 
-    TAG_ITEMS_MIN("minItems", Type.TAG),
-    TAG_ITEMS_MAX("maxItems", Type.TAG),
-    TAG_ITEMS_UNIQUE("uniqueItems", Type.TAG),
+    TAG_ITEMS_MIN("minItems", Collections.singletonList(SchemaType.ARRAY), TagContent.NON_SCHEMA),
+    TAG_ITEMS_MAX("maxItems", Collections.singletonList(SchemaType.ARRAY), TagContent.NON_SCHEMA),
+    TAG_ITEMS_UNIQUE("uniqueItems", Collections.singletonList(SchemaType.ARRAY), TagContent.NON_SCHEMA),
 
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_IF("if", Type.TAG),
+    TAG_IF("if", Collections.emptyList(), TagContent.SCHEMA),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_THEN("then", Type.TAG),
+    TAG_THEN("then", Collections.emptyList(), TagContent.SCHEMA),
     /**
      * Beware that this keyword was only introduced in {@link SchemaVersion#DRAFT_7}.
      */
-    TAG_ELSE("else", Type.TAG);
+    TAG_ELSE("else", Collections.emptyList(), TagContent.SCHEMA);
 
     private final Function<SchemaVersion, String> valueProvider;
-    private final SchemaKeyword.Type type;
+    private final List<SchemaType> impliedTypes;
+    private final List<TagContent> contentTypes;
 
     /**
      * Constructor.
      *
      * @param fixedValue single value applying regardless of schema version
-     * @param keywordType what kind of keyword this represents
+     * @param impliedTypes values of the {@link #TAG_TYPE} being implied by the presence of this keyword in a schema
+     * @param contentTypes what kind of values can be expected under this keyword (empty when this keyword represents such a value)
      */
-    SchemaKeyword(String fixedValue, SchemaKeyword.Type keywordType) {
-        this(_version -> fixedValue, keywordType);
+    SchemaKeyword(String fixedValue, List<SchemaType> impliedTypes, TagContent... contentTypes) {
+        this(_version -> fixedValue, impliedTypes, contentTypes);
     }
 
     /**
      * Constructor.
      *
      * @param valueProvider dynamic value provider that may return different values base on specific JSON Schema versions
-     * @param keywordType what kind of keyword this represents
+     * @param impliedTypes values of the {@link #TAG_TYPE} being implied by the presence of this keyword in a schema
+     * @param contentTypes what kind of values can be expected under this keyword (empty when this keyword represents such a value)
      */
-    SchemaKeyword(Function<SchemaVersion, String> valueProvider, SchemaKeyword.Type keywordType) {
+    SchemaKeyword(Function<SchemaVersion, String> valueProvider, List<SchemaType> impliedTypes, TagContent... contentTypes) {
         this.valueProvider = valueProvider;
-        this.type = keywordType;
+        this.impliedTypes = Collections.unmodifiableList(impliedTypes);
+        this.contentTypes = Arrays.asList(contentTypes);
+    }
+
+    /**
+     * Determine which (if any) specific {@link #TAG_TYPE} values this keyword implies.
+     *
+     * @return implied type values or an empty list if this keyword is not type specific
+     */
+    public List<SchemaType> getImpliedTypes() {
+        return this.impliedTypes;
+    }
+
+    /**
+     * Indicate what the given kind of values can be expected under this keyword (if it represents a tag). Returns always false for values.
+     *
+     * @param contentType type of content/values to be expected under a schema tag
+     * @return whether the given tag content type is supported by this keyword
+     */
+    public boolean supportsContentType(TagContent contentType) {
+        return this.contentTypes.contains(contentType);
     }
 
     /**
@@ -165,12 +197,48 @@ public enum SchemaKeyword {
         return this.valueProvider.apply(version);
     }
 
-    public static Stream<SchemaKeyword> getTagStream() {
+    /**
+     * Provide a map over all keywords, that represent a schema tag/property, i.e., not a value.
+     *
+     * @param version schema draft version to look-up keyword for
+     * @param filter additional tag filter to apply
+     * @return mapping of schema tag/property name to its corresponding tag
+     */
+    public static Map<String, SchemaKeyword> getReverseTagMap(SchemaVersion version, Predicate<SchemaKeyword> filter) {
         return EnumSet.allOf(SchemaKeyword.class).stream()
-                .filter(keyword -> keyword.type == SchemaKeyword.Type.TAG);
+                .filter(keyword -> !keyword.contentTypes.isEmpty() && filter.test(keyword))
+                .collect(Collectors.toMap(keyword -> keyword.forVersion(version), keyword -> keyword,
+                        // when two keywords are mapped to the same tag name, stick to the first (as per declaration order in this enum)
+                        (k1, k2) -> k1));
     }
 
-    private enum Type {
-        TAG, VALUE;
+    /**
+     * Values of the {@link SchemaKeyword#TAG_TYPE}.
+     */
+    public enum SchemaType {
+        NULL("null"),
+        ARRAY("array"),
+        OBJECT("object"),
+        BOOLEAN("boolean"),
+        STRING("string"),
+        INTEGER("integer"),
+        NUMBER("number");
+
+        private final String schemaKeywordValue;
+
+        SchemaType(String schemaKeywordValue) {
+            this.schemaKeywordValue = schemaKeywordValue;
+        }
+
+        public String getSchemaKeywordValue() {
+            return this.schemaKeywordValue;
+        }
+    }
+
+    /**
+     * Type of content/values to be expected under a schema tag.
+     */
+    public enum TagContent {
+        SCHEMA, ARRAY_OF_SCHEMAS, NAMED_SCHEMAS, NON_SCHEMA;
     }
 }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
@@ -190,8 +190,11 @@ public class SchemaCleanUpUtils {
         case TAG_DEPENDENT_SCHEMAS:
             if (this.config.getSchemaVersion() == SchemaVersion.DRAFT_6 || this.config.getSchemaVersion() == SchemaVersion.DRAFT_7) {
                 // in Draft 6 and Draft 7, the "dependencies" keyword was covering both "dependentSchemas" and "dependentRequired" scenarios
-                return () -> Optional.ofNullable(this.mergeDependentRequiredNode(valuesToMerge).get())
-                        .orElseGet(() -> this.mergeObjectProperties(valuesToMerge).get());
+                return () -> Optional.ofNullable(this.mergeDependentRequiredNode(valuesToMerge))
+                        .map(Supplier::get)
+                        .orElseGet(() -> Optional.ofNullable(this.mergeObjectProperties(valuesToMerge))
+                                .map(Supplier::get)
+                                .orElse(null));
             } else {
                 return this.mergeObjectProperties(valuesToMerge);
             }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
@@ -147,6 +147,11 @@ public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
     }
 
     @Override
+    public boolean shouldIncludeStrictTypeInfo() {
+        return this.isOptionEnabled(Option.STRICT_TYPE_INFO);
+    }
+
+    @Override
     public boolean shouldIncludeStaticFields() {
         return this.isOptionEnabled(Option.PUBLIC_STATIC_FIELDS) || this.isOptionEnabled(Option.NONPUBLIC_STATIC_FIELDS);
     }

--- a/slate-docs/source/includes/_main-generator.md
+++ b/slate-docs/source/includes/_main-generator.md
@@ -306,6 +306,7 @@ configBuilder.without(
       <td>Ensure that the keys for any <code>$defs</code>/<code>definitions</code> match the regular expression <code>^[a-zA-Z0-9\.\-_]+$</code> (as expected by the OpenAPI specification 3.0).</td>
       <td>Ensure that the keys for any <code>$defs</code>/<code>definitions</code> are URI compatible (as expected by the JSON Schema specification).</td>
     </tr>
+    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
       <td rowspan="2" style="text-align: right">33</td>
       <td colspan="2"><code>Option.ALLOF_CLEANUP_AT_THE_END</code></td>
@@ -313,6 +314,14 @@ configBuilder.without(
     <tr>
       <td>At the very end of the schema generation reduce <code>allOf</code> wrappers where it is possible without overwriting any attributes – this also affects the results from custom definitions.</td>
       <td>Do not attempt to reduce <code>allOf</code> wrappers but preserve them as they were generated regardless of them being necessary or not.</td>
+    </tr>
+    <tr>
+      <td rowspan="2" style="text-align: right">34</td>
+      <td colspan="2"><code>Option.STRICT_TYPE_INFO</code></td>
+    </tr>
+    <tr>
+      <td>As final step in the schema generation process, ensure all sub schemas containing keywords implying a particular "type" (e.g., "properties" implying an "object") have this "type" declared explicitly – this also affects the results from custom definitions.</td>
+      <td>No additional "type" indication will be added for each sub schema, e.g. on the collected attributes where the "allOf" clean-up could not be applied or was disabled.</td>
     </tr>
   </tbody>
 </table>
@@ -323,41 +332,42 @@ Below, you can find the lists of <code>Option</code>s included/excluded in the r
 * "J_O" = <code>JAVA_OBJECT</code>
 * "P_J" = <code>PLAIN_JSON</code>
 
-| # | Standard `Option` | F_D | J_O | P_J |
-| --- | --- | --- | --- | --- |
-|  1 | `SCHEMA_VERSION_INDICATOR` | ⬜️ | ⬜️ | ✅ |
-|  2 | `ADDITIONAL_FIXED_TYPES` | ⬜️ | ⬜️ | ✅ |
-|  3 | `EXTRA_OPEN_API_FORMAT_VALUES` | ⬜️ | ⬜️ | ⬜️ |
-|  4 | `SIMPLIFIED_ENUMS` | ✅ | ✅ | ⬜️ |
-|  5 | `FLATTENED_ENUMS` | ⬜️ | ⬜️ | ✅ |
-|  6 | `FLATTENED_ENUMS_FROM_TOSTRING` | ⬜️ | ⬜️ | ⬜️ |
-|  7 | `SIMPLIFIED_OPTIONALS` | ✅ | ✅ | ⬜️ 
-|  8 | `FLATTENED_OPTIONALS` | ⬜️ | ⬜️ | ✅ |
-|  8 | `FLATTENED_SUPPLIERS` | ⬜️ | ⬜️ | ✅ |
-| 10 | `VALUES_FROM_CONSTANT_FIELDS` | ✅ | ✅ | ✅ |
-| 11 | `PUBLIC_STATIC_FIELDS` | ✅ | ✅ | ⬜️ |
-| 12 | `PUBLIC_NONSTATIC_FIELDS` | ✅ | ✅ | ✅ |
-| 13 | `NONPUBLIC_STATIC_FIELDS` | ✅ | ⬜️ | ⬜️ |
-| 14 | `NONPUBLIC_NONSTATIC_FIELDS_WITH_GETTERS` | ✅ | ⬜️ | ✅ |
+|  # | Standard `Option`                            | F_D | J_O | P_J |
+| -- | -------------------------------------------- | --- | --- | --- |
+|  1 | `SCHEMA_VERSION_INDICATOR`                   | ⬜️ | ⬜️ | ✅ |
+|  2 | `ADDITIONAL_FIXED_TYPES`                     | ⬜️ | ⬜️ | ✅ |
+|  3 | `EXTRA_OPEN_API_FORMAT_VALUES`               | ⬜️ | ⬜️ | ⬜️ |
+|  4 | `SIMPLIFIED_ENUMS`                           | ✅ | ✅ | ⬜️ |
+|  5 | `FLATTENED_ENUMS`                            | ⬜️ | ⬜️ | ✅ |
+|  6 | `FLATTENED_ENUMS_FROM_TOSTRING`              | ⬜️ | ⬜️ | ⬜️ |
+|  7 | `SIMPLIFIED_OPTIONALS`                       | ✅ | ✅ | ⬜️ |
+|  8 | `FLATTENED_OPTIONALS`                        | ⬜️ | ⬜️ | ✅ |
+|  8 | `FLATTENED_SUPPLIERS`                        | ⬜️ | ⬜️ | ✅ |
+| 10 | `VALUES_FROM_CONSTANT_FIELDS`                | ✅ | ✅ | ✅ |
+| 11 | `PUBLIC_STATIC_FIELDS`                       | ✅ | ✅ | ⬜️ |
+| 12 | `PUBLIC_NONSTATIC_FIELDS`                    | ✅ | ✅ | ✅ |
+| 13 | `NONPUBLIC_STATIC_FIELDS`                    | ✅ | ⬜️ | ⬜️ |
+| 14 | `NONPUBLIC_NONSTATIC_FIELDS_WITH_GETTERS`    | ✅ | ⬜️ | ✅ |
 | 15 | `NONPUBLIC_NONSTATIC_FIELDS_WITHOUT_GETTERS` | ✅ | ⬜️ | ✅ |
-| 16 | `TRANSIENT_FIELDS` | ✅ | ⬜️ | ⬜️ |
-| 17 | `STATIC_METHODS` | ✅ | ✅ | ⬜️ |
-| 18 | `VOID_METHODS` | ✅ | ✅ | ⬜️ |
-| 19 | `GETTER_METHODS` | ✅ | ✅ | ⬜️ |
-| 20 | `NONSTATIC_NONVOID_NONGETTER_METHODS` | ✅ | ✅ | ⬜️ |
-| 21 | `NULLABLE_FIELDS_BY_DEFAULT` | ✅ | ⬜️ | ⬜️ |
-| 22 | `NULLABLE_METHOD_RETURN_VALUES_BY_DEFAULT` | ✅ | ⬜️ | ⬜️ |
-| 23 | `NULLABLE_ARRAY_ITEMS_ALLOWED` | ⬜️ | ⬜️ | ⬜️ |
-| 24 | `FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS` | ⬜️ | ⬜️ | ⬜️ |
-| 25 | `MAP_VALUES_AS_ADDITIONAL_PROPERTIES` | ⬜️ | ⬜️ | ⬜️ |
-| 26 | `ENUM_KEYWORD_FOR_SINGLE_VALUES` | ⬜️ | ⬜️ | ⬜️ |
+| 16 | `TRANSIENT_FIELDS`                           | ✅ | ⬜️ | ⬜️ |
+| 17 | `STATIC_METHODS`                             | ✅ | ✅ | ⬜️ |
+| 18 | `VOID_METHODS`                               | ✅ | ✅ | ⬜️ |
+| 19 | `GETTER_METHODS`                             | ✅ | ✅ | ⬜️ |
+| 20 | `NONSTATIC_NONVOID_NONGETTER_METHODS`        | ✅ | ✅ | ⬜️ |
+| 21 | `NULLABLE_FIELDS_BY_DEFAULT`                 | ✅ | ⬜️ | ⬜️ |
+| 22 | `NULLABLE_METHOD_RETURN_VALUES_BY_DEFAULT`   | ✅ | ⬜️ | ⬜️ |
+| 23 | `NULLABLE_ARRAY_ITEMS_ALLOWED`               | ⬜️ | ⬜️ | ⬜️ |
+| 24 | `FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS`   | ⬜️ | ⬜️ | ⬜️ |
+| 25 | `MAP_VALUES_AS_ADDITIONAL_PROPERTIES`        | ⬜️ | ⬜️ | ⬜️ |
+| 26 | `ENUM_KEYWORD_FOR_SINGLE_VALUES`             | ⬜️ | ⬜️ | ⬜️ |
 | 27 | `FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT` | ⬜️ | ⬜️ | ⬜️ |
-| 28 | `DEFINITIONS_FOR_ALL_OBJECTS` | ⬜️ | ⬜️ | ⬜️ |
-| 29 | `DEFINITION_FOR_MAIN_SCHEMA` | ⬜️ | ⬜️ | ⬜️ |
-| 30 | `DEFINITIONS_FOR_MEMBER_SUPERTYPES` | ⬜️ | ⬜️ | ⬜️ |
-| 31 | `INLINE_ALL_SCHEMAS` | ⬜️ | ⬜️ | ⬜️ |
-| 32 | `PLAIN_DEFINITION_KEYS` | ⬜️ | ⬜️ | ⬜️ |
-| 33 | `ALLOF_CLEANUP_AT_THE_END` | ✅ | ✅ | ✅ |
+| 28 | `DEFINITIONS_FOR_ALL_OBJECTS`                | ⬜️ | ⬜️ | ⬜️ |
+| 29 | `DEFINITION_FOR_MAIN_SCHEMA`                 | ⬜️ | ⬜️ | ⬜️ |
+| 30 | `DEFINITIONS_FOR_MEMBER_SUPERTYPES`          | ⬜️ | ⬜️ | ⬜️ |
+| 31 | `INLINE_ALL_SCHEMAS`                         | ⬜️ | ⬜️ | ⬜️ |
+| 32 | `PLAIN_DEFINITION_KEYS`                      | ⬜️ | ⬜️ | ⬜️ |
+| 33 | `ALLOF_CLEANUP_AT_THE_END`                   | ✅ | ✅ | ✅ |
+| 34 | `STRICT_TYPE_INFO`                           | ⬜️ | ⬜️ | ⬜️ |
 
 # Generator – Modules
 Similar to an `OptionPreset` being a short-cut to including various `Option`s, the concept of `Module`s is a convenient way of including multiple [individual configurations](#generator-individual-configurations) or even [advanced configurations](#generator-advanced-configurations) (as per the following sections) at once.


### PR DESCRIPTION
- introduce new `Option.STRICT_TYPE_INFO` for implying the `type` of sub-schemas based on their contained attributes (note: implied "type" array always contains "null")
- extend consideration of sub-schemas for `allOf` clean-up to more recognized keywords