### PR TITLE
feat: Introduce `JacksonOption.INLINE_TRANSFORMED_SUBTYPES`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - enable `allOf` clean-up when any of the following keywords are contained: `dependentRequired`/`dependentSchemas`/`prefixItems`/`unevaluatedItems`/`unevaluatedProperties`
 - extend consideration of sub-schemas for `allOf` clean-up to more recognized keywords
 
+### `jsonschema-module-jackson`
+#### Fixed
+- use `prefixItems` instead of `items` keyword (from Draft 2019-09 onward) for tuples in `WRAPPING_ARRAY` subtype definitions 
+
 ### `jsonschema-examples`
 #### Added
 - new collection of examples (and implicit integration test) holding various examples (e.g., ones created in response to issues/discussions on Github)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - extend consideration of sub-schemas for `allOf` clean-up to more recognized keywords
 
 ### `jsonschema-module-jackson`
+#### Added
+- introduce new `JacksonOption.INLINE_TRANSFORMED_SUBTYPES` in order to avoid definitions with `-1`/`-2` suffixes being generated in case of subtypes involving transformation (e.g., additional property, wrapping array, wrapping object)  
+  To be used with care, as a recursive reference can cause a `StackOverflowError`. In some scenarios, such an error can be avoided by also enabling the `Option.DEFINITIONS_FOR_MEMBER_SUPERTYPES`.
+
 #### Fixed
 - use `prefixItems` instead of `items` keyword (from Draft 2019-09 onward) for tuples in `WRAPPING_ARRAY` subtype definitions 
 

--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/JacksonSubtypeDefinitionExample.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/JacksonSubtypeDefinitionExample.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.github.victools.jsonschema.examples;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.Option;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.module.jackson.JacksonModule;
+import com.github.victools.jsonschema.module.jackson.JacksonOption;
+import java.util.List;
+
+/**
+ * Example created in response to <a href="https://github.com/victools/jsonschema-generator/discussions/337">#337</a>.
+ * <br/>
+ * Utilising Jackson subtype resolution in combination with various options to steer what is included in the "$defs".
+ */
+public class JacksonSubtypeDefinitionExample implements SchemaGenerationExampleInterface {
+
+    @Override
+    public ObjectNode generateSchema() {
+        JacksonModule jacksonModule = new JacksonModule(JacksonOption.ALWAYS_REF_SUBTYPES, JacksonOption.INLINE_TRANSFORMED_SUBTYPES);
+        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .with(jacksonModule)
+                .with(Option.DEFINITIONS_FOR_ALL_OBJECTS, Option.DEFINITIONS_FOR_MEMBER_SUPERTYPES, Option.DEFINITION_FOR_MAIN_SCHEMA);
+        SchemaGeneratorConfig config = configBuilder.build();
+        SchemaGenerator generator = new SchemaGenerator(config);
+        return generator.generateSchema(BaseType.class);
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = SubType1.class, name = "subtype1"),
+            @JsonSubTypes.Type(value = SubType2.class, name = "subtype2"),
+    })
+    interface BaseType {
+    }
+
+    static class SubType1 implements BaseType {
+        public NestedObject nestedObject;
+    }
+
+    static class SubType2 implements BaseType {
+        public List<BaseType> conditions;
+    }
+
+    static class NestedObject {
+        public Object field;
+    }
+}

--- a/jsonschema-examples/src/test/java/com/github/victools/jsonschema/examples/ExampleTest.java
+++ b/jsonschema-examples/src/test/java/com/github/victools/jsonschema/examples/ExampleTest.java
@@ -35,6 +35,7 @@ public class ExampleTest {
             ExternalRefPackageExample.class,
             GroupedAnnotationExample.class,
             IfThenElseExample.class,
+            JacksonSubtypeDefinitionExample.class,
             StrictTypeInfoExample.class
     })
     public void testExample(Class<? extends SchemaGenerationExampleInterface> exampleType) throws Exception {

--- a/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/JacksonSubtypeDefinitionExample-result.json
+++ b/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/JacksonSubtypeDefinitionExample-result.json
@@ -1,0 +1,46 @@
+{
+    "$schema" : "https://json-schema.org/draft/2020-12/schema",
+    "$ref" : "#/$defs/BaseType",
+    "$defs" : {
+        "BaseType" : {
+            "anyOf" : [ {
+                "$ref" : "#/$defs/SubType1"
+            }, {
+                "$ref" : "#/$defs/SubType2"
+            } ]
+        },
+        "NestedObject" : {
+            "type" : "object",
+            "properties" : {
+                "field" : { }
+            }
+        },
+        "SubType1" : {
+            "type" : "object",
+            "properties" : {
+                "nestedObject" : {
+                    "$ref" : "#/$defs/NestedObject"
+                },
+                "@type" : {
+                    "const" : "subtype1"
+                }
+            },
+            "required" : [ "@type" ]
+        },
+        "SubType2" : {
+            "type" : "object",
+            "properties" : {
+                "conditions" : {
+                    "type" : "array",
+                    "items" : {
+                        "$ref" : "#/$defs/BaseType"
+                    }
+                },
+                "@type" : {
+                    "const" : "subtype2"
+                }
+            },
+            "required" : [ "@type" ]
+        }
+    }
+}

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonOption.java
@@ -73,6 +73,16 @@ public enum JacksonOption {
      */
     ALWAYS_REF_SUBTYPES,
     /**
+     * Use this option to ensure all looked-up subtypes according to {@code @JsonSubTypes} annotations are referenced via the central "$defs". This
+     * applies to the nested schema inside the wrapping object/array or "allOf" based on {@code @JsonTypeInfo} annotations. This can be used to
+     * counter-act the {@link com.github.victools.jsonschema.generator.Option#DEFINITIONS_FOR_ALL_OBJECTS Option.DEFINITIONS_FOR_ALL_OBJECTS}.
+     * Beware: as with every explicit inlining, recursive non-transformed references can result in a stack overflow during schema generation when this
+     * option is enabled (similar to {@link com.github.victools.jsonschema.generator.Option#INLINE_ALL_SCHEMAS Option.INLINE_ALL_SCHEMAS})!
+     *
+     * @since 4.30.0
+     */
+    INLINE_TRANSFORMED_SUBTYPES,
+    /**
      * Use this option to skip the automatic look-up of subtypes according to {@code @JsonSubTypes} annotations.
      */
     SKIP_SUBTYPE_LOOKUP,

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolver.java
@@ -45,7 +45,7 @@ import java.util.stream.Stream;
  */
 public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionProviderV2 {
 
-    private final CustomDefinition.DefinitionType subtypeDefinitionType;
+    private final CustomDefinition.DefinitionType wrappingSubtypeDefinitionType;
     private final Optional<JsonIdentityReferenceDefinitionProvider> identityReferenceProvider;
 
     /**
@@ -64,7 +64,7 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
      * @param options module options to derive differing behavior from
      */
     public JsonSubTypesResolver(Collection<JacksonOption> options) {
-        this.subtypeDefinitionType = options.contains(JacksonOption.ALWAYS_REF_SUBTYPES)
+        this.wrappingSubtypeDefinitionType = options.contains(JacksonOption.ALWAYS_REF_SUBTYPES)
                 ? CustomDefinition.DefinitionType.ALWAYS_REF
                 : CustomDefinition.DefinitionType.STANDARD;
         if (options.contains(JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID)) {
@@ -176,7 +176,7 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
         if (definition == null) {
             return null;
         }
-        return new CustomDefinition(definition, this.subtypeDefinitionType, CustomDefinition.AttributeInclusion.NO);
+        return new CustomDefinition(definition, this.wrappingSubtypeDefinitionType, CustomDefinition.AttributeInclusion.NO);
     }
 
     /**
@@ -308,7 +308,7 @@ public class JsonSubTypesResolver implements SubtypeResolver, CustomDefinitionPr
         switch (typeInfoAnnotation.include()) {
         case WRAPPER_ARRAY:
             definition.put(context.getKeyword(SchemaKeyword.TAG_TYPE), context.getKeyword(SchemaKeyword.TAG_TYPE_ARRAY));
-            ArrayNode itemsArray = definition.withArray(context.getKeyword(SchemaKeyword.TAG_ITEMS));
+            ArrayNode itemsArray = definition.withArray(context.getKeyword(SchemaKeyword.TAG_PREFIX_ITEMS));
             itemsArray.addObject()
                     .put(context.getKeyword(SchemaKeyword.TAG_TYPE), context.getKeyword(SchemaKeyword.TAG_TYPE_STRING))
                     .put(context.getKeyword(SchemaKeyword.TAG_CONST), typeIdentifier);

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolverCustomDefinitionsTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JsonSubTypesResolverCustomDefinitionsTest.java
@@ -109,11 +109,11 @@ public class JsonSubTypesResolverCustomDefinitionsTest extends AbstractTypeAware
                 "{\"allOf\":[{},{\"type\":\"object\",\"properties\":{\"@type\":{\"const\":\"SUB_CLASS_2\"}},\"required\":[\"@type\"]}]}"),
             Arguments.of("superTypeWithAnnotationOnFieldAndGetter", null, null),
             Arguments.of("superTypeWithAnnotationOnFieldAndGetter", TestSubClass1.class,
-                "{\"type\":\"array\",\"items\":[{\"type\":\"string\",\"const\":"
+                "{\"type\":\"array\",\"prefixItems\":[{\"type\":\"string\",\"const\":"
                 + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass1\"},"
                 + "{\"allOf\":[{},{\"title\":\"property attribute\"}]}]}"),
             Arguments.of("superTypeWithAnnotationOnFieldAndGetter", TestSubClass2.class,
-                "{\"type\":\"array\",\"items\":[{\"type\":\"string\",\"const\":"
+                "{\"type\":\"array\",\"prefixItems\":[{\"type\":\"string\",\"const\":"
                 + "\"com.github.victools.jsonschema.module.jackson.JsonSubTypesResolverCustomDefinitionsTest$TestSubClass2\"},{}]}"),
             Arguments.of("superInterfaceWithAnnotationOnField", null, null),
             Arguments.of("superInterfaceWithAnnotationOnField", TestSubClass3.class,

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
@@ -1,5 +1,40 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "BaseType": {
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/SubType1"
+                }, {
+                    "$ref": "#/definitions/SubType2"
+                }
+            ]
+        },
+        "SubType1": {
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string"
+                },
+                "@type": {
+                    "const": "subtype1"
+                }
+            },
+            "required": ["@type"]
+        },
+        "SubType2": {
+            "type": "object",
+            "properties": {
+                "recursiveBaseReference": {
+                    "$ref": "#/definitions/BaseType"
+                },
+                "@type": {
+                    "const": "subtype2"
+                }
+            },
+            "required": ["@type"]
+        }
+    },
     "type": "object",
     "properties": {
         "calculated": {
@@ -26,6 +61,9 @@
         "fieldWithOverriddenName": {
             "type": "boolean",
             "writeOnly": true
+        },
+        "interfaceWithDeclaredSubtypes": {
+            "$ref": "#/definitions/BaseType"
         },
         "referenceByObjectId": {
             "type": "object",

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-integration-test-result.json
@@ -100,7 +100,7 @@
                     "type": "null"
                 }, {
                     "type": "array",
-                    "items": [{
+                    "prefixItems": [{
                             "type": "string",
                             "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionIntegrationTest$TestSubClassWithTypeNameAnnotation"
                         }, {
@@ -108,7 +108,7 @@
                         }]
                 }, {
                     "type": "array",
-                    "items": [{
+                    "prefixItems": [{
                             "type": "string",
                             "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionIntegrationTest$TestSubClass2"
                         }, {
@@ -116,7 +116,7 @@
                         }]
                 }, {
                     "type": "array",
-                    "items": [{
+                    "prefixItems": [{
                             "type": "string",
                             "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionIntegrationTest$TestSubClass3"
                         }, {

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-interface-integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/subtype-interface-integration-test-result.json
@@ -94,7 +94,7 @@
                     "type": "null"
                 }, {
                     "type": "array",
-                    "items": [{
+                    "prefixItems": [{
                             "type": "string",
                             "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionFromInterfaceIntegrationTest$TestSubClassWithTypeNameAnnotation"
                         }, {
@@ -102,7 +102,7 @@
                         }]
                 }, {
                     "type": "array",
-                    "items": [{
+                    "prefixItems": [{
                             "type": "string",
                             "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass2"
                         }, {
@@ -110,7 +110,7 @@
                         }]
                 }, {
                     "type": "array",
-                    "items": [{
+                    "prefixItems": [{
                             "type": "string",
                             "const": "com.github.victools.jsonschema.module.jackson.SubtypeResolutionFromInterfaceIntegrationTest$TestSubClass3"
                         }, {


### PR DESCRIPTION
Introducing new `JacksonOption.INLINE_TRANSFORMED_SUBTYPES` in order to avoid definitions with `-1`/`-2` suffixes being generated in case of subtypes involving transformation (e.g., additional property, wrapping array, wrapping object).
To be used with care, as a recursive reference can cause a `StackOverflowError`. In some scenarios, such an error can be avoided by also enabling the `Option.DEFINITIONS_FOR_MEMBER_SUPERTYPES`.

Created in response to https://github.com/victools/jsonschema-generator/discussions/337