### PR TITLE
fix: error during allOf clean-up for invalid schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-generator`
+#### Fixed
+- avoid error being thrown in `allOf` clean-up for invalid payload
 
 ## [4.31.0] - 2023-04-22
 ### `jsonschema-generator`

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
@@ -386,8 +386,13 @@ public class SchemaCleanUpUtils {
                 // invalid node; abort merge
                 return null;
             }
-            encounteredValues.retainAll(nextValues);
-            if (encounteredValues.isEmpty()) {
+            if (encounteredValues.size() > 1) {
+                encounteredValues.retainAll(nextValues);
+                if (encounteredValues.isEmpty()) {
+                    // invalid merge result: no valid value remained; abort merge
+                    return null;
+                }
+            } else if (!nextValues.contains(encounteredValues.get(0))) {
                 // invalid merge result: no valid value remained; abort merge
                 return null;
             }

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorAllOfCleanUpTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorAllOfCleanUpTest.java
@@ -52,8 +52,23 @@ public class SchemaGeneratorAllOfCleanUpTest {
                                 + "\"allOf\": [{ \"title\":\"same in all three\" }, { \"title\":\"same in all three\" }] }",
                         "{ \"type\": \"object\", \"title\":\"same in all three\" }"),
                     Arguments.of(schemaVersion,
-                        "{ \"type\": \"object\",\"allOf\": [{ \"title\":\"from allOf[0]\" }, { \"description\":\"from allOf[1]\" }] }",
-                        "{ \"type\": \"object\", \"title\":\"from allOf[0]\", \"description\":\"from allOf[1]\" }")
+                        "{ \"type\": \"object\", \"allOf\": [{ \"title\":\"from allOf[0]\" }, { \"description\":\"from allOf[1]\" }] }",
+                        "{ \"type\": \"object\", \"title\":\"from allOf[0]\", \"description\":\"from allOf[1]\" }"),
+                    Arguments.of(schemaVersion,
+                        "{ \"type\": \"object\", \"allOf\": [{ \"type\": [\"object\",\"null\"] }] }",
+                        "{ \"type\": \"object\" }"),
+                    Arguments.of(schemaVersion,
+                        "{ \"type\": [\"object\",\"null\"], \"allOf\": [{ \"type\": \"object\" }] }",
+                        "{ \"type\": \"object\" }"),
+                    Arguments.of(schemaVersion,
+                        "{ \"type\": \"object\", \"allOf\": [{ \"type\": \"null\" }] }",
+                        "{ \"type\": \"object\", \"allOf\": [{ \"type\": \"null\" }] }"),
+                    Arguments.of(schemaVersion,
+                        "{ \"type\": \"object\", \"allOf\": [{ \"type\": [\"string\",\"null\"] }] }",
+                        "{ \"type\": \"object\", \"allOf\": [{ \"type\": [\"string\",\"null\"] }] }"),
+                    Arguments.of(schemaVersion,
+                        "{ \"type\": [\"object\",\"null\"], \"allOf\": [{ \"type\": \"string\" }] }",
+                        "{ \"type\": [\"object\",\"null\"], \"allOf\": [{ \"type\": \"string\" }] }")
                 ))
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
This fixes #348.

However, that doesn't resolve the fact that when you reach the affected point in the code, your generated schema may contain an error due to unresolvable type definitions (e.g., at the same time `type: object` and `type: string`).