### PR TITLE
Fix Option.VALUES_FROM_CONSTANT_FIELDS not triggering

### DIFF
--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
@@ -155,7 +155,7 @@ public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
 
     @Override
     public boolean shouldIncludeStaticFields() {
-        return this.isOptionEnabled(Option.PUBLIC_STATIC_FIELDS) || this.isOptionEnabled(Option.NONPUBLIC_STATIC_FIELDS);
+        return this.isOptionEnabled(Option.PUBLIC_STATIC_FIELDS) || this.isOptionEnabled(Option.NONPUBLIC_STATIC_FIELDS) || this.isOptionEnabled(Option.VALUES_FROM_CONSTANT_FIELDS);
     }
 
     @Override


### PR DESCRIPTION
Previously, Option.VALUES_FROM_CONSTANT_FIELDS could only work when static fields were also considered for exposition as properties.