### PR TITLE
feat: swagger-2 additionalProperties support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### `jsonschema-module-swagger-2`
+#### Added
+- consider `@Schema(additionalProperties = ...)` attribute (only values `TRUE` and `FALSE`), when it is annotated on a type (not on a member)
 
 ## [4.31.1] - 2023-04-28
 ### `jsonschema-generator`
@@ -83,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - enable look-up of annotations on a member's type parameter (e.g., a `Map`'s value type)
 - enable providing full custom schema definition to be included in `additionalProperties` or `patternProperties`
 - new function `TypeContext.getTypeWithAnnotation()` for finding also super type of interface with certain type annotation
-- new function `TypeContext.getTypeAnnotationConsideringHierarchy()´ for searching type annotations also on super types and interfaces
+- new function `TypeContext.getTypeAnnotationConsideringHierarchy()` for searching type annotations also on super types and interfaces
 
 #### Changed
 - consider annotations on `Map` value types when using `Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES`

--- a/jsonschema-module-swagger-2/src/test/java/com/github/victools/jsonschema/module/swagger2/IntegrationTest.java
+++ b/jsonschema-module-swagger-2/src/test/java/com/github/victools/jsonschema/module/swagger2/IntegrationTest.java
@@ -133,12 +133,14 @@ public class IntegrationTest {
         }
     }
 
+    @Schema(additionalProperties = Schema.AdditionalPropertiesValue.FALSE)
     static class Foo {
 
         @Schema(implementation = PersonReference.class, accessMode = Schema.AccessMode.WRITE_ONLY)
         private Reference<Person> person;
 
-        @Schema(ref = "http://example.com/bar", accessMode = Schema.AccessMode.READ_ONLY)
+        @Schema(ref = "http://example.com/bar", accessMode = Schema.AccessMode.READ_ONLY,
+                additionalProperties = Schema.AdditionalPropertiesValue.TRUE)
         private Object bar;
 
         @Schema(anyOf = {Double.class, Integer.class})
@@ -147,6 +149,8 @@ public class IntegrationTest {
         @Schema(oneOf = {Boolean.class, String.class})
         private Object oneOfBooleanOrString;
 
+        // on a member, the "additionalProperties" attribute is ignored
+        @Schema(additionalProperties = Schema.AdditionalPropertiesValue.FALSE)
         private TestClass test;
     }
 }

--- a/jsonschema-module-swagger-2/src/test/java/com/github/victools/jsonschema/module/swagger2/Swagger2ModuleTest.java
+++ b/jsonschema-module-swagger-2/src/test/java/com/github/victools/jsonschema/module/swagger2/Swagger2ModuleTest.java
@@ -16,12 +16,14 @@
 
 package com.github.victools.jsonschema.module.swagger2;
 
+import com.github.victools.jsonschema.generator.ConfigFunction;
 import com.github.victools.jsonschema.generator.FieldScope;
 import com.github.victools.jsonschema.generator.InstanceAttributeOverrideV2;
 import com.github.victools.jsonschema.generator.MethodScope;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigPart;
 import com.github.victools.jsonschema.generator.SchemaGeneratorGeneralConfigPart;
+import java.util.function.BiFunction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,6 +71,8 @@ public class Swagger2ModuleTest {
 
         Mockito.verify(this.typesInGeneralConfigPart).withDescriptionResolver(Mockito.any());
         Mockito.verify(this.typesInGeneralConfigPart).withTitleResolver(Mockito.any());
+        Mockito.verify(this.typesInGeneralConfigPart).withAdditionalPropertiesResolver(Mockito.any(ConfigFunction.class));
+        Mockito.verify(this.typesInGeneralConfigPart).withAdditionalPropertiesResolver(Mockito.any(BiFunction.class));
         Mockito.verify(this.typesInGeneralConfigPart).withCustomDefinitionProvider(Mockito.any(ExternalRefCustomDefinitionProvider.class));
         Mockito.verify(this.typesInGeneralConfigPart).withSubtypeResolver(Mockito.any(Swagger2SubtypeResolver.class));
         Mockito.verify(this.typesInGeneralConfigPart).getDefinitionNamingStrategy();

--- a/jsonschema-module-swagger-2/src/test/resources/com/github/victools/jsonschema/module/swagger2/integration-test-result-Foo.json
+++ b/jsonschema-module-swagger-2/src/test/resources/com/github/victools/jsonschema/module/swagger2/integration-test-result-Foo.json
@@ -40,5 +40,6 @@
         "test": {
             "$ref": "./TestClass-schema.json"
         }
-    }
+    },
+    "additionalProperties": false
 }


### PR DESCRIPTION
Introduction support for the `@Schema(additionalProperties = ...)` annotation attribute.
- only considering it on a type definition – not on a member (i.e., field or method) as that may cause conflicts
- additional exception: when there is also an external `@Schema(ref = "...")`, the `additionalProperties` attribute is not only ignored but explicitly set to allowed (even if otherwise forbidden by default).

Closes #352.