### PR TITLE
KotlinJacksonModule supports JsonProperty annotations on Kotlin data classes

### DIFF
--- a/jsonschema-module-jackson/pom.xml
+++ b/jsonschema-module-jackson/pom.xml
@@ -51,9 +51,6 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
             <plugin>

--- a/jsonschema-module-jackson/pom.xml
+++ b/jsonschema-module-jackson/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <java.module.name>com.github.victools.jsonschema.module.jackson</java.module.name>
+        <kotlin.version>1.9.0-Beta</kotlin.version>
     </properties>
 
     <dependencies>
@@ -33,6 +34,17 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -53,6 +65,19 @@
             <plugin>
                 <groupId>org.moditect</groupId>
                 <artifactId>moditect-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <jvmTarget>1.8</jvmTarget>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -196,11 +196,22 @@ public class JacksonModule implements Module {
         if (annotation != null) {
             String nameOverride = annotation.value();
             // check for invalid overrides
-            if (nameOverride != null && !nameOverride.isEmpty() && !nameOverride.equals(member.getDeclaredName())) {
+            if (isValidNameOverride(member, nameOverride)) {
                 return nameOverride;
             }
         }
         return null;
+    }
+
+    /**
+     * Checks whether the potential name override is valid for the specified member
+     *
+     * @param member field/method to override
+     * @param nameOverride the name that will override the original name of the member
+     * @return true if the specified override is valid for the member, false otherwise
+     */
+    protected static boolean isValidNameOverride(MemberScope<?, ?> member, String nameOverride) {
+        return nameOverride != null && !nameOverride.isEmpty() && !nameOverride.equals(member.getDeclaredName());
     }
 
     /**

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -204,7 +204,7 @@ public class JacksonModule implements Module {
     }
 
     /**
-     * Checks whether the potential name override is valid for the specified member
+     * Checks whether the potential name override is valid for the specified member.
      *
      * @param member field/method to override
      * @param nameOverride the name that will override the original name of the member

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/KotlinJacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/KotlinJacksonModule.java
@@ -1,0 +1,63 @@
+package com.github.victools.jsonschema.module.jackson;
+
+import com.fasterxml.classmate.members.RawField;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.victools.jsonschema.generator.MemberScope;
+import kotlin.Metadata;
+
+import java.lang.reflect.Parameter;
+import java.util.List;
+import java.util.OptionalInt;
+
+public class KotlinJacksonModule extends JacksonModule {
+    /**
+     * Look up an alternative name for a member in the constructor parameter list.
+     * When the Kotlin compiler compiles a Kotlin data class, it creates a constructor with a parameter
+     * for each field in the data class. The parameters have generic name such as "arg0", "arg1", etc.
+     * In order to find the appropriate constructor parameter, the method first determines the index of
+     * specified member within its type member list and uses the parameter with the same index.
+     * In order to avoid erroneous overrides, this method verifies that the specified member is indeed of a
+     * Kotlin class.
+     *
+     * @param member field/method to look-up alternative property name for
+     * @return alternative property name or the base class implementation return value
+     */
+    @Override
+    protected String getPropertyNameOverrideBasedOnJsonPropertyAnnotation(MemberScope<?, ?> member) {
+        if (isKotlinType(member)) {
+            OptionalInt memberIndex = getMemberIndex(member);
+            if (memberIndex.isPresent()) {
+                Parameter[] parameters = getConstructorParameters(member);
+                Parameter parameter = parameters[memberIndex.getAsInt()];
+                JsonProperty jsonPropertyAnnotation = parameter.getAnnotation(JsonProperty.class);
+                if (jsonPropertyAnnotation != null) {
+                    String nameOverride = jsonPropertyAnnotation.value();
+                    if (isValidNameOverride(member, nameOverride)) {
+                        return nameOverride;
+                    }
+                }
+            }
+        }
+        return super.getPropertyNameOverrideBasedOnJsonPropertyAnnotation(member);
+
+    }
+
+    private OptionalInt getMemberIndex(MemberScope<?, ?> member) {
+        List<RawField> memberFields = member.getDeclaringType().getMemberFields();
+        for (int i = 0; i < memberFields.size(); i++) {
+            if (memberFields.get(i).getName().equals(member.getName())) {
+                return OptionalInt.of(i);
+            }
+        }
+        return OptionalInt.empty();
+    }
+
+    private static Parameter[] getConstructorParameters(MemberScope<?, ?> member) {
+        return member.getDeclaringType().getConstructors().get(0).getRawMember().getParameters();
+    }
+
+    private static boolean isKotlinType(MemberScope<?, ?> member) {
+        return member.getDeclaringType().getErasedType().isAnnotationPresent(Metadata.class);
+    }
+
+}

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/KotlinJacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/KotlinJacksonModule.java
@@ -3,11 +3,10 @@ package com.github.victools.jsonschema.module.jackson;
 import com.fasterxml.classmate.members.RawField;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.victools.jsonschema.generator.MemberScope;
-import kotlin.Metadata;
-
 import java.lang.reflect.Parameter;
 import java.util.List;
 import java.util.OptionalInt;
+import kotlin.Metadata;
 
 public class KotlinJacksonModule extends JacksonModule {
     /**

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/KotlinJacksonModuleTest.kt
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/KotlinJacksonModuleTest.kt
@@ -1,0 +1,29 @@
+package com.github.victools.jsonschema.module.jackson
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.github.victools.jsonschema.generator.*
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class KotlinJacksonModuleTest {
+    data class TestJsonProperty(
+            @JsonProperty("my_text") val text: String,
+            @JsonProperty("my_number") val number: Int)
+
+    @Test
+    fun `naming override in kotlin data class with JsonProperty`() {
+        val config = SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .with(KotlinJacksonModule())
+                .build()
+
+        val generator = SchemaGenerator(config)
+        val result = generator.generateSchema(TestJsonProperty::class.java)
+        val propertiesNode = result[config.getKeyword(SchemaKeyword.TAG_PROPERTIES)]
+        val propertyNames: MutableSet<String> = TreeSet()
+        propertiesNode.fieldNames().forEachRemaining { e: String -> propertyNames.add(e) }
+        Assertions.assertTrue(propertyNames.contains("my_text"))
+        Assertions.assertTrue(propertyNames.contains("my_number"))
+    }
+
+}


### PR DESCRIPTION
[victools/jsonschema-generator/issues/358]

I have extended `JacksonModule` and created `KotlinJacksonModule` to support Kotlin data classes.
I have updated `pom.xml` in order to include a Kotlin test class. Please review these changes to make sure it doesn't break anything.
The only functionality currently is to detect `@JsonProperty` annotations on data classes by identifying the appropriate constructor parameter in the compiled class. The functionality only supports the required primary constructor and will ignore any additional constructors.