### PR TITLE
feat: add `withObjectMapper` method to customize serialization of schemas to file

### DIFF
--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
@@ -17,6 +17,7 @@
 package com.github.victools.jsonschema.generator;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.victools.jsonschema.generator.impl.TypeContextFactory;
 import java.lang.reflect.Type;
@@ -74,5 +75,15 @@ public class SchemaGenerator {
      */
     public SchemaBuilder buildMultipleSchemaDefinitions() {
         return SchemaBuilder.forMultipleTypes(this.config, this.typeContext);
+    }
+
+    /**
+     * Returns the {@link ObjectMapper} instance that is associated with the {@link SchemaGeneratorConfig} that was
+     * used to build this {@link SchemaGenerator}.
+     *
+     * @return {@link ObjectMapper}  instance
+     */
+    public ObjectMapper getObjectMapper() {
+        return this.config.getObjectMapper();
     }
 }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
@@ -78,12 +78,11 @@ public class SchemaGenerator {
     }
 
     /**
-     * Returns the {@link ObjectMapper} instance that is associated with the {@link SchemaGeneratorConfig} that was
-     * used to build this {@link SchemaGenerator}.
+     * Returns the {@link SchemaGeneratorConfig} associated with this {@link SchemaGenerator}.
      *
-     * @return {@link ObjectMapper}  instance
+     * @return a {@link SchemaGeneratorConfig} instance
      */
-    public ObjectMapper getObjectMapper() {
-        return this.config.getObjectMapper();
+    public SchemaGeneratorConfig getConfig() {
+        return this.config;
     }
 }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGenerator.java
@@ -17,7 +17,6 @@
 package com.github.victools.jsonschema.generator;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.victools.jsonschema.generator.impl.TypeContextFactory;
 import java.lang.reflect.Type;

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
@@ -19,6 +19,7 @@ package com.github.victools.jsonschema.generator;
 import com.fasterxml.classmate.AnnotationInclusion;
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.github.victools.jsonschema.generator.impl.SchemaGeneratorConfigImpl;
 import java.lang.annotation.Annotation;
@@ -41,7 +42,9 @@ public class SchemaGeneratorConfigBuilder {
      * @return default ObjectMapper instance
      */
     private static ObjectMapper createDefaultObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = new ObjectMapper()
+                // enables pretty-printing by default (users can override this by supplying their own mapper)
+                .enable(SerializationFeature.INDENT_OUTPUT);
         mapper.getSerializationConfig()
                 // since version 4.21.0
                 .with(JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS);

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
@@ -43,7 +43,7 @@ public class SchemaGeneratorConfigBuilder {
      */
     private static ObjectMapper createDefaultObjectMapper() {
         ObjectMapper mapper = new ObjectMapper()
-                // enables pretty-printing by default (users can override this by supplying their own mapper)
+                // since version 4.32.0; pretty print by default (can be overridden by supplying explicit mapper)
                 .enable(SerializationFeature.INDENT_OUTPUT);
         mapper.getSerializationConfig()
                 // since version 4.21.0
@@ -311,10 +311,11 @@ public class SchemaGeneratorConfigBuilder {
     }
 
     /**
-     * Register a custom {@link ObjectMapper} to use for serialization of the schema. This can be used to customize
-     * the serialization behavior of the schema (eg serialize to yaml instead of json).
+     * Register a custom {@link ObjectMapper} to create object and array nodes for the JSON structure being
+     * generated. Additionally, it is used to serialize a given schema, e.g., within the standard Maven plugin as
+     * either YAML or JSON.
      *
-     * @param objectMapper the {@link ObjectMapper} to use for serializing schemas
+     * @param objectMapper supplier for object and array nodes for the JSON structure being generated
      * @return this builder instance (for chaining)
      *
      * @since 4.32.0

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
@@ -51,7 +51,7 @@ public class SchemaGeneratorConfigBuilder {
         return mapper;
     }
 
-    private final ObjectMapper objectMapper;
+    private ObjectMapper objectMapper;
     private final OptionPreset preset;
     private final SchemaVersion schemaVersion;
 
@@ -304,6 +304,20 @@ public class SchemaGeneratorConfigBuilder {
      */
     public SchemaGeneratorConfigBuilder withAnnotationInclusionOverride(Class<? extends Annotation> annotationType, AnnotationInclusion override) {
         this.annotationInclusionOverrides.put(annotationType, override);
+        return this;
+    }
+
+    /**
+     * Register a custom {@link ObjectMapper} to use for serialization of the schema. This can be used to customize
+     * the serialization behavior of the schema (eg serialize to yaml instead of json).
+     *
+     * @param objectMapper the {@link ObjectMapper} to use for serializing schemas
+     * @return this builder instance (for chaining)
+     *
+     * @since 4.32.0
+     */
+    public SchemaGeneratorConfigBuilder withObjectMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
         return this;
     }
 }

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilderTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilderTest.java
@@ -16,6 +16,7 @@
 
 package com.github.victools.jsonschema.generator;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,15 @@ public class SchemaGeneratorConfigBuilderTest {
     public void testGetSetting_WithoutOption() {
         Assertions.assertSame(this.builder, this.builder.without(Option.DEFINITIONS_FOR_ALL_OBJECTS));
         Assertions.assertFalse(this.builder.getSetting(Option.DEFINITIONS_FOR_ALL_OBJECTS));
+    }
+
+    @Test
+    public void testWithObjectMapper() {
+        ObjectMapper currMapper = this.builder.getObjectMapper();
+        ObjectMapper newMapper = new ObjectMapper();
+        this.builder.withObjectMapper(newMapper);
+        Assertions.assertSame(newMapper, this.builder.getObjectMapper());
+        Assertions.assertNotEquals(currMapper, this.builder.getObjectMapper());
     }
 
     @Test

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
@@ -17,6 +17,7 @@
 package com.github.victools.jsonschema.plugin.maven;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.victools.jsonschema.generator.Module;
 import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.OptionPreset;
@@ -248,7 +249,7 @@ public class SchemaGeneratorMojo extends AbstractMojo {
         JsonNode jsonSchema = getGenerator().generateSchema(schemaClass);
         File file = getSchemaFile(schemaClass);
         this.getLog().info("- Writing schema to file: " + file);
-        this.writeToFile(jsonSchema, file);
+        this.writeToFile(getGenerator().getObjectMapper(), jsonSchema, file);
     }
 
     /**
@@ -625,10 +626,10 @@ public class SchemaGeneratorMojo extends AbstractMojo {
      * @param file The file to write to
      * @throws MojoExecutionException In case of problems when writing the targeted file
      */
-    private void writeToFile(JsonNode jsonSchema, File file) throws MojoExecutionException {
+    private void writeToFile(ObjectMapper mapper, JsonNode jsonSchema, File file) throws MojoExecutionException {
         try (FileOutputStream outputStream = new FileOutputStream(file);
                 PrintWriter writer = new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
-            writer.print(jsonSchema.toPrettyString());
+            writer.print(mapper.writeValueAsString(jsonSchema));
         } catch (IOException e) {
             throw new MojoExecutionException("Error: Can not write to file " + file, e);
         }

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
@@ -249,7 +249,7 @@ public class SchemaGeneratorMojo extends AbstractMojo {
         JsonNode jsonSchema = getGenerator().generateSchema(schemaClass);
         File file = getSchemaFile(schemaClass);
         this.getLog().info("- Writing schema to file: " + file);
-        this.writeToFile(getGenerator().getConfig().getObjectMapper(), jsonSchema, file);
+        this.writeToFile(jsonSchema, file);
     }
 
     /**
@@ -622,12 +622,12 @@ public class SchemaGeneratorMojo extends AbstractMojo {
     /**
      * Write generated schema to a file.
      *
-     * @param mapper ObjectMapper to use when writing the given schema to the given file
      * @param jsonSchema Generated schema to be written
      * @param file The file to write to
      * @throws MojoExecutionException In case of problems when writing the targeted file
      */
-    private void writeToFile(ObjectMapper mapper, JsonNode jsonSchema, File file) throws MojoExecutionException {
+    private void writeToFile(JsonNode jsonSchema, File file) throws MojoExecutionException {
+        ObjectMapper mapper = getGenerator().getConfig().getObjectMapper();
         try (FileOutputStream outputStream = new FileOutputStream(file);
                 PrintWriter writer = new PrintWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8))) {
             writer.print(mapper.writeValueAsString(jsonSchema));

--- a/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
+++ b/jsonschema-maven-plugin/src/main/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojo.java
@@ -249,7 +249,7 @@ public class SchemaGeneratorMojo extends AbstractMojo {
         JsonNode jsonSchema = getGenerator().generateSchema(schemaClass);
         File file = getSchemaFile(schemaClass);
         this.getLog().info("- Writing schema to file: " + file);
-        this.writeToFile(getGenerator().getObjectMapper(), jsonSchema, file);
+        this.writeToFile(getGenerator().getConfig().getObjectMapper(), jsonSchema, file);
     }
 
     /**
@@ -622,6 +622,7 @@ public class SchemaGeneratorMojo extends AbstractMojo {
     /**
      * Write generated schema to a file.
      *
+     * @param mapper ObjectMapper to use when writing the given schema to the given file
      * @param jsonSchema Generated schema to be written
      * @param file The file to write to
      * @throws MojoExecutionException In case of problems when writing the targeted file

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
@@ -75,7 +75,11 @@ public class SchemaGeneratorMojoTest extends AbstractMojoTestCase {
         File referenceFile = new File(testCaseLocation, testCaseName + "-reference.json");
         Assertions.assertTrue(referenceFile.exists());
         Assertions.assertTrue(FileUtils.contentEqualsIgnoreEOL(resultFile, referenceFile, CHARSET_NAME),
-                "Generated schema for " + testCaseName + " is not equal to the expected reference.");
+                "Generated schema for " + testCaseName + " is not equal to the expected reference.\n" +
+                        "Generated: " + FileUtils.readFileToString(resultFile) + "\n" +
+                        "Expected: " + FileUtils.readFileToString(referenceFile));
+        System.out.println(FileUtils.readFileToString(resultFile));
+        System.out.println(FileUtils.readFileToString(referenceFile));
     }
 
     /**

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
@@ -75,11 +75,12 @@ public class SchemaGeneratorMojoTest extends AbstractMojoTestCase {
         File referenceFile = new File(testCaseLocation, testCaseName + "-reference.json");
         Assertions.assertTrue(referenceFile.exists());
         Assertions.assertTrue(FileUtils.contentEqualsIgnoreEOL(resultFile, referenceFile, CHARSET_NAME),
-                "Generated schema for " + testCaseName + " is not equal to the expected reference.\n" +
-                        "Generated: " + FileUtils.readFileToString(resultFile) + "\n" +
-                        "Expected: " + FileUtils.readFileToString(referenceFile));
-        System.out.println(FileUtils.readFileToString(resultFile));
-        System.out.println(FileUtils.readFileToString(referenceFile));
+                "Generated schema for " + testCaseName + " is not equal to the expected reference.\n"
+                        + "Generated:\n"
+                        + FileUtils.readFileToString(resultFile)
+                        + "\n----------\n"
+                        + "Expected:\n"
+                        + FileUtils.readFileToString(referenceFile));
     }
 
     /**


### PR DESCRIPTION
Hi, I put together this rough PR based on our discussion in #384. 

3 quick questions on this:
1. Assuming the logic looks fine to you, can you clarify which test classes I need to update? (So far I found `SchemaGeneratorConfigBuilderTest.java`).
2. Do I need to update the github.io documentation you have published on the gh-pages branch?
3. Is it worthwhile to add an example within jsonschema-examples demonstrating the customization of the ObjectMapper to print yaml?