### PR TITLE
feat: include standard formats in plain JSON preset by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-*-*
+## [Unreleased]
+### `jsonschema-generator`
+#### Added
+- new `Option.STANDARD_FORMATS` includes standard `"format"` values to some types considered by `Option.ADDITIONAL_FIXED_TYPES`
+
+#### Changed
+- include new `Option.STANDARD_FORMATS` in `OptionPreset.PLAIN_JSON` by default
 
 ## [4.32.0] - 2023-10-27
 ### `jsonschema-generator`

--- a/jsonschema-examples/pom.xml
+++ b/jsonschema-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.32.1-SNAPSHOT</version>
+        <version>4.33.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-examples</artifactId>

--- a/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/JacksonDescriptionAsTitleExample-result.json
+++ b/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/JacksonDescriptionAsTitleExample-result.json
@@ -8,6 +8,7 @@
         },
         "id" : {
             "type" : "string",
+            "format" : "uuid",
             "title" : "Method Title"
         }
     },

--- a/jsonschema-generator-bom/pom.xml
+++ b/jsonschema-generator-bom/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.github.victools</groupId>
     <artifactId>jsonschema-generator-bom</artifactId>
-    <version>4.32.1-SNAPSHOT</version>
+    <version>4.33.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/jsonschema-generator-parent/pom.xml
+++ b/jsonschema-generator-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-bom</artifactId>
-        <version>4.32.1-SNAPSHOT</version>
+        <version>4.33.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-bom/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-generator-parent</artifactId>
@@ -111,6 +111,13 @@
             <url>https://github.com/takanuva15</url>
             <roles>
                 <role>Provided PR #388 (allowing configuration of Maven plugin serialization behavior)</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Daniel Gómez-Sánchez</name>
+            <url>https://github.com/magicDGS</url>
+            <roles>
+                <role>Provided PR #300 (introducing support for standard "format" values via Option)</role>
             </roles>
         </contributor>
     </contributors>

--- a/jsonschema-generator/pom.xml
+++ b/jsonschema-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.32.1-SNAPSHOT</version>
+        <version>4.33.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-generator</artifactId>

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/Option.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/Option.java
@@ -286,18 +286,14 @@ public enum Option {
      * @since 4.11.0
      */
     PLAIN_DEFINITION_KEYS(null, null),
-
     /**
-     * For the "format" attribute, JSON Schema defines various built-in supported values.
+     * For the "format" attribute, JSON Schema defines various supported values.
      * <br>
-     * Some of those data-types would be handed if either {@link #ADDITIONAL_FIXED_TYPES}
-     * or a custom {@link SimpleTypeModule} (i.e., {@link SimpleTypeModule#forPrimitiveTypes()})
-     * are added.
-     * In that case, by enabling this option these standard built-in "format" values would be added.
-     * Note that if {@link #EXTRA_OPEN_API_FORMAT_VALUES} is enabled, it overrides this option as
-     * it include extra "format" attributes.
+     * Some of those data-types would be included if either {@link #ADDITIONAL_FIXED_TYPES} is enabled or a custom {@link SimpleTypeModule} are added.
+     * By enabling this option, only the standard built-in "format" values would be added, which is a subset of the values considered with the
+     * {@link #EXTRA_OPEN_API_FORMAT_VALUES} being enabled.
      *
-     * @since 4.32.1
+     * @since 4.33.0
      */
     STANDARD_FORMATS(null, null),
     /**

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/OptionPreset.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/OptionPreset.java
@@ -55,6 +55,7 @@ public class OptionPreset {
     public static final OptionPreset PLAIN_JSON = new OptionPreset(
             Option.SCHEMA_VERSION_INDICATOR,
             Option.ADDITIONAL_FIXED_TYPES,
+            Option.STANDARD_FORMATS,
             Option.FLATTENED_ENUMS,
             Option.FLATTENED_OPTIONALS,
             Option.FLATTENED_SUPPLIERS,

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSimpleTypesTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSimpleTypesTest.java
@@ -49,10 +49,10 @@ public class SchemaGeneratorSimpleTypesTest {
             Arguments.of(long.class, SchemaKeyword.TAG_TYPE_INTEGER, "int64", null),
             Arguments.of(Short.class, SchemaKeyword.TAG_TYPE_INTEGER, null, null),
             Arguments.of(short.class, SchemaKeyword.TAG_TYPE_INTEGER, null, null),
-            Arguments.of(Double.class, SchemaKeyword.TAG_TYPE_NUMBER, "double", null, null),
-            Arguments.of(double.class, SchemaKeyword.TAG_TYPE_NUMBER, "double", null, null),
-            Arguments.of(Float.class, SchemaKeyword.TAG_TYPE_NUMBER, "float", null, null),
-            Arguments.of(float.class, SchemaKeyword.TAG_TYPE_NUMBER, "float", null, null),
+            Arguments.of(Double.class, SchemaKeyword.TAG_TYPE_NUMBER, "double", null),
+            Arguments.of(double.class, SchemaKeyword.TAG_TYPE_NUMBER, "double", null),
+            Arguments.of(Float.class, SchemaKeyword.TAG_TYPE_NUMBER, "float", null),
+            Arguments.of(float.class, SchemaKeyword.TAG_TYPE_NUMBER, "float", null),
             Arguments.of(java.time.LocalDate.class, SchemaKeyword.TAG_TYPE_STRING, "date", "date"),
             Arguments.of(java.time.LocalDateTime.class, SchemaKeyword.TAG_TYPE_STRING, "date-time", "date-time"),
             Arguments.of(java.time.LocalTime.class, SchemaKeyword.TAG_TYPE_STRING, "time", "time"),
@@ -155,7 +155,7 @@ public class SchemaGeneratorSimpleTypesTest {
     @ParameterizedTest
     @MethodSource("parametersForTestGenerateSchema_SimpleTypeWithStandardFormat")
     public void testGenerateSchema_SimpleTypeWithStandardFormat(Class<?> targetType, SchemaKeyword expectedJsonSchemaType, String expectedFormat,
-                                                        SchemaVersion schemaVersion) throws Exception {
+            SchemaVersion schemaVersion) throws Exception {
         SchemaGeneratorConfig config = new SchemaGeneratorConfigBuilder(schemaVersion)
                 .with(Option.ADDITIONAL_FIXED_TYPES, Option.STANDARD_FORMATS)
                 .build();

--- a/jsonschema-maven-plugin/pom.xml
+++ b/jsonschema-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.32.1-SNAPSHOT</version>
+        <version>4.33.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-maven-plugin</artifactId>

--- a/jsonschema-module-jackson/pom.xml
+++ b/jsonschema-module-jackson/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.32.1-SNAPSHOT</version>
+        <version>4.33.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-module-jackson</artifactId>

--- a/jsonschema-module-jakarta-validation/pom.xml
+++ b/jsonschema-module-jakarta-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.32.1-SNAPSHOT</version>
+        <version>4.33.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-module-jakarta-validation</artifactId>

--- a/jsonschema-module-javax-validation/pom.xml
+++ b/jsonschema-module-javax-validation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.32.1-SNAPSHOT</version>
+        <version>4.33.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-module-javax-validation</artifactId>

--- a/jsonschema-module-swagger-1.5/pom.xml
+++ b/jsonschema-module-swagger-1.5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.32.1-SNAPSHOT</version>
+        <version>4.33.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-module-swagger-1.5</artifactId>

--- a/jsonschema-module-swagger-2/pom.xml
+++ b/jsonschema-module-swagger-2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.github.victools</groupId>
         <artifactId>jsonschema-generator-parent</artifactId>
-        <version>4.32.1-SNAPSHOT</version>
+        <version>4.33.0-SNAPSHOT</version>
         <relativePath>../jsonschema-generator-parent/pom.xml</relativePath>
     </parent>
     <artifactId>jsonschema-module-swagger-2</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.victools</groupId>
     <artifactId>jsonschema-generator-reactor</artifactId>
-    <version>4.32.1-SNAPSHOT</version>
+    <version>4.33.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Java JSON Schema Generator (Reactor)</name>

--- a/slate-docs/source/includes/_main-generator-options.md
+++ b/slate-docs/source/includes/_main-generator-options.md
@@ -58,23 +58,32 @@ configBuilder.without(
     </tr>
     <tr>
       <td rowspan="2" style="text-align: right">3</td>
-      <td colspan="2"><code>Option.EXTRA_OPEN_API_FORMAT_VALUES</code></td>
+      <td colspan="2"><code>Option.STANDARD_FORMATS</code></td>
     </tr>
     <tr>
-      <td>Include extra <code>"format"</code> values (e.g. <code>"int32"</code>, <code>"int64"</code>, <code>"date"</code>, <code>"time"</code>, <code>"date-time"</code>, <code>"duration"</code>, <code>"uuid"</code>, <code>"uri"</code>) for fixed types (primitive/basic types, plus some of the <code>Option.ADDITIONAL_FIXED_TYPES</code> if they are enabled as well). Only works if <code>Option.ADDITIONAL_FIXED_TYPES</code> is set and it overrides <code>Option.STANDARD_FORMATS.</code></td></td>
-      <td>no automatic <code>"format"</code> values are being included.</td>
+      <td>Subset of the <code>"format"</code> values being added by <code>Option.EXTRA_OPEN_API_FORMAT_VALUES</code> but limited to built-in supported <code>"format"</code> values (<code>"date"</code>, <code>"time"</code>, <code>"date-time"</code>, <code>"duration"</code>, <code>"uuid"</code>, <code>"uri"</code>).
+      Only works if <code>Option.ADDITIONAL_FIXED_TYPES</code> is set. and it is overriden by <code>Option.EXTRA_OPEN_API_FORMAT_VALUES</code></td>
+      <td>no automatic <code>"format"</code> values are being included, unless <code>Option.EXTRA_OPEN_API_FORMAT_VALUES</code> indicates otherwise.</td>
     </tr>
     <tr>
       <td rowspan="2" style="text-align: right">4</td>
+      <td colspan="2"><code>Option.EXTRA_OPEN_API_FORMAT_VALUES</code></td>
+    </tr>
+    <tr>
+      <td>Include extra <code>"format"</code> values (e.g. <code>"int32"</code>, <code>"int64"</code>, <code>"date"</code>, <code>"time"</code>, <code>"date-time"</code>, <code>"duration"</code>, <code>"uuid"</code>, <code>"uri"</code>) for fixed types (primitive/basic types, plus some of the <code>Option.ADDITIONAL_FIXED_TYPES</code> if they are enabled as well). It overrides <code>Option.STANDARD_FORMATS</code>, which would cover only a subset of the OpenAPI format values.</td></td>
+      <td>no automatic <code>"format"</code> values are being included, unless <code>Option.STANDARD_FORMATS</code> indicates otherwise.</td>
+    </tr>
+    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
+    <tr>
+      <td rowspan="2" style="text-align: right">5</td>
       <td colspan="2"><code>Option.SIMPLIFIED_ENUMS</code></td>
     </tr>
     <tr>
       <td>Treating encountered enum types as objects, but including only the <code>name()</code> method and listing the names of the enum constants as its <code>enum</code> values.</td>
       <td>-</td>
     </tr>
-    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">5</td>
+      <td rowspan="2" style="text-align: right">6</td>
       <td colspan="2"><code>Option.FLATTENED_ENUMS</code></td>
     </tr>
     <tr>
@@ -82,7 +91,7 @@ configBuilder.without(
       <td>-</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">6</td>
+      <td rowspan="2" style="text-align: right">7</td>
       <td colspan="2"><code>Option.FLATTENED_ENUMS_FROM_TOSTRING</code></td>
     </tr>
     <tr>
@@ -90,24 +99,24 @@ configBuilder.without(
       <td>-</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">7</td>
+      <td rowspan="2" style="text-align: right">8</td>
       <td colspan="2"><code>Option.SIMPLIFIED_OPTIONALS</code></td>
     </tr>
     <tr>
       <td>Treating encountered <code>Optional</code> instances as objects, but including only the <code>get()</code>, <code>orElse()</code> and <code>isPresent()</code> methods.</td>
       <td>-</td>
     </tr>
+    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">8</td>
+      <td rowspan="2" style="text-align: right">9</td>
       <td colspan="2"><code>Option.FLATTENED_OPTIONALS</code></td>
     </tr>
     <tr>
       <td>Replacing encountered <code>Optional</code> instances as null-able forms of their generic parameter type.</td>
       <td>-</td>
     </tr>
-    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">9</td>
+      <td rowspan="2" style="text-align: right">10</td>
       <td colspan="2"><code>Option.FLATTENED_SUPPLIERS</code></td>
     </tr>
     <tr>
@@ -115,7 +124,7 @@ configBuilder.without(
       <td>-</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">10</td>
+      <td rowspan="2" style="text-align: right">11</td>
       <td colspan="2"><code>Option.VALUES_FROM_CONSTANT_FIELDS</code></td>
     </tr>
     <tr>
@@ -126,24 +135,24 @@ configBuilder.without(
       <td>No <code>const</code> values are populated for <code>static</code> <code>final</code> fields.</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">11</td>
+      <td rowspan="2" style="text-align: right">12</td>
       <td colspan="2"><code>Option.PUBLIC_STATIC_FIELDS</code></td>
     </tr>
     <tr>
       <td>Include <code>public</code> <code>static</code> fields in an object's <code>properties</code>.</td>
       <td>No <code>public</code> <code>static</code> fields are included in an object's <code>properties</code>.</td>
     </tr>
+    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">12</td>
+      <td rowspan="2" style="text-align: right">13</td>
       <td colspan="2"><code>Option.PUBLIC_NONSTATIC_FIELDS</code></td>
     </tr>
     <tr>
       <td>Include <code>public</code> non-<code>static</code> fields in an object's <code>properties</code>.</td>
       <td>No <code>public</code> non-<code>static</code> fields are included in an object's <code>properties</code>.</td>
     </tr>
-    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">13</td>
+      <td rowspan="2" style="text-align: right">14</td>
       <td colspan="2"><code>Option.NONPUBLIC_STATIC_FIELDS</code></td>
     </tr>
     <tr>
@@ -151,7 +160,7 @@ configBuilder.without(
       <td>No <code>protected</code>/package-visible/<code>private</code> <code>static</code> fields are included in an object's <code>properties</code>.</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">14</td>
+      <td rowspan="2" style="text-align: right">15</td>
       <td colspan="2"><code>Option.NONPUBLIC_NONSTATIC_FIELDS_WITH_GETTERS</code></td>
     </tr>
     <tr>
@@ -159,24 +168,24 @@ configBuilder.without(
       <td>No <code>protected</code>/package-visible/<code>private</code> non-<code>static</code> fields with getter methods are included in an object's <code>properties</code>.</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">15</td>
+      <td rowspan="2" style="text-align: right">16</td>
       <td colspan="2"><code>Option.NONPUBLIC_NONSTATIC_FIELDS_WITHOUT_GETTERS</code></td>
     </tr>
     <tr>
       <td>Include <code>protected</code>/package-visible/<code>private</code> non-<code>static</code> fields in an object's <code>properties</code> if they don't have corresponding getter methods.</td>
       <td>No <code>protected</code>/package-visible/<code>private</code> non-<code>static</code> fields without getter methods are included in an object's <code>properties</code>.</td>
     </tr>
+    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">16</td>
+      <td rowspan="2" style="text-align: right">17</td>
       <td colspan="2"><code>Option.TRANSIENT_FIELDS</code></td>
     </tr>
     <tr>
       <td>Include <code>transient</code> fields in an object's <code>properties</code> if they would otherwise be included according to the <code>Option</code>s above.</td>
       <td>No <code>transient</code> fields are included in an object's <code>properties</code> even if they would otherwise be included according to the <code>Option</code>s above.</td>
     </tr>
-    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">17</td>
+      <td rowspan="2" style="text-align: right">18</td>
       <td colspan="2"><code>Option.STATIC_METHODS</code></td>
     </tr>
     <tr>
@@ -184,7 +193,7 @@ configBuilder.without(
       <td>No <code>static</code> methods are included in an object's <code>properties</code> even if they would be included according to the <code>Option.VOID_METHODS</code> below.</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">18</td>
+      <td rowspan="2" style="text-align: right">19</td>
       <td colspan="2"><code>Option.VOID_METHODS</code></td>
     </tr>
     <tr>
@@ -192,24 +201,24 @@ configBuilder.without(
       <td>No <code>void</code> methods are included in an object's <code>properties</code> even if they would be included according to the <code>Option.STATIC_METHODS</code> above.</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">19</td>
+      <td rowspan="2" style="text-align: right">20</td>
       <td colspan="2"><code>Option.GETTER_METHODS</code></td>
     </tr>
     <tr>
       <td>Include <code>public</code> methods in an object's <code>properties</code> if a corresponding field exists that fulfills the usual naming conventions (<code>getX()</code>/<code>x</code> or <code>isValid()</code>/<code>valid</code>).</td>
       <td>No methods are included in an object's <code>properties</code>> for which a field exists that fulfills the usual naming conventions.</td>
     </tr>
+    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">20</td>
+      <td rowspan="2" style="text-align: right">21</td>
       <td colspan="2"><code>Option.NONSTATIC_NONVOID_NONGETTER_METHODS</code></td>
     </tr>
     <tr>
       <td>Include <code>public</code> non-<code>static</code> non-<code>void</code> methods in an object's <code>properties</code> for which no field exists that fulfills the usual getter naming conventions.</td>
       <td>No non-<code>static</code>/non-<code>void</code>/non-getter methods are included in an object's <code>properties</code>.</td>
     </tr>
-    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">21</td>
+      <td rowspan="2" style="text-align: right">22</td>
       <td colspan="2"><code>Option.NULLABLE_FIELDS_BY_DEFAULT</code></td>
     </tr>
     <tr>
@@ -217,7 +226,7 @@ configBuilder.without(
       <td>The schema <code>type</code> for a field does not allow for <code>null</code> by default unless some configuration specifically says it is null-able.</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">22</td>
+      <td rowspan="2" style="text-align: right">23</td>
       <td colspan="2"><code>Option.NULLABLE_METHOD_RETURN_VALUES_BY_DEFAULT</code></td>
     </tr>
     <tr>
@@ -225,24 +234,24 @@ configBuilder.without(
       <td>The schema <code>type</code> for a method's return type does not allow for <code>null</code> by default unless some configuration specifically says it is null-able.</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">23</td>
+      <td rowspan="2" style="text-align: right">24</td>
       <td colspan="2"><code>Option.NULLABLE_ARRAY_ITEMS_ALLOWED</code></td>
     </tr>
     <tr>
       <td>The schema <code>type</code> for the items in an array (in case of a field's value or method's return value being a container/array) allows <code>null</code>, if the corresponding configuration explicitly says so. Otherwise, they're still deemed not null-able by default.</td>
       <td>The schema <code>type</code> for the items in an array (in case of a field's value or method's return value being a container/array) never allows <code>null</code>.</td>
     </tr>
+    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">24</td>
+      <td rowspan="2" style="text-align: right">25</td>
       <td colspan="2"><code>Option.FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS</code></td>
     </tr>
     <tr>
       <td>Include argument-free methods as fields, e.g. the return type of <code>getName()</code> will be included as <code>name</code> field.</td>
       <td>Argument-free methods will be included with the appended parentheses.</td>
     </tr>
-    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">25</td>
+      <td rowspan="2" style="text-align: right">26</td>
       <td colspan="2"><code>Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES</code></td>
     </tr>
     <tr>
@@ -250,7 +259,7 @@ configBuilder.without(
       <td>Omitting the <code>additionalProperties</code> attribute in <code>Map&lt;K, V&gt;</code> schemas by default (thereby allowing additional properties of any type) unless some configuration specifically says something else.</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">26</td>
+      <td rowspan="2" style="text-align: right">27</td>
       <td colspan="2"><code>Option.ENUM_KEYWORD_FOR_SINGLE_VALUES</code></td>
     </tr>
     <tr>
@@ -258,24 +267,24 @@ configBuilder.without(
       <td>In case of a single allowed value, use the <code>const</code> keyword instead of <code>enum</code>.</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">27</td>
+      <td rowspan="2" style="text-align: right">28</td>
       <td colspan="2"><code>Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT</code></td>
     </tr>
     <tr>
       <td>Setting the <code>additionalProperties</code> attribute in all object schemas to <code>false</code> by default unless some configuration specifically says something else.</td>
       <td>Omitting the <code>additionalProperties</code> attribute in all object schemas by default (thereby allowing any additional properties) unless some configuration specifically says something else.</td>
     </tr>
+    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">28</td>
+      <td rowspan="2" style="text-align: right">29</td>
       <td colspan="2"><code>Option.DEFINITIONS_FOR_ALL_OBJECTS</code></td>
     </tr>
     <tr>
       <td>Include an entry in the <code>$defs</code>/<code>definitions</code> for each encountered object type that is not explicitly declared as "inline" via a custom definition.</td>
       <td>Only include those entries in the <code>$defs</code>/<code>definitions</code> for object types that are referenced more than once and which are not explicitly declared as "inline" via a custom definition.</td>
     </tr>
-    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">29</td>
+      <td rowspan="2" style="text-align: right">30</td>
       <td colspan="2"><code>Option.DEFINITION_FOR_MAIN_SCHEMA</code></td>
     </tr>
     <tr>
@@ -283,7 +292,7 @@ configBuilder.without(
       <td>Define the main/target type "inline".</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">30</td>
+      <td rowspan="2" style="text-align: right">31</td>
       <td colspan="2"><code>Option.DEFINITIONS_FOR_MEMBER_SUPERTYPES</code></td>
     </tr>
     <tr>
@@ -291,24 +300,24 @@ configBuilder.without(
       <td>For a member (field/method), having a declared type for which subtypes are being detected, include a list of definittions: one for each subtype in the given member's context. This allows independently interpreting contextual information (e.g., member annotations) for each subtype.</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">31</td>
+      <td rowspan="2" style="text-align: right">32</td>
       <td colspan="2"><code>Option.INLINE_ALL_SCHEMAS</code></td>
     </tr>
     <tr>
       <td>Do not include any <code>$defs</code>/<code>definitions</code> but rather define all sub-schemas "inline" – however, this results in an exception being thrown if the given type contains any kind of circular reference.</td>
       <td>Depending on whether <code>DEFINITIONS_FOR_ALL_OBJECTS</code> is included or excluded.</td>
     </tr>
+    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">32</td>
+      <td rowspan="2" style="text-align: right">33</td>
       <td colspan="2"><code>Option.PLAIN_DEFINITION_KEYS</code></td>
     </tr>
     <tr>
       <td>Ensure that the keys for any <code>$defs</code>/<code>definitions</code> match the regular expression <code>^[a-zA-Z0-9\.\-_]+$</code> (as expected by the OpenAPI specification 3.0).</td>
       <td>Ensure that the keys for any <code>$defs</code>/<code>definitions</code> are URI compatible (as expected by the JSON Schema specification).</td>
     </tr>
-    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
-      <td rowspan="2" style="text-align: right">33</td>
+      <td rowspan="2" style="text-align: right">34</td>
       <td colspan="2"><code>Option.ALLOF_CLEANUP_AT_THE_END</code></td>
     </tr>
     <tr>
@@ -316,21 +325,12 @@ configBuilder.without(
       <td>Do not attempt to reduce <code>allOf</code> wrappers but preserve them as they were generated regardless of them being necessary or not.</td>
     </tr>
     <tr>
-      <td rowspan="2" style="text-align: right">34</td>
+      <td rowspan="2" style="text-align: right">35</td>
       <td colspan="2"><code>Option.STRICT_TYPE_INFO</code></td>
     </tr>
     <tr>
       <td>As final step in the schema generation process, ensure all sub schemas containing keywords implying a particular "type" (e.g., "properties" implying an "object") have this "type" declared explicitly – this also affects the results from custom definitions.</td>
       <td>No additional "type" indication will be added for each sub schema, e.g. on the collected attributes where the "allOf" clean-up could not be applied or was disabled.</td>
-    </tr>
-    <tr>
-      <td rowspan="2" style="text-align: right">35</td>
-      <td colspan="2"><code>Option.STANDARD_FORMATS</code></td>
-    </tr>
-    <tr>
-      <td>Same as <code>Option.EXTRA_OPEN_API_FORMAT_VALUES</code> but only for built-in supported <code>"format"</code> values (<code>"date"</code>, <code>"time"</code>, <code>"date-time"</code>, <code>"duration"</code>, <code>"uuid"</code>, <code>"uri"</code>).
-      Only works if <code>Option.ADDITIONAL_FIXED_TYPES</code> is set and it is overriden by <code>Option.EXTRA_OPEN_API_FORMAT_VALUES</code></td>
-      <td>no automatic <code>"format"</code> values are being included.</td>
     </tr>
   </tbody>
 </table>
@@ -341,40 +341,40 @@ Below, you can find the lists of <code>Option</code>s included/excluded in the r
 * "J_O" = <code>JAVA_OBJECT</code>
 * "P_J" = <code>PLAIN_JSON</code>
 
-|  # | Standard `Option`                            | F_D | J_O | P_J |
-| -- | -------------------------------------------- | --- | --- | --- |
-|  1 | `SCHEMA_VERSION_INDICATOR`                   | ⬜️ | ⬜️ | ✅ |
-|  2 | `ADDITIONAL_FIXED_TYPES`                     | ⬜️ | ⬜️ | ✅ |
-|  3 | `EXTRA_OPEN_API_FORMAT_VALUES`               | ⬜️ | ⬜️ | ⬜️ |
-|  4 | `SIMPLIFIED_ENUMS`                           | ✅ | ✅ | ⬜️ |
-|  5 | `FLATTENED_ENUMS`                            | ⬜️ | ⬜️ | ✅ |
-|  6 | `FLATTENED_ENUMS_FROM_TOSTRING`              | ⬜️ | ⬜️ | ⬜️ |
-|  7 | `SIMPLIFIED_OPTIONALS`                       | ✅ | ✅ | ⬜️ |
-|  8 | `FLATTENED_OPTIONALS`                        | ⬜️ | ⬜️ | ✅ |
-|  8 | `FLATTENED_SUPPLIERS`                        | ⬜️ | ⬜️ | ✅ |
-| 10 | `VALUES_FROM_CONSTANT_FIELDS`                | ✅ | ✅ | ✅ |
-| 11 | `PUBLIC_STATIC_FIELDS`                       | ✅ | ✅ | ⬜️ |
-| 12 | `PUBLIC_NONSTATIC_FIELDS`                    | ✅ | ✅ | ✅ |
-| 13 | `NONPUBLIC_STATIC_FIELDS`                    | ✅ | ⬜️ | ⬜️ |
-| 14 | `NONPUBLIC_NONSTATIC_FIELDS_WITH_GETTERS`    | ✅ | ⬜️ | ✅ |
-| 15 | `NONPUBLIC_NONSTATIC_FIELDS_WITHOUT_GETTERS` | ✅ | ⬜️ | ✅ |
-| 16 | `TRANSIENT_FIELDS`                           | ✅ | ⬜️ | ⬜️ |
-| 17 | `STATIC_METHODS`                             | ✅ | ✅ | ⬜️ |
-| 18 | `VOID_METHODS`                               | ✅ | ✅ | ⬜️ |
-| 19 | `GETTER_METHODS`                             | ✅ | ✅ | ⬜️ |
-| 20 | `NONSTATIC_NONVOID_NONGETTER_METHODS`        | ✅ | ✅ | ⬜️ |
-| 21 | `NULLABLE_FIELDS_BY_DEFAULT`                 | ✅ | ⬜️ | ⬜️ |
-| 22 | `NULLABLE_METHOD_RETURN_VALUES_BY_DEFAULT`   | ✅ | ⬜️ | ⬜️ |
-| 23 | `NULLABLE_ARRAY_ITEMS_ALLOWED`               | ⬜️ | ⬜️ | ⬜️ |
-| 24 | `FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS`   | ⬜️ | ⬜️ | ⬜️ |
-| 25 | `MAP_VALUES_AS_ADDITIONAL_PROPERTIES`        | ⬜️ | ⬜️ | ⬜️ |
-| 26 | `ENUM_KEYWORD_FOR_SINGLE_VALUES`             | ⬜️ | ⬜️ | ⬜️ |
-| 27 | `FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT` | ⬜️ | ⬜️ | ⬜️ |
-| 28 | `DEFINITIONS_FOR_ALL_OBJECTS`                | ⬜️ | ⬜️ | ⬜️ |
-| 29 | `DEFINITION_FOR_MAIN_SCHEMA`                 | ⬜️ | ⬜️ | ⬜️ |
-| 30 | `DEFINITIONS_FOR_MEMBER_SUPERTYPES`          | ⬜️ | ⬜️ | ⬜️ |
-| 31 | `INLINE_ALL_SCHEMAS`                         | ⬜️ | ⬜️ | ⬜️ |
-| 32 | `PLAIN_DEFINITION_KEYS`                      | ⬜️ | ⬜️ | ⬜️ |
-| 33 | `ALLOF_CLEANUP_AT_THE_END`                   | ✅ | ✅ | ✅ |
-| 34 | `STRICT_TYPE_INFO`                           | ⬜️ | ⬜️ | ⬜️ |
-| 35 | `STANDARD_FORMATS`                           | ⬜️ | ⬜️ | ⬜️ |
+| #  | Standard `Option`                            | F_D | J_O | P_J |
+|----| -------------------------------------------- | -- | --- | --- |
+| 1  | `SCHEMA_VERSION_INDICATOR`                   | ⬜️ | ⬜️ | ✅ |
+| 2  | `ADDITIONAL_FIXED_TYPES`                     | ⬜️ | ⬜️ | ✅ |
+| 3  | `STANDARD_FORMATS`                           | ⬜ | ⬜️ | ✅ |
+| 4  | `EXTRA_OPEN_API_FORMAT_VALUES`               | ⬜️ | ⬜️ | ⬜️ |
+| 5  | `SIMPLIFIED_ENUMS`                           | ✅ | ✅ | ⬜️ |
+| 6  | `FLATTENED_ENUMS`                            | ⬜️ | ⬜️ | ✅ |
+| 7  | `FLATTENED_ENUMS_FROM_TOSTRING`              | ⬜️ | ⬜️ | ⬜️ |
+| 8  | `SIMPLIFIED_OPTIONALS`                       | ✅ | ✅ | ⬜️ |
+| 9  | `FLATTENED_OPTIONALS`                        | ⬜️ | ⬜️ | ✅ |
+| 10 | `FLATTENED_SUPPLIERS`                        | ⬜️ | ⬜️ | ✅ |
+| 11 | `VALUES_FROM_CONSTANT_FIELDS`                | ✅ | ✅ | ✅ |
+| 12 | `PUBLIC_STATIC_FIELDS`                       | ✅ | ✅ | ⬜️ |
+| 13 | `PUBLIC_NONSTATIC_FIELDS`                    | ✅ | ✅ | ✅ |
+| 14 | `NONPUBLIC_STATIC_FIELDS`                    | ✅ | ⬜️ | ⬜️ |
+| 15 | `NONPUBLIC_NONSTATIC_FIELDS_WITH_GETTERS`    | ✅ | ⬜️ | ✅ |
+| 16 | `NONPUBLIC_NONSTATIC_FIELDS_WITHOUT_GETTERS` | ✅ | ⬜️ | ✅ |
+| 17 | `TRANSIENT_FIELDS`                           | ✅ | ⬜️ | ⬜️ |
+| 18 | `STATIC_METHODS`                             | ✅ | ✅ | ⬜️ |
+| 19 | `VOID_METHODS`                               | ✅ | ✅ | ⬜️ |
+| 20 | `GETTER_METHODS`                             | ✅ | ✅ | ⬜️ |
+| 21 | `NONSTATIC_NONVOID_NONGETTER_METHODS`        | ✅ | ✅ | ⬜️ |
+| 22 | `NULLABLE_FIELDS_BY_DEFAULT`                 | ✅ | ⬜️ | ⬜️ |
+| 23 | `NULLABLE_METHOD_RETURN_VALUES_BY_DEFAULT`   | ✅ | ⬜️ | ⬜️ |
+| 24 | `NULLABLE_ARRAY_ITEMS_ALLOWED`               | ⬜️ | ⬜️ | ⬜️ |
+| 25 | `FIELDS_DERIVED_FROM_ARGUMENTFREE_METHODS`   | ⬜️ | ⬜️ | ⬜️ |
+| 26 | `MAP_VALUES_AS_ADDITIONAL_PROPERTIES`        | ⬜️ | ⬜️ | ⬜️ |
+| 27 | `ENUM_KEYWORD_FOR_SINGLE_VALUES`             | ⬜️ | ⬜️ | ⬜️ |
+| 28 | `FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT` | ⬜️ | ⬜️ | ⬜️ |
+| 29 | `DEFINITIONS_FOR_ALL_OBJECTS`                | ⬜️ | ⬜️ | ⬜️ |
+| 30 | `DEFINITION_FOR_MAIN_SCHEMA`                 | ⬜️ | ⬜️ | ⬜️ |
+| 31 | `DEFINITIONS_FOR_MEMBER_SUPERTYPES`          | ⬜️ | ⬜️ | ⬜️ |
+| 32 | `INLINE_ALL_SCHEMAS`                         | ⬜️ | ⬜️ | ⬜️ |
+| 33 | `PLAIN_DEFINITION_KEYS`                      | ⬜️ | ⬜️ | ⬜️ |
+| 34 | `ALLOF_CLEANUP_AT_THE_END`                   | ✅ | ✅ | ✅ |
+| 35 | `STRICT_TYPE_INFO`                           | ⬜️ | ⬜️ | ⬜️ |


### PR DESCRIPTION
Extension to #399 provided by @magicDGS.

Including new `Option.STANDARD_FORMATS` in `OptionPreset.PLAIN_JSON` by default.