### PR TITLE
fix: respect definitions for all when inlining nullable references

### DIFF
--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
@@ -300,18 +300,14 @@ public class SchemaBuilder {
                 // global setting: always inline schemas by default
                 return false;
             }
-            if (definitionKey.equals(mainSchemaKey)) {
+            if (createDefinitionsForAll || definitionKey.equals(mainSchemaKey)) {
                 return true;
             }
             List<ObjectNode> references = this.generationContext.getReferences(definitionKey);
-            boolean skipDirectReferenceDefinition = considerOnlyDirectReferences.get()
-                    && !createDefinitionsForAll
-                    && references.isEmpty();
-            if (skipDirectReferenceDefinition) {
+            if (considerOnlyDirectReferences.get() && references.isEmpty()) {
                 return false;
             }
-            return createDefinitionsForAll
-                    || references.size() > 1
+            return references.size() > 1
                     || (references.size() + this.generationContext.getNullableReferences(definitionKey).size()) > 1;
         };
     }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
@@ -304,7 +304,10 @@ public class SchemaBuilder {
                 return true;
             }
             List<ObjectNode> references = this.generationContext.getReferences(definitionKey);
-            if (considerOnlyDirectReferences.get() && references.isEmpty()) {
+            boolean skipDirectReferenceDefinition = considerOnlyDirectReferences.get()
+                    && !createDefinitionsForAll
+                    && references.isEmpty();
+            if (skipDirectReferenceDefinition) {
                 return false;
             }
             return createDefinitionsForAll

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/circular-custom-definition-DRAFT_2019_09.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/circular-custom-definition-DRAFT_2019_09.json
@@ -1,15 +1,32 @@
 {
     "$defs": {
+        "List(TestCircularClass1)": {
+            "type": "object",
+            "properties": {
+                "get(0)": {
+                    "$ref": "#"
+                }
+            }
+        },
+        "List(TestCircularClass2)": {
+            "type": "object",
+            "properties": {
+                "get(0)": {
+                    "$ref": "#/$defs/TestCircularClass2"
+                }
+            }
+        },
         "TestCircularClass2": {
             "type": "object",
             "properties": {
                 "list1": {
-                    "type": ["object", "null"],
-                    "properties": {
-                        "get(0)": {
-                            "$ref": "#"
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, {
+                            "$ref": "#/$defs/List(TestCircularClass1)"
                         }
-                    }
+                    ]
                 }
             }
         }
@@ -17,12 +34,13 @@
     "type": "object",
     "properties": {
         "list2": {
-            "type": ["object", "null"],
-            "properties": {
-                "get(0)": {
-                    "$ref": "#/$defs/TestCircularClass2"
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/$defs/List(TestCircularClass2)"
                 }
-            }
+            ]
         }
     }
 }

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/circular-custom-definition-DRAFT_2020_12.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/circular-custom-definition-DRAFT_2020_12.json
@@ -1,15 +1,32 @@
 {
     "$defs": {
+        "List(TestCircularClass1)": {
+            "type": "object",
+            "properties": {
+                "get(0)": {
+                    "$ref": "#"
+                }
+            }
+        },
+        "List(TestCircularClass2)": {
+            "type": "object",
+            "properties": {
+                "get(0)": {
+                    "$ref": "#/$defs/TestCircularClass2"
+                }
+            }
+        },
         "TestCircularClass2": {
             "type": "object",
             "properties": {
                 "list1": {
-                    "type": ["object", "null"],
-                    "properties": {
-                        "get(0)": {
-                            "$ref": "#"
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, {
+                            "$ref": "#/$defs/List(TestCircularClass1)"
                         }
-                    }
+                    ]
                 }
             }
         }
@@ -17,12 +34,13 @@
     "type": "object",
     "properties": {
         "list2": {
-            "type": ["object", "null"],
-            "properties": {
-                "get(0)": {
-                    "$ref": "#/$defs/TestCircularClass2"
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/$defs/List(TestCircularClass2)"
                 }
-            }
+            ]
         }
     }
 }

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/circular-custom-definition-DRAFT_6.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/circular-custom-definition-DRAFT_6.json
@@ -1,15 +1,32 @@
 {
     "definitions": {
+        "List(TestCircularClass1)": {
+            "type": "object",
+            "properties": {
+                "get(0)": {
+                    "$ref": "#"
+                }
+            }
+        },
+        "List(TestCircularClass2)": {
+            "type": "object",
+            "properties": {
+                "get(0)": {
+                    "$ref": "#/definitions/TestCircularClass2"
+                }
+            }
+        },
         "TestCircularClass2": {
             "type": "object",
             "properties": {
                 "list1": {
-                    "type": ["object", "null"],
-                    "properties": {
-                        "get(0)": {
-                            "$ref": "#"
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, {
+                            "$ref": "#/definitions/List(TestCircularClass1)"
                         }
-                    }
+                    ]
                 }
             }
         }
@@ -17,12 +34,13 @@
     "type": "object",
     "properties": {
         "list2": {
-            "type": ["object", "null"],
-            "properties": {
-                "get(0)": {
-                    "$ref": "#/definitions/TestCircularClass2"
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/definitions/List(TestCircularClass2)"
                 }
-            }
+            ]
         }
     }
 }

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/circular-custom-definition-DRAFT_7.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/circular-custom-definition-DRAFT_7.json
@@ -1,15 +1,32 @@
 {
     "definitions": {
+        "List(TestCircularClass1)": {
+            "type": "object",
+            "properties": {
+                "get(0)": {
+                    "$ref": "#"
+                }
+            }
+        },
+        "List(TestCircularClass2)": {
+            "type": "object",
+            "properties": {
+                "get(0)": {
+                    "$ref": "#/definitions/TestCircularClass2"
+                }
+            }
+        },
         "TestCircularClass2": {
             "type": "object",
             "properties": {
                 "list1": {
-                    "type": ["object", "null"],
-                    "properties": {
-                        "get(0)": {
-                            "$ref": "#"
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, {
+                            "$ref": "#/definitions/List(TestCircularClass1)"
                         }
-                    }
+                    ]
                 }
             }
         }
@@ -17,12 +34,13 @@
     "type": "object",
     "properties": {
         "list2": {
-            "type": ["object", "null"],
-            "properties": {
-                "get(0)": {
-                    "$ref": "#/definitions/TestCircularClass2"
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/definitions/List(TestCircularClass2)"
                 }
-            }
+            ]
         }
     }
 }

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass-withsupertypereferences-NO_SUBTYPES.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass-withsupertypereferences-NO_SUBTYPES.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
-        "TestSuperClass(Boolean)-nullable": {
-            "type": ["object", "null"],
+        "TestSuperClass(Boolean)": {
+            "type": "object",
             "properties": {
                 "genericFieldInSupertype": {
                     "type": ["boolean", "null"],
@@ -12,8 +12,17 @@
             "title": "TestSuperClass<Boolean>",
             "description": "supertype-only description"
         },
-        "TestSuperClass(String)-nullable": {
-            "type": ["object", "null"],
+        "TestSuperClass(Boolean)-nullable": {
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/definitions/TestSuperClass(Boolean)"
+                }
+            ]
+        },
+        "TestSuperClass(String)": {
+            "type": "object",
             "properties": {
                 "genericFieldInSupertype": {
                     "type": ["string", "null"],
@@ -22,6 +31,15 @@
             },
             "title": "TestSuperClass<String>",
             "description": "supertype-only description"
+        },
+        "TestSuperClass(String)-nullable": {
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/definitions/TestSuperClass(String)"
+                }
+            ]
         }
     },
     "type": "object",

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass-withsupertypereferences-ONE_SUBTYPE_INVALID.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass-withsupertypereferences-ONE_SUBTYPE_INVALID.json
@@ -15,8 +15,8 @@
             },
             "title": "TestSubClass3"
         },
-        "TestSuperClass(Boolean)-nullable": {
-            "type": ["object", "null"],
+        "TestSuperClass(Boolean)": {
+            "type": "object",
             "properties": {
                 "genericFieldInSupertype": {
                     "type": ["boolean", "null"],
@@ -26,12 +26,26 @@
             "title": "TestSuperClass<Boolean>",
             "description": "supertype-only description"
         },
-        "TestSuperClass(String)-nullable": {
-            "anyOf": [{
+        "TestSuperClass(Boolean)-nullable": {
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
-                    "$ref": "#/definitions/TestSubClass3"
-                }]
+                    "$ref": "#/definitions/TestSuperClass(Boolean)"
+                }
+            ]
+        },
+        "TestSuperClass(String)": {
+            "$ref": "#/definitions/TestSubClass3"
+        },
+        "TestSuperClass(String)-nullable": {
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/definitions/TestSuperClass(String)"
+                }
+            ]
         }
     },
     "type": "object",
@@ -40,7 +54,8 @@
             "$ref": "#/definitions/TestSuperClass(Boolean)-nullable"
         },
         "numberOrStringObjectField": {
-            "anyOf": [{
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
                     "type": "number",
@@ -48,7 +63,8 @@
                 }, {
                     "type": "string",
                     "title": "String"
-                }]
+                }
+            ]
         },
         "stringSupertypeField": {
             "$ref": "#/definitions/TestSuperClass(String)-nullable"

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass-withsupertypereferences-ONE_SUBTYPE_VALID.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass-withsupertypereferences-ONE_SUBTYPE_VALID.json
@@ -45,19 +45,29 @@
             },
             "title": "TestSubClass1<String>"
         },
+        "TestSuperClass(Boolean)": {
+            "$ref": "#/definitions/TestSubClass1(Boolean)"
+        },
         "TestSuperClass(Boolean)-nullable": {
-            "anyOf": [{
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
-                    "$ref": "#/definitions/TestSubClass1(Boolean)"
-                }]
+                    "$ref": "#/definitions/TestSuperClass(Boolean)"
+                }
+            ]
+        },
+        "TestSuperClass(String)": {
+            "$ref": "#/definitions/TestSubClass1(String)"
         },
         "TestSuperClass(String)-nullable": {
-            "anyOf": [{
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
-                    "$ref": "#/definitions/TestSubClass1(String)"
-                }]
+                    "$ref": "#/definitions/TestSuperClass(String)"
+                }
+            ]
         }
     },
     "type": "object",
@@ -66,7 +76,8 @@
             "$ref": "#/definitions/TestSuperClass(Boolean)-nullable"
         },
         "numberOrStringObjectField": {
-            "anyOf": [{
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
                     "type": "number",
@@ -74,7 +85,8 @@
                 }, {
                     "type": "string",
                     "title": "String"
-                }]
+                }
+            ]
         },
         "stringSupertypeField": {
             "$ref": "#/definitions/TestSuperClass(String)-nullable"

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass-withsupertypereferences-THREE_SUBTYPES.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass-withsupertypereferences-THREE_SUBTYPES.json
@@ -87,25 +87,43 @@
             },
             "title": "TestSubClass3"
         },
-        "TestSuperClass(Boolean)-nullable": {
-            "anyOf": [{
-                    "type": "null"
-                }, {
+        "TestSuperClass(Boolean)": {
+            "anyOf": [
+                {
                     "$ref": "#/definitions/TestSubClass1(Boolean)"
                 }, {
                     "$ref": "#/definitions/TestSubClass2(Boolean)"
-                }]
+                }
+            ]
         },
-        "TestSuperClass(String)-nullable": {
-            "anyOf": [{
+        "TestSuperClass(Boolean)-nullable": {
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
+                    "$ref": "#/definitions/TestSuperClass(Boolean)"
+                }
+            ]
+        },
+        "TestSuperClass(String)": {
+            "anyOf": [
+                {
                     "$ref": "#/definitions/TestSubClass1(String)"
                 }, {
                     "$ref": "#/definitions/TestSubClass2(String)"
                 }, {
                     "$ref": "#/definitions/TestSubClass3"
-                }]
+                }
+            ]
+        },
+        "TestSuperClass(String)-nullable": {
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/definitions/TestSuperClass(String)"
+                }
+            ]
         }
     },
     "type": "object",
@@ -114,7 +132,8 @@
             "$ref": "#/definitions/TestSuperClass(Boolean)-nullable"
         },
         "numberOrStringObjectField": {
-            "anyOf": [{
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
                     "type": "number",
@@ -122,7 +141,8 @@
                 }, {
                     "type": "string",
                     "title": "String"
-                }]
+                }
+            ]
         },
         "stringSupertypeField": {
             "$ref": "#/definitions/TestSuperClass(String)-nullable"

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass-withsupertypereferences-TWO_SUBTYPES.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass-withsupertypereferences-TWO_SUBTYPES.json
@@ -43,21 +43,35 @@
             },
             "title": "TestSubClass3"
         },
-        "TestSuperClass(Boolean)-nullable": {
-            "anyOf": [{
-                    "type": "null"
-                }, {
-                    "$ref": "#/definitions/TestSubClass2(Boolean)"
-                }]
+        "TestSuperClass(Boolean)": {
+            "$ref": "#/definitions/TestSubClass2(Boolean)"
         },
-        "TestSuperClass(String)-nullable": {
-            "anyOf": [{
+        "TestSuperClass(Boolean)-nullable": {
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
+                    "$ref": "#/definitions/TestSuperClass(Boolean)"
+                }
+            ]
+        },
+        "TestSuperClass(String)": {
+            "anyOf": [
+                {
                     "$ref": "#/definitions/TestSubClass2(String)"
                 }, {
                     "$ref": "#/definitions/TestSubClass3"
-                }]
+                }
+            ]
+        },
+        "TestSuperClass(String)-nullable": {
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/definitions/TestSuperClass(String)"
+                }
+            ]
         }
     },
     "type": "object",
@@ -66,7 +80,8 @@
             "$ref": "#/definitions/TestSuperClass(Boolean)-nullable"
         },
         "numberOrStringObjectField": {
-            "anyOf": [{
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
                     "type": "number",
@@ -74,7 +89,8 @@
                 }, {
                     "type": "string",
                     "title": "String"
-                }]
+                }
+            ]
         },
         "stringSupertypeField": {
             "$ref": "#/definitions/TestSuperClass(String)-nullable"

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION-typeattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION-typeattributes.json
@@ -62,11 +62,13 @@
             "additionalProperties": false
         },
         "Optional(Integer)-nullable": {
-            "anyOf": [{
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
                     "$ref": "#/definitions/Optional(Integer)"
-                }]
+                }
+            ]
         },
         "RoundingMode": {
             "type": "object",
@@ -136,14 +138,16 @@
             "additionalProperties": false
         },
         "RoundingMode-nullable": {
-            "anyOf": [{
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
                     "$ref": "#/definitions/RoundingMode"
-                }]
+                }
+            ]
         },
-        "Supplier(Integer)-nullable": {
-            "type": ["object", "null"],
+        "Supplier(Integer)": {
+            "type": "object",
             "properties": {
                 "get()": {
                     "type": ["integer", "null"],
@@ -163,6 +167,15 @@
             "title": "Supplier<Integer>",
             "description": "for type in general: Supplier<Integer>",
             "additionalProperties": false
+        },
+        "Supplier(Integer)-nullable": {
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/definitions/Supplier(Integer)"
+                }
+            ]
         },
         "TestClass1": {
             "type": "object",
@@ -347,11 +360,13 @@
             }
         },
         "TestClass2(Long)-nullable": {
-            "anyOf": [{
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
                     "$ref": "#/definitions/TestClass2(Long)"
-                }]
+                }
+            ]
         },
         "TestClass2(String)": {
             "type": "object",
@@ -418,14 +433,16 @@
             }
         },
         "TestClass2(String)-nullable": {
-            "anyOf": [{
+            "anyOf": [
+                {
                     "type": "null"
                 }, {
                     "$ref": "#/definitions/TestClass2(String)"
-                }]
+                }
+            ]
         },
-        "TestClass2(TestClass1*)-nullable": {
-            "type": ["object", "null"],
+        "TestClass2(TestClass1*)": {
+            "type": "object",
             "properties": {
                 "genericValue": {
                     "type": ["array", "null"],
@@ -493,8 +510,17 @@
                 }
             }
         },
-        "TestClass2(TestClass2(String))-nullable": {
-            "type": ["object", "null"],
+        "TestClass2(TestClass1*)-nullable": {
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/definitions/TestClass2(TestClass1*)"
+                }
+            ]
+        },
+        "TestClass2(TestClass2(String))": {
+            "type": "object",
             "properties": {
                 "genericValue": {
                     "$ref": "#/definitions/TestClass2(String)-nullable"
@@ -526,8 +552,17 @@
                 }
             }
         },
-        "TestClass4(Integer,String)-nullable": {
-            "type": ["object", "null"],
+        "TestClass2(TestClass2(String))-nullable": {
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/definitions/TestClass2(TestClass2(String))"
+                }
+            ]
+        },
+        "TestClass4(Integer,String)": {
+            "type": "object",
             "properties": {
                 "class2OfClass2OfT": {
                     "$ref": "#/definitions/TestClass2(TestClass2(String))-nullable"
@@ -564,11 +599,13 @@
                     "$ref": "#/definitions/TestClass2(TestClass2(String))-nullable"
                 },
                 "DEFAULT_ROUNDING_MODE": {
-                    "allOf": [{
+                    "allOf": [
+                        {
                             "$ref": "#/definitions/RoundingMode"
                         }, {
                             "const": "HALF_UP"
-                        }]
+                        }
+                    ]
                 }
             },
             "$id": "id-TestClass4<Integer, String>",
@@ -586,6 +623,15 @@
                 "format": "date",
                 "pattern": "^.{1,256}$"
             }
+        },
+        "TestClass4(Integer,String)-nullable": {
+            "anyOf": [
+                {
+                    "type": "null"
+                }, {
+                    "$ref": "#/definitions/TestClass4(Integer,String)"
+                }
+            ]
         }
     },
     "type": "object",
@@ -611,9 +657,6 @@
         "class4": {
             "$ref": "#/definitions/TestClass4(Integer,String)-nullable"
         },
-        "getClass4()": {
-            "$ref": "#/definitions/TestClass4(Integer,String)-nullable"
-        },
         "getNestedLong()": {
             "$ref": "#/definitions/TestClass2(Long)-nullable"
         },
@@ -631,6 +674,9 @@
             "minItems": 2,
             "maxItems": 100,
             "uniqueItems": false
+        },
+        "getClass4()": {
+            "$ref": "#/definitions/TestClass4(Integer,String)-nullable"
         }
     },
     "$id": "id-TestClass3",

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-FULL_DOCUMENTATION.json
@@ -68,6 +68,14 @@
                 }
             }
         },
+        "Supplier_Integer_": {
+            "type": "object",
+            "properties": {
+                "get()": {
+                    "type": ["integer", "null"]
+                }
+            }
+        },
         "TestClass1": {
             "type": "object",
             "properties": {
@@ -124,91 +132,66 @@
                 }
             }
         },
+        "TestClass2_TestClass1..._": {
+            "type": "object",
+            "properties": {
+                "genericArray": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/TestClass1"
+                        }
+                    }
+                },
+                "genericValue": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "#/definitions/TestClass1"
+                    }
+                }
+            }
+        },
+        "TestClass2_TestClass2_String__": {
+            "type": "object",
+            "properties": {
+                "genericArray": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "#/definitions/TestClass2_String_"
+                    }
+                },
+                "genericValue": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, {
+                            "$ref": "#/definitions/TestClass2_String_"
+                        }
+                    ]
+                }
+            }
+        },
         "TestClass3": {
             "type": "object",
             "properties": {
                 "class4": {
-                    "type": ["object", "null"],
-                    "properties": {
-                        "DEFAULT_ROUNDING_MODE": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/RoundingMode"
-                                }, {
-                                    "const": "HALF_UP"
-                                }
-                            ]
-                        },
-                        "class2OfClass2OfT": {
-                            "type": ["object", "null"],
-                            "properties": {
-                                "genericArray": {
-                                    "type": ["array", "null"],
-                                    "items": {
-                                        "$ref": "#/definitions/TestClass2_String_"
-                                    }
-                                },
-                                "genericValue": {
-                                    "anyOf": [
-                                        {
-                                            "type": "null"
-                                        }, {
-                                            "$ref": "#/definitions/TestClass2_String_"
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        "listOfOptionalS": {
-                            "type": ["array", "null"],
-                            "items": {
-                                "$ref": "#/definitions/Optional_Integer_"
-                            }
-                        },
-                        "optionalS": {
-                            "anyOf": [
-                                {
-                                    "type": "null"
-                                }, {
-                                    "$ref": "#/definitions/Optional_Integer_"
-                                }
-                            ]
-                        },
-                        "setOfStringSupplier": {
-                            "type": ["array", "null"],
-                            "items": {
-                                "$ref": "#/definitions/LazyStringSupplier"
-                            }
-                        },
-                        "supplierS": {
-                            "type": ["object", "null"],
-                            "properties": {
-                                "get()": {
-                                    "type": ["integer", "null"]
-                                }
-                            }
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, {
+                            "$ref": "#/definitions/TestClass4_Integer.String_"
                         }
-                    }
+                    ]
                 },
                 "nestedClass1Array": {
-                    "type": ["object", "null"],
-                    "properties": {
-                        "genericArray": {
-                            "type": ["array", "null"],
-                            "items": {
-                                "type": "array",
-                                "items": {
-                                    "$ref": "#/definitions/TestClass1"
-                                }
-                            }
-                        },
-                        "genericValue": {
-                            "type": ["array", "null"],
-                            "items": {
-                                "$ref": "#/definitions/TestClass1"
-                            }
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, {
+                            "$ref": "#/definitions/TestClass2_TestClass1..._"
                         }
-                    }
+                    ]
                 },
                 "nestedLong": {
                     "anyOf": [
@@ -224,6 +207,59 @@
                     "items": {
                         "$ref": "#/definitions/TestClass2_Long_"
                     }
+                }
+            }
+        },
+        "TestClass4_Integer.String_": {
+            "type": "object",
+            "properties": {
+                "DEFAULT_ROUNDING_MODE": {
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/RoundingMode"
+                        }, {
+                            "const": "HALF_UP"
+                        }
+                    ]
+                },
+                "class2OfClass2OfT": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, {
+                            "$ref": "#/definitions/TestClass2_TestClass2_String__"
+                        }
+                    ]
+                },
+                "listOfOptionalS": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "#/definitions/Optional_Integer_"
+                    }
+                },
+                "optionalS": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, {
+                            "$ref": "#/definitions/Optional_Integer_"
+                        }
+                    ]
+                },
+                "setOfStringSupplier": {
+                    "type": ["array", "null"],
+                    "items": {
+                        "$ref": "#/definitions/LazyStringSupplier"
+                    }
+                },
+                "supplierS": {
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        }, {
+                            "$ref": "#/definitions/Supplier_Integer_"
+                        }
+                    ]
                 }
             }
         }


### PR DESCRIPTION
When using `Option.DEFINITIONS_FOR_ALL_SCHEMAS` and the new `Option.INLINE_NULLABLE_SCHEMAS`, while all references to a given type are nullable, no non-nullable definition is being created.

Fixing that here, with the result that some expected unit test results changed in https://github.com/victools/jsonschema-generator/pull/412 are being reverted again to their previous behavior.