### PR TITLE
Fix Jackson JsonUnwrapped to consider inherited members

### DIFF
--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
@@ -100,6 +100,8 @@ public class IntegrationTest {
         @JsonUnwrapped
         public TypeToBeUnwrapped typeToBeUnwrapped;
 
+        public TypeWithInheritedFieldToBeUnwrapped typeWithInheritedFieldToBeUnwrapped;
+
         public String ignoredUnannotatedMethod() {
             return "nothing";
         }
@@ -157,5 +159,14 @@ public class IntegrationTest {
 
     static class TypeToBeUnwrapped {
         public String unwrappedProperty;
+    }
+
+    static class TypeWithInheritedFieldToBeUnwrapped extends TypeWithFieldToBeUnwrapped {
+
+    }
+
+    static class TypeWithFieldToBeUnwrapped {
+        @JsonUnwrapped
+        public TypeToBeUnwrapped typeToBeUnwrapped;
     }
 }

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
@@ -76,6 +76,14 @@
                 }
             }
         },
+        "typeWithInheritedFieldToBeUnwrapped": {
+            "type": "object",
+            "properties": {
+                "unwrappedProperty": {
+                    "type": "string"
+                }
+            }
+        },
         "unwrappedProperty": {
             "type": "string"
         }


### PR DESCRIPTION
Members with the `@JsonUnwrapped` annotation were being completely dropped when inherited from a super-class or interface.

This PR fixes the `@JsonUnwrapped` lookup to use `ResolvedMember` instead of `RawMember` so that it would now consider inherited members. I added a concrete example of how this should work to the `IntegrationTest`.