### PR TITLE
feat: extend support for void methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-generator`
+#### Added
+- check for custom definitions for `void` methods (this may result in exceptions inside custom configuration if a `null` return type is not considered)
+
+#### Changed
+- if present, apply custom definition for `void` methods
 
 ## [4.34.0] - 2024-03-14
 ### `jsonschema-generator`

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImpl.java
@@ -592,7 +592,12 @@ public class SchemaGenerationContextImpl implements SchemaGenerationContext {
      */
     private JsonNode createMethodSchema(MemberDetails<MethodScope> methodDetails) {
         if (methodDetails.getScope().isVoid()) {
-            return BooleanNode.FALSE;
+            // since 4.35.0: support custom definitions for void methods
+            CustomDefinition customDefinition = this.generatorConfig.getCustomDefinition(methodDetails.getScope(), this,
+                    methodDetails.getIgnoredDefinitionProvider());
+            if (customDefinition == null) {
+                return BooleanNode.FALSE;
+            }
         }
         ObjectNode subSchema = this.generatorConfig.createObjectNode();
         ObjectNode methodAttributes = AttributeCollector.collectMethodAttributes(methodDetails.getScope(), this);

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/FlattenedWrapperModule.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/FlattenedWrapperModule.java
@@ -50,7 +50,7 @@ public class FlattenedWrapperModule<W> implements Module {
      * @return whether the given type is deemed to be of the targeted wrapper type in the context of this module
      */
     protected boolean isWrapperType(ResolvedType type) {
-        return this.wrapperType.isAssignableFrom(type.getErasedType());
+        return type != null && this.wrapperType.isAssignableFrom(type.getErasedType());
     }
 
     /**

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/SimpleTypeModule.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/SimpleTypeModule.java
@@ -283,13 +283,14 @@ public class SimpleTypeModule implements Module {
     }
 
     private boolean shouldHaveEmptySchema(TypeScope scope) {
-        return SchemaKeyword.TAG_TYPE_NULL == this.fixedJsonSchemaTypes.get(scope.getType().getErasedType());
+        return scope.getType() == null
+               || SchemaKeyword.TAG_TYPE_NULL == this.fixedJsonSchemaTypes.get(scope.getType().getErasedType());
     }
 
     /**
      * Implementation of the {@link CustomDefinitionProviderV2} interface for applying fixed schema definitions for simple java types.
      */
-    private class SimpleTypeDefinitionProvider implements CustomDefinitionProviderV2 {
+    private final class SimpleTypeDefinitionProvider implements CustomDefinitionProviderV2 {
 
         @Override
         public CustomDefinition provideCustomSchemaDefinition(ResolvedType javaType, SchemaGenerationContext context) {


### PR DESCRIPTION
Change in response to #440.

When a custom property definition is provided for a `void` method, it is now being considered and applied.