### PR TITLE
JsonEnumDefaultValue support

### DIFF
--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -114,6 +114,8 @@ public class JacksonModule implements Module {
 
         applySubtypeResolverToConfigBuilder(generalConfigPart, fieldConfigPart, methodConfigPart);
 
+        fieldConfigPart.withDefaultResolver(JsonEnumDefaultValueResolver::apply);
+
         generalConfigPart.withCustomDefinitionProvider(new JsonUnwrappedDefinitionProvider());
     }
 

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonEnumDefaultValueResolver.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonEnumDefaultValueResolver.java
@@ -1,0 +1,20 @@
+package com.github.victools.jsonschema.module.jackson;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.github.victools.jsonschema.generator.TypeScope;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+public class JsonEnumDefaultValueResolver {
+
+    public static String apply(TypeScope typeScope) {
+        if (typeScope.getType().getErasedType().isEnum()) {
+            return Arrays.stream(typeScope.getType().getErasedType().getDeclaredFields())
+                    .filter(enumValue -> enumValue.isAnnotationPresent(JsonEnumDefaultValue.class))
+                    .findFirst()
+                    .map(Field::getName)
+                    .orElse(null);
+        }
+        return null;
+    }
+}

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
@@ -17,6 +17,7 @@
 package com.github.victools.jsonschema.module.jackson;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -95,6 +96,8 @@ public class IntegrationTest {
 
         public TestEnumWithJsonPropertyAnnotations enumValueWithJsonPropertyAnnotations;
 
+        public TestEnumWithJsonEnumDefaultAnnotations enumValueWithJsonEnumDefaultValueAnnotation;
+
         public BaseType interfaceWithDeclaredSubtypes;
 
         @JsonUnwrapped
@@ -129,6 +132,10 @@ public class IntegrationTest {
     enum TestEnumWithJsonPropertyAnnotations {
         @JsonProperty("x_property") X,
         @JsonProperty Y
+    }
+
+    enum TestEnumWithJsonEnumDefaultAnnotations {
+        A, @JsonEnumDefaultValue B, C
     }
 
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
@@ -54,6 +54,11 @@
             "type": "string",
             "enum": ["entry1", "entry2", "entry3"]
         },
+      "enumValueWithJsonEnumDefaultValueAnnotation": {
+            "type": "string",
+            "enum": ["A", "B", "C"],
+             "default": "B"
+        },
         "fieldWithDescription": {
             "type": "string",
             "description": "field description"


### PR DESCRIPTION
We check the backward compatibility of payloads based on schemas. There is a case that we want to mark as backward compatible, particularly when the enum set is reduced but there was a default enum value set. This will allow developers to fallback to it even if some enum is deleted. Here is the PR to support it in the Jackson module.
 ```java
      enum TestEnumWithJsonEnumDefaultAnnotations {
          A, @JsonEnumDefaultValue B, C
      }
```

->

```json
      "enumValueWithJsonEnumDefaultValueAnnotation": {
            "type": "string",
            "enum": ["A", "B", "C"],
            "default": "B"
        },
```


PS: Not sure about using DefaultResolver in the module.