### PR TITLE
Use JsonValue method type when present.

### DIFF
--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -115,6 +115,7 @@ public class JacksonModule implements Module {
         applySubtypeResolverToConfigBuilder(generalConfigPart, fieldConfigPart, methodConfigPart);
 
         generalConfigPart.withCustomDefinitionProvider(new JsonUnwrappedDefinitionProvider());
+        generalConfigPart.withCustomDefinitionProvider(new JsonValueDefinitionProvider());
     }
 
     private void applySubtypeResolverToConfigBuilder(SchemaGeneratorGeneralConfigPart generalConfigPart,

--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonValueDefinitionProvider.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JsonValueDefinitionProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.module.jackson;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.members.ResolvedMethod;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.github.victools.jsonschema.generator.CustomDefinition;
+import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2;
+import com.github.victools.jsonschema.generator.SchemaGenerationContext;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Implementation of the {@link CustomDefinitionProviderV2} interface for treating object types based on a {@link JsonValue} annotation
+ * being present with {@code value = true} on exactly one argument-free method. If no such annotations exist, no custom definition will be returned;
+ * thereby falling back on whatever is defined in a following custom definition (e.g. from one of the standard generator {@code Option}s).
+ */
+public class JsonValueDefinitionProvider implements CustomDefinitionProviderV2 {
+
+    @Override
+    public CustomDefinition provideCustomSchemaDefinition(ResolvedType javaType, SchemaGenerationContext context) {
+        ResolvedMethod jsonValueAnnotatedMethod = getJsonValueAnnotatedMethod(javaType, context);
+        if (jsonValueAnnotatedMethod == null) {
+            return null;
+        }
+        return new CustomDefinition(context.createDefinition(jsonValueAnnotatedMethod.getType()));
+    }
+
+    /**
+     * Look-up the single {@link JsonValue} annotated method with {@code value = true} and no expected arguments.
+     *
+     * @param javaType targeted type to look-up serialization method for
+     * @param context generation context providing access to type resolution context
+     * @return single method with {@link JsonValue} annotation
+     */
+    protected ResolvedMethod getJsonValueAnnotatedMethod(ResolvedType javaType, SchemaGenerationContext context) {
+        ResolvedMethod[] memberMethods = context.getTypeContext().resolveWithMembers(javaType).getMemberMethods();
+        Set<ResolvedMethod> jsonValueAnnotatedMethods = Stream.of(memberMethods)
+                .filter(method -> method.getArgumentCount() == 0)
+                .filter(method -> Optional.ofNullable(method.getAnnotations().get(JsonValue.class)).map(JsonValue::value).orElse(false))
+                .collect(Collectors.toSet());
+        if (jsonValueAnnotatedMethods.size() == 1) {
+            return jsonValueAnnotatedMethods.iterator().next();
+        }
+        return null;
+    }
+
+}

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IntegrationTest.java
@@ -95,6 +95,8 @@ public class IntegrationTest {
 
         public TestEnumWithJsonPropertyAnnotations enumValueWithJsonPropertyAnnotations;
 
+        public TestTypeWithJsonValue typeWithJsonValue;
+
         public BaseType interfaceWithDeclaredSubtypes;
 
         @JsonUnwrapped
@@ -129,6 +131,15 @@ public class IntegrationTest {
     enum TestEnumWithJsonPropertyAnnotations {
         @JsonProperty("x_property") X,
         @JsonProperty Y
+    }
+
+    static class TestTypeWithJsonValue {
+        String value;
+
+        @JsonValue
+        String getJsonValue() {
+            return value;
+        }
     }
 
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, property = "id")

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/JacksonModuleTest.java
@@ -185,7 +185,7 @@ public class JacksonModuleTest {
         Mockito.verify(this.methodConfigPart).withWriteOnlyCheck(Mockito.any());
 
         Mockito.verify(this.typesInGeneralConfigPart).withDescriptionResolver(Mockito.any());
-        Mockito.verify(this.typesInGeneralConfigPart, Mockito.times(1 + additionalCustomTypeDefinitions))
+        Mockito.verify(this.typesInGeneralConfigPart, Mockito.times(2 + additionalCustomTypeDefinitions))
                 .withCustomDefinitionProvider(Mockito.any());
     }
 

--- a/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
+++ b/jsonschema-module-jackson/src/test/resources/com/github/victools/jsonschema/module/jackson/integration-test-result.json
@@ -54,6 +54,9 @@
             "type": "string",
             "enum": ["entry1", "entry2", "entry3"]
         },
+        "typeWithJsonValue":{
+            "type":"string"
+        },
         "fieldWithDescription": {
             "type": "string",
             "description": "field description"


### PR DESCRIPTION
JsonValue can be set not only on enums but on regular types. And the return type of this method will be used as a serialization target type. 

This PR makes Jackson module aware of JsonValue annotations on regular types.