### PR TITLE
Populate enum/const from Jakarta AssertTrue and/or AssertFalse annotations

### DIFF
--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/AttributeCollector.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/AttributeCollector.java
@@ -435,6 +435,7 @@ public class AttributeCollector {
         }
         Class<?> targetType = target.getClass();
         return targetType.isPrimitive()
+                || Boolean.class.isAssignableFrom(targetType)
                 || Number.class.isAssignableFrom(targetType)
                 || CharSequence.class.isAssignableFrom(targetType)
                 || Enum.class.isAssignableFrom(targetType);

--- a/jsonschema-module-jakarta-validation/README.md
+++ b/jsonschema-module-jakarta-validation/README.md
@@ -13,6 +13,7 @@ Module for the [jsonschema-generator](../jsonschema-generator) – deriving JSON
 7. Populate "pattern" for strings. Based on `@Pattern`/`@Email`, when corresponding `JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS` is being provided in constructor.
 8. Populate "minimum"/"exclusiveMinimum" for numbers. Based on `@Min`/`@DecimalMin`/`@Positive`/`@PositiveOrZero`.
 9. Populate "maximum"/"exclusiveMaximum" for numbers. Based on `@Max`/`@DecimalMax`/`@Negative`/`@NegativeOrZero`.
+10. Populate "enum"/"const" for booleans. Based on `@AssertTrue`/`@AssertFalse`.
 
 Schema attributes derived from validation annotations on fields are also applied to their respective getter methods.  
 Schema attributes derived from validation annotations on getter methods are also applied to their associated fields.

--- a/jsonschema-module-jakarta-validation/src/main/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationModule.java
+++ b/jsonschema-module-jakarta-validation/src/main/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationModule.java
@@ -512,17 +512,15 @@ public class JakartaValidationModule implements Module {
      * @see AssertFalse
      */
     protected List<Object> resolveEnum(MemberScope<?, ?> member) {
-        List<Object> values = new ArrayList<>();
-
+        List<Object> values;
         if (this.getAnnotationFromFieldOrGetter(member, AssertTrue.class, AssertTrue::groups) != null) {
-            values.add(true);
+            values = Collections.singletonList(true);
+        } else if (this.getAnnotationFromFieldOrGetter(member, AssertFalse.class, AssertFalse::groups) != null) {
+            values = Collections.singletonList(false);
+        } else {
+            values = null;
         }
-
-        if (this.getAnnotationFromFieldOrGetter(member, AssertFalse.class, AssertFalse::groups) != null) {
-            values.add(false);
-        }
-
-        return values.isEmpty() ? null : values;
+        return values;
     }
 
     /**

--- a/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/IntegrationTest.java
+++ b/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/IntegrationTest.java
@@ -141,9 +141,6 @@ public class IntegrationTest {
         public boolean trueBoolean;
         @AssertFalse
         public boolean falseBoolean;
-        @AssertTrue
-        @AssertFalse
-        public Object allEnumResolvedObject;
     }
 
     static class Book implements Publication {

--- a/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/IntegrationTest.java
+++ b/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/IntegrationTest.java
@@ -24,6 +24,8 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import jakarta.validation.Constraint;
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Email;
@@ -134,6 +136,14 @@ public class IntegrationTest {
         @DecimalMin(value = "0", inclusive = false)
         @DecimalMax(value = "1", inclusive = false)
         public double exclusiveRangeDouble;
+
+        @AssertTrue
+        public boolean trueBoolean;
+        @AssertFalse
+        public boolean falseBoolean;
+        @AssertTrue
+        @AssertFalse
+        public Object allEnumResolvedObject;
     }
 
     static class Book implements Publication {

--- a/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationModuleTest.java
+++ b/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationModuleTest.java
@@ -23,6 +23,8 @@ import com.github.victools.jsonschema.generator.InstanceAttributeOverrideV2;
 import com.github.victools.jsonschema.generator.MethodScope;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigPart;
+import jakarta.validation.constraints.AssertFalse;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Email;
@@ -40,6 +42,8 @@ import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -146,6 +150,7 @@ public class JakartaValidationModuleTest {
         Mockito.verify(this.fieldConfigPart).withNumberExclusiveMinimumResolver(Mockito.any());
         Mockito.verify(this.fieldConfigPart).withNumberInclusiveMaximumResolver(Mockito.any());
         Mockito.verify(this.fieldConfigPart).withNumberExclusiveMaximumResolver(Mockito.any());
+        Mockito.verify(this.fieldConfigPart).withEnumResolver(Mockito.any());
         Mockito.verify(this.fieldConfigPart).withInstanceAttributeOverride(Mockito.any(InstanceAttributeOverrideV2.class));
 
         Mockito.verify(this.methodConfigPart).withNullableCheck(Mockito.any());
@@ -158,9 +163,10 @@ public class JakartaValidationModuleTest {
         Mockito.verify(this.methodConfigPart).withNumberExclusiveMinimumResolver(Mockito.any());
         Mockito.verify(this.methodConfigPart).withNumberInclusiveMaximumResolver(Mockito.any());
         Mockito.verify(this.methodConfigPart).withNumberExclusiveMaximumResolver(Mockito.any());
+        Mockito.verify(this.methodConfigPart).withEnumResolver(Mockito.any());
         Mockito.verify(this.methodConfigPart).withInstanceAttributeOverride(Mockito.any(InstanceAttributeOverrideV2.class));
 
-        Mockito.verify(this.configBuilder, Mockito.times(15))
+        Mockito.verify(this.configBuilder, Mockito.times(17))
                 .withAnnotationInclusionOverride(Mockito.any(), Mockito.eq(AnnotationInclusion.INCLUDE_AND_INHERIT));
     }
 
@@ -533,6 +539,57 @@ public class JakartaValidationModuleTest {
         Assertions.assertEquals(expectedMaxExclusive, maxExclusive);
     }
 
+    static Stream<Arguments> parametersForTestEnumResolvers() {
+        return Stream.of(
+                Arguments.of("unannotatedBoolean", new Object[]{}),
+                Arguments.of("trueBoolean", new Object[]{true}),
+                Arguments.of("trueOnGetterBoolean", new Object[]{true}),
+                Arguments.of("falseBoolean", new Object[]{false}),
+                Arguments.of("falseOnGetterBoolean", new Object[]{false}),
+                Arguments.of("trueAndFalseBoolean", new Object[]{true, false}),
+                Arguments.of("trueAndFalseOnGetterBoolean", new Object[]{true, false})
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersForTestEnumResolvers")
+    public void testEnumResolversNoValidationGroup(String fieldName, Object[] expectedValues) {
+        new JakartaValidationModule().applyToConfigBuilder(this.configBuilder);
+
+        this.testEnumResolvers(fieldName, expectedValues);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersForTestEnumResolvers")
+    public void testEnumResolversMatchingValidationGroup(String fieldName, Object[] expectedValues) {
+        new JakartaValidationModule()
+                .forValidationGroups(Test.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        this.testEnumResolvers(fieldName, expectedValues);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parametersForTestEnumResolvers")
+    public void testEnumResolversDifferentValidationGroup(String fieldName, Object[] ignoredExpectedValues) {
+        new JakartaValidationModule()
+                .forValidationGroups(Object.class)
+                .applyToConfigBuilder(this.configBuilder);
+
+        // none of the annotated values are actually expected to be returned
+        this.testEnumResolvers(fieldName);
+    }
+
+    private void testEnumResolvers(String fieldName, Object... values) {
+        TestType testType = new TestType(TestClassForEnums.class);
+        FieldScope field = testType.getMemberField(fieldName);
+
+        ArgumentCaptor<ConfigFunction<FieldScope, Collection<?>>> enumCaptor = ArgumentCaptor.forClass(ConfigFunction.class);
+        Mockito.verify(this.fieldConfigPart).withEnumResolver(enumCaptor.capture());
+        Collection<?> enumValues = enumCaptor.getValue().apply(field);
+        Assertions.assertEquals(values.length > 0 ? Arrays.asList(values) : null, enumValues);
+    }
+
     static Stream<Arguments> parametersForTestValidationGroupSetting() {
         return Stream.of(
             Arguments.of("skippedConfiguringGroups", "fieldWithoutValidationGroup", Boolean.TRUE, null),
@@ -815,6 +872,36 @@ public class JakartaValidationModuleTest {
         @NegativeOrZero(groups = Test.class)
         public Long getNegativeOrZeroOnGetterLong() {
             return negativeOrZeroOnGetterLong;
+        }
+    }
+
+    private static class TestClassForEnums {
+        boolean unannotatedBoolean;
+        @AssertTrue(groups = Test.class)
+        boolean trueBoolean;
+        boolean trueOnGetterBoolean;
+        @AssertFalse(groups = Test.class)
+        boolean falseBoolean;
+        boolean falseOnGetterBoolean;
+        @AssertTrue(groups = Test.class)
+        @AssertFalse(groups = Test.class)
+        boolean trueAndFalseBoolean;
+        boolean trueAndFalseOnGetterBoolean;
+
+        @AssertTrue(groups = Test.class)
+        public boolean isTrueOnGetterBoolean() {
+            return trueOnGetterBoolean;
+        }
+
+        @AssertFalse(groups = Test.class)
+        public boolean isFalseOnGetterBoolean() {
+            return falseOnGetterBoolean;
+        }
+
+        @AssertTrue(groups = Test.class)
+        @AssertFalse(groups = Test.class)
+        public boolean isTrueAndFalseOnGetterBoolean() {
+            return trueAndFalseOnGetterBoolean;
         }
     }
 

--- a/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationModuleTest.java
+++ b/jsonschema-module-jakarta-validation/src/test/java/com/github/victools/jsonschema/module/jakarta/validation/JakartaValidationModuleTest.java
@@ -546,8 +546,8 @@ public class JakartaValidationModuleTest {
                 Arguments.of("trueOnGetterBoolean", new Object[]{true}),
                 Arguments.of("falseBoolean", new Object[]{false}),
                 Arguments.of("falseOnGetterBoolean", new Object[]{false}),
-                Arguments.of("trueAndFalseBoolean", new Object[]{true, false}),
-                Arguments.of("trueAndFalseOnGetterBoolean", new Object[]{true, false})
+                Arguments.of("trueAndFalseBoolean", new Object[]{true}),
+                Arguments.of("trueAndFalseOnGetterBoolean", new Object[]{true})
         );
     }
 

--- a/jsonschema-module-jakarta-validation/src/test/resources/com/github/victools/jsonschema/module/jakarta/validation/integration-test-result.json
+++ b/jsonschema-module-jakarta-validation/src/test/resources/com/github/victools/jsonschema/module/jakarta/validation/integration-test-result.json
@@ -2,9 +2,6 @@
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "object",
     "properties": {
-        "allEnumResolvedObject": {
-            "enum": [true, false]
-        },
         "exclusiveRangeDouble": {
             "type": "number",
             "exclusiveMinimum": 0,

--- a/jsonschema-module-jakarta-validation/src/test/resources/com/github/victools/jsonschema/module/jakarta/validation/integration-test-result.json
+++ b/jsonschema-module-jakarta-validation/src/test/resources/com/github/victools/jsonschema/module/jakarta/validation/integration-test-result.json
@@ -2,10 +2,17 @@
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "type": "object",
     "properties": {
+        "allEnumResolvedObject": {
+            "enum": [true, false]
+        },
         "exclusiveRangeDouble": {
             "type": "number",
             "exclusiveMinimum": 0,
             "exclusiveMaximum": 1
+        },
+        "falseBoolean": {
+            "type": "boolean",
+            "const": false
         },
         "inclusiveRangeInt": {
             "type": "integer",
@@ -113,6 +120,10 @@
             "type": "string",
             "minLength": 5,
             "maxLength": 12
+        },
+        "trueBoolean": {
+            "type": "boolean",
+            "const": true
         }
     },
     "required": ["notBlankText", "notEmptyList", "notEmptyMap", "notEmptyPatternText", "notNullEmail", "notNullList"]

--- a/slate-docs/source/includes/_jakarta-validation-module.md
+++ b/slate-docs/source/includes/_jakarta-validation-module.md
@@ -24,6 +24,7 @@ SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(Sc
 7. Populate "pattern" for strings. Based on `@Pattern`/`@Email`, if `JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS` is being provided (i.e. this is an "opt-in").
 8. Populate "minimum"/"exclusiveMinimum" for numbers. Based on `@Min`/`@DecimalMin`/`@Positive`/`@PositiveOrZero`.
 9. Populate "maximum"/"exclusiveMaximum" for numbers. Based on `@Max`/`@DecimalMax`/`@Negative`/`@NegativeOrZero`.
+10. Populate "enum"/"const" for booleans. Based on `@AssertTrue`/`@AssertFalse`.
 
 Schema attributes derived from validation annotations on fields are also applied to their respective getter methods.  
 Schema attributes derived from validation annotations on getter methods are also applied to their associated fields.


### PR DESCRIPTION
Set `enum`/`const` based on the presence of Jakarta `@AssertTrue` and/or `@AssertFalse`.

See https://github.com/victools/jsonschema-generator/issues/455#issuecomment-2221494969 for background info.