### PR TITLE
chore(docs): add example for dependentRequired usage

### DIFF
--- a/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/DependentRequiredExample.java
+++ b/jsonschema-examples/src/main/java/com/github/victools/jsonschema/examples/DependentRequiredExample.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.examples;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Example created in response to <a href="https://github.com/victools/jsonschema-generator/issues/463">#463</a>.
+ * <br/>
+ * Demonstrating the use of "dependentRequired" by using a custom annotation.
+ */
+public class DependentRequiredExample implements SchemaGenerationExampleInterface {
+
+    @Override
+    public ObjectNode generateSchema() {
+        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON);
+        configBuilder.forFields().withDependentRequiresResolver(field -> Optional
+                .ofNullable(field.getAnnotationConsideringFieldAndGetter(IfPresentAlsoRequire.class))
+                .map(IfPresentAlsoRequire::value)
+                .map(Arrays::asList)
+                .orElse(null));
+        SchemaGeneratorConfig config = configBuilder.build();
+        SchemaGenerator generator = new SchemaGenerator(config);
+        return generator.generateSchema(Example.class);
+    }
+
+    static class Example {
+        @IfPresentAlsoRequire({"foobar", "bar"})
+        public String foo;
+        public Integer foobar;
+        public List<String> bar;
+        public Double baz;
+    }
+
+    @Target({ElementType.FIELD, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface IfPresentAlsoRequire {
+        String[] value();
+    }
+}

--- a/jsonschema-examples/src/test/java/com/github/victools/jsonschema/examples/ExampleTest.java
+++ b/jsonschema-examples/src/test/java/com/github/victools/jsonschema/examples/ExampleTest.java
@@ -32,6 +32,7 @@ public class ExampleTest {
     @ParameterizedTest
     @ValueSource(classes = {
             AnnotationInheritanceExample.class,
+            DependentRequiredExample.class,
             EnumMapExample.class,
             ExternalRefAnnotationExample.class,
             ExternalRefPackageExample.class,

--- a/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/DependentRequiredExample-result.json
+++ b/jsonschema-examples/src/test/resources/com/github/victools/jsonschema/examples/DependentRequiredExample-result.json
@@ -1,0 +1,24 @@
+{
+    "$schema" : "https://json-schema.org/draft/2020-12/schema",
+    "type" : "object",
+    "properties" : {
+        "bar" : {
+            "type" : "array",
+            "items" : {
+                "type" : "string"
+            }
+        },
+        "baz" : {
+            "type" : "number"
+        },
+        "foo" : {
+            "type" : "string"
+        },
+        "foobar" : {
+            "type" : "integer"
+        }
+    },
+    "dependentRequired" : {
+        "foo" : [ "foobar", "bar" ]
+    }
+}

--- a/slate-docs/source/includes/_main-generator-individual.md
+++ b/slate-docs/source/includes/_main-generator-individual.md
@@ -194,7 +194,7 @@ configBuilder.forMethods()
 ```java
 configBuilder.forFields()
     .withDependentRequiresResolver(field -> Optional
-        .ofNullable(field.getAnnotationConsideringFieldAndGetter(IfPresentAlsoRequire.class)
+        .ofNullable(field.getAnnotationConsideringFieldAndGetter(IfPresentAlsoRequire.class))
         .map(IfPresentAlsoRequire::value)
         .map(Arrays::asList)
         .orElse(null));


### PR DESCRIPTION
As requested in the issue, I'm adding a complete version of the provided example for configuring the `"dependentRequired"` keyword.

Resolves #463.