### PR TITLE
feat: add maven plugin flags to skip abstract types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 - avoid exception in subtype resolution, when targeting void method
 
+### `jsonschema-maven-plugin`
+### Added
+- support `<skipAbstractTypes>` flag to exclude abstract types (not interfaces)
+- support `<skipInterfaces>` flag to exclude interface types
+
 ## [4.36.0] - 2024-07-20
 ### `jsonschema-generator`
 #### Added

--- a/jsonschema-maven-plugin/README.md
+++ b/jsonschema-maven-plugin/README.md
@@ -61,6 +61,16 @@ The content of each of these elements can be either:
 </configuration>
 ```
 
+Additionally, you can omit the generation for abstract classes and/or interfaces by setting the respective `<skipAbstractTypes>` or `<skipInterfaces>`
+flags to `true` (by default, they are `false`).
+```xml
+<configuration>
+    <packageNames>com/myOrg/myApp/package/**</packageNames>
+    <skipAbstractTypes>true</skipAbstractTypes>
+    <skipInterfaces>true</skipInterfaces>
+</configuration>
+```
+
 #### Based on Annotations (`<annotations>`)
 
 Alternatively classes can be selected based on annotations using the `<annotations>` element. Then

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
@@ -158,13 +158,14 @@ public class SchemaGeneratorMojoTest extends AbstractMojoTestCase {
     /**
      * Unit test to test the generation of schemas for multiple classes
      */
-    @Test
-    public void testPackageName() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = { "WithoutAbstracts", "WithoutInterfaces" })
+    public void testPackageName(String scenario) throws Exception {
         File testCaseLocation = new File("src/test/resources/reference-test-cases");
-        File generationLocation = new File("target/generated-test-sources/PackageName");
+        File generationLocation = new File("target/generated-test-sources/PackageName" + scenario);
 
         // Execute the pom
-        executePom(new File("src/test/resources/reference-test-cases/PackageName-pom.xml"));
+        executePom(new File("src/test/resources/reference-test-cases/PackageName" + scenario + "-pom.xml"));
 
         // Validate that the schema files are created.
         File resultFileA = new File(generationLocation,"TestClassA-schema.json");
@@ -178,6 +179,11 @@ public class SchemaGeneratorMojoTest extends AbstractMojoTestCase {
         File resultFileC = new File(generationLocation,"TestClassC-schema.json");
         Assertions.assertTrue(resultFileC.exists());
         resultFileC.deleteOnExit();
+
+        File resultFileAbstract = new File(generationLocation,"AbstractTestClass-schema.json");
+        Assertions.assertNotEquals("WithoutAbstracts".equals(scenario), resultFileAbstract.exists());
+        File resultFileInterface = new File(generationLocation,"TestInterface-schema.json");
+        Assertions.assertNotEquals("WithoutInterfaces".equals(scenario), resultFileInterface.exists());
 
         // Validate that they are the same as the reference
         File referenceFileA = new File(testCaseLocation, "TestClassA-reference.json");

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/testpackage/AbstractTestClass.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/testpackage/AbstractTestClass.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.plugin.maven.testpackage;
+
+public abstract class AbstractTestClass {
+
+    public abstract int getInteger();
+}

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/testpackage/TestInterface.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/testpackage/TestInterface.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 VicTools.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.plugin.maven.testpackage;
+
+public interface TestInterface {
+
+    String getValue();
+}

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/PackageNameWithoutAbstracts-pom.xml
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/PackageNameWithoutAbstracts-pom.xml
@@ -1,0 +1,16 @@
+<project>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.victools</groupId>
+                <artifactId>jsonschema-maven-plugin</artifactId>
+                <configuration>
+                    <packageNames>com.github.victools.jsonschema.plugin.maven.testpackage</packageNames>
+                    <schemaFilePath>target/generated-test-sources/PackageNameWithoutAbstracts</schemaFilePath>
+                    <excludeClassNames>com.github.victools.jsonschema.plugin.maven.testpackage.TestClassB</excludeClassNames>
+                    <skipAbstractTypes>true</skipAbstractTypes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/PackageNameWithoutInterfaces-pom.xml
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/PackageNameWithoutInterfaces-pom.xml
@@ -6,8 +6,9 @@
                 <artifactId>jsonschema-maven-plugin</artifactId>
                 <configuration>
                     <packageNames>com.github.victools.jsonschema.plugin.maven.testpackage</packageNames>
-                    <schemaFilePath>target/generated-test-sources/PackageName</schemaFilePath>
+                    <schemaFilePath>target/generated-test-sources/PackageNameWithoutInterfaces</schemaFilePath>
                     <excludeClassNames>com.github.victools.jsonschema.plugin.maven.testpackage.TestClassB</excludeClassNames>
+                    <skipInterfaces>true</skipInterfaces>
                 </configuration>
             </plugin>
         </plugins>

--- a/slate-docs/source/includes/_maven-plugin.md
+++ b/slate-docs/source/includes/_maven-plugin.md
@@ -21,6 +21,8 @@ There are a number of basic configuration options as well as the possibility to 
         <annotations>
             <annotation>com.myOrg.MySchemaAnnotation</annotation>
         </annotations>
+        <skipAbstractTypes>true</skipAbstractTypes>
+        <skipInterfaces>true</skipInterfaces>
         <classpath>PROJECT_ONLY</classpath>
         <failIfNoClassesMatch>false</failIfNoClassesMatch>
     </configuration>
@@ -82,6 +84,15 @@ For example, the given configuration will create a `MyClass.schema` file.
 ```
 To store the generated schema files in the same directory structure as the originating classes, the following can be used `<schemaFileName>{1}/{0}-schema.json</schemaFileName>`.   
 The default `<schemaFileName>` is `{0}-schema.json`.
+
+Additionally, you can omit the generation for abstract classes and/or interfaces by setting the respective `<skipAbstractTypes>` or `<skipInterfaces>` flags to `true` (by default, they are `false`).
+```xml
+<configuration>
+    <packageNames>com/myOrg/myApp/package/**</packageNames>
+    <skipAbstractTypes>true</skipAbstractTypes>
+    <skipInterfaces>true</skipInterfaces>
+</configuration>
+```
 
 ### Selecting Options
 


### PR DESCRIPTION
Introduce new configuration flags for Maven plugin:
- `<skipAbstractTypes>`
- `<skipInterfaces>`

Closes #476.