### PR TITLE
feat: Enable special null type handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### `jsonschema-generator`
+#### Added
+- new `Option.NULLABLE_ALWAYS_AS_ANYOF` that avoids the `"null"` type being included with other type values, e.g. `"type": ["object", "null"]`
+
 #### Changed
 - apply property name overrides before triggering the ignore check (i.e., provide both the declared and overridden property names if there is one)
 - update various (runtime/test/build-time) dependencies

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/Option.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/Option.java
@@ -239,6 +239,14 @@ public enum Option {
      */
     ENUM_KEYWORD_FOR_SINGLE_VALUES(null, null),
     /**
+     * Whether a {@code {"type":"null"}} schema should always be grouped as {@link SchemaKeyword#TAG_ANYOF "anyOf"} with the not-null schema.
+     * Otherwise, it is deemed acceptable to include the {@code "null"} option in the main schema's {@link SchemaKeyword#TAG_TYPE "type"} value, e.g.
+     * as {@code {"type":["null","string]}} resulting in a simpler/smaller schema overall.
+     *
+     * @since 4.37.0
+     */
+    NULLABLE_ALWAYS_AS_ANYOF(null, null),
+    /**
      * Whether a schema's "additionalProperties" should be set to "false" if no specific configuration says otherwise.
      * <br>
      * Without this option, i.e. by default, the "additionalProperties" keyword will be omitted and thereby allowing any additional properties in an

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaBuilder.java
@@ -200,6 +200,8 @@ public class SchemaBuilder {
         }
         if (this.config.shouldIncludeStrictTypeInfo()) {
             cleanUpUtils.setStrictTypeInfo(this.schemaNodes, true);
+            // since version 4.37.0 as extraneous "anyOf" wrappers may have been introduced to support type "null"
+            cleanUpUtils.reduceAnyOfNodes(this.schemaNodes);
         }
     }
 

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfig.java
@@ -94,6 +94,17 @@ public interface SchemaGeneratorConfig extends StatefulConfig {
     boolean shouldInlineNullableSchemas();
 
     /**
+     * Determine whether a {@code {"type":"null"}} schema should always be grouped as {@link SchemaKeyword#TAG_ANYOF "anyOf"} with the not-null
+     * schema. Otherwise, it is deemed acceptable to include the {@code "null"} option in the main schema's {@link SchemaKeyword#TAG_TYPE "type"}
+     * value, e.g. as {@code {"type":["null","string]}} resulting in a simpler/smaller schema overall.
+     *
+     * @return whether to avoid adding {@code "null"} as additional option in the {@link SchemaKeyword#TAG_TYPE "type"} attribute's value array
+     *
+     * @since 4.37.0
+     */
+    boolean shouldAlwaysWrapNullSchemaInAnyOf();
+
+    /**
      * Determine whether the {@link SchemaKeyword#TAG_SCHEMA} attribute with {@link SchemaKeyword#TAG_SCHEMA_VALUE} should be added.
      *
      * @return whether to add the schema version attribute

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
@@ -24,6 +24,7 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
 import com.github.victools.jsonschema.generator.SchemaKeyword;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -644,17 +645,7 @@ public class SchemaCleanUpUtils {
      */
     private void addTypeInfoWhereMissing(ObjectNode schemaNode, String typeTagName, boolean considerNullType,
             Map<String, SchemaKeyword> reverseTagMap) {
-        if (schemaNode.has(typeTagName)) {
-            // explicit type indication is already present
-            return;
-        }
-        List<String> impliedTypes = reverseTagMap.entrySet().stream()
-                .filter(entry -> schemaNode.has(entry.getKey()))
-                .flatMap(entry -> entry.getValue().getImpliedTypes().stream())
-                .distinct()
-                .sorted()
-                .map(SchemaKeyword.SchemaType::getSchemaKeywordValue)
-                .collect(Collectors.toList());
+        List<String> impliedTypes = this.collectImpliedTypes(schemaNode, typeTagName, reverseTagMap);
         if (impliedTypes.isEmpty()) {
             return;
         }
@@ -670,6 +661,20 @@ public class SchemaCleanUpUtils {
             // since version 4.37.0
             SchemaGenerationContextImpl.makeNullable(schemaNode, this.config);
         }
+    }
+
+    private List<String> collectImpliedTypes(ObjectNode schemaNode, String typeTagName, Map<String, SchemaKeyword> reverseTagMap) {
+        if (schemaNode.has(typeTagName)) {
+            // explicit type indication is already present
+            return Collections.emptyList();
+        }
+        return reverseTagMap.entrySet().stream()
+                .filter(entry -> schemaNode.has(entry.getKey()))
+                .flatMap(entry -> entry.getValue().getImpliedTypes().stream())
+                .distinct()
+                .sorted()
+                .map(SchemaKeyword.SchemaType::getSchemaKeywordValue)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
@@ -658,13 +658,14 @@ public class SchemaCleanUpUtils {
         if (impliedTypes.isEmpty()) {
             return;
         }
-        if (considerNullType) {
-            impliedTypes.add(SchemaKeyword.SchemaType.NULL.getSchemaKeywordValue());
-        }
         if (impliedTypes.size() == 1) {
             schemaNode.put(typeTagName, impliedTypes.get(0));
         } else {
             impliedTypes.forEach(schemaNode.putArray(typeTagName)::add);
+        }
+        if (considerNullType) {
+            // since version 4.37.0
+            SchemaGenerationContextImpl.makeNullable(schemaNode, this.config);
         }
     }
 

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
@@ -658,12 +658,15 @@ public class SchemaCleanUpUtils {
         if (impliedTypes.isEmpty()) {
             return;
         }
+        if (considerNullType && !this.config.shouldAlwaysWrapNullSchemaInAnyOf()) {
+            impliedTypes.add(SchemaKeyword.SchemaType.NULL.getSchemaKeywordValue());
+        }
         if (impliedTypes.size() == 1) {
             schemaNode.put(typeTagName, impliedTypes.get(0));
         } else {
             impliedTypes.forEach(schemaNode.putArray(typeTagName)::add);
         }
-        if (considerNullType) {
+        if (considerNullType && this.config.shouldAlwaysWrapNullSchemaInAnyOf()) {
             // since version 4.37.0
             SchemaGenerationContextImpl.makeNullable(schemaNode, this.config);
         }

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGenerationContextImpl.java
@@ -428,10 +428,10 @@ public class SchemaGenerationContextImpl implements SchemaGenerationContext {
      */
     private void generateArrayDefinition(GenericTypeDetails typeDetails, ObjectNode definition) {
         definition.put(this.getKeyword(SchemaKeyword.TAG_TYPE), this.getKeyword(SchemaKeyword.TAG_TYPE_ARRAY));
-        if (typeDetails.isNullable()) {
-            this.extendTypeDeclarationToIncludeNull(definition);
-        }
         definition.set(this.getKeyword(SchemaKeyword.TAG_ITEMS), this.populateItemMemberSchema(typeDetails.getScope()));
+        if (typeDetails.isNullable()) {
+            this.makeNullable(definition);
+        }
     }
 
     private JsonNode populateItemMemberSchema(TypeScope targetScope) {
@@ -676,34 +676,50 @@ public class SchemaGenerationContextImpl implements SchemaGenerationContext {
     }
 
     @Override
+    public String getKeyword(SchemaKeyword keyword) {
+        return this.generatorConfig.getKeyword(keyword);
+    }
+
+    @Override
     public ObjectNode makeNullable(ObjectNode node) {
+        return SchemaGenerationContextImpl.makeNullable(node, this.generatorConfig);
+    }
+
+    static ObjectNode makeNullable(ObjectNode node, SchemaGeneratorConfig config) {
+        if (SchemaGenerationContextImpl.canExtendTypeDeclarationToIncludeNull(node, config)) {
+            // given node is a simple schema, we can adjust its "type" attribute
+            SchemaGenerationContextImpl.extendTypeDeclarationToIncludeNull(node, config);
+        } else {
+            // cannot be sure what is specified in those other schema parts, instead simply create an anyOf wrapper
+            ObjectNode nullSchema = config.createObjectNode()
+                    .put(config.getKeyword(SchemaKeyword.TAG_TYPE), config.getKeyword(SchemaKeyword.TAG_TYPE_NULL));
+            ArrayNode anyOf = config.createArrayNode()
+                    // one option in the anyOf should be null
+                    .add(nullSchema)
+                    // the other option is the given (assumed to be) not-nullable node
+                    .add(config.createObjectNode().setAll(node));
+            // replace all existing (and already copied properties with the anyOf wrapper
+            node.removeAll();
+            node.set(config.getKeyword(SchemaKeyword.TAG_ANYOF), anyOf);
+        }
+        return node;
+    }
+
+    private static boolean canExtendTypeDeclarationToIncludeNull(ObjectNode node, SchemaGeneratorConfig config) {
+        if (config.shouldAlwaysWrapNullSchemaInAnyOf()) {
+            return false;
+        }
         Stream<SchemaKeyword> requiringAnyOfWrapper = Stream.of(
                 SchemaKeyword.TAG_REF, SchemaKeyword.TAG_ALLOF, SchemaKeyword.TAG_ANYOF, SchemaKeyword.TAG_ONEOF,
                 // since version 4.21.0
                 SchemaKeyword.TAG_CONST, SchemaKeyword.TAG_ENUM
         );
-        if (requiringAnyOfWrapper.map(this::getKeyword).anyMatch(node::has)) {
-            // cannot be sure what is specified in those other schema parts, instead simply create an anyOf wrapper
-            ObjectNode nullSchema = this.generatorConfig.createObjectNode()
-                    .put(this.getKeyword(SchemaKeyword.TAG_TYPE), this.getKeyword(SchemaKeyword.TAG_TYPE_NULL));
-            ArrayNode anyOf = this.generatorConfig.createArrayNode()
-                    // one option in the anyOf should be null
-                    .add(nullSchema)
-                    // the other option is the given (assumed to be) not-nullable node
-                    .add(this.generatorConfig.createObjectNode().setAll(node));
-            // replace all existing (and already copied properties with the anyOf wrapper
-            node.removeAll();
-            node.set(this.getKeyword(SchemaKeyword.TAG_ANYOF), anyOf);
-        } else {
-            // given node is a simple schema, we can adjust its "type" attribute
-            this.extendTypeDeclarationToIncludeNull(node);
-        }
-        return node;
+        return requiringAnyOfWrapper.map(config::getKeyword).noneMatch(node::has);
     }
 
-    private void extendTypeDeclarationToIncludeNull(ObjectNode node) {
-        JsonNode fixedJsonSchemaType = node.get(this.getKeyword(SchemaKeyword.TAG_TYPE));
-        final String nullTypeName = this.getKeyword(SchemaKeyword.TAG_TYPE_NULL);
+    private static void extendTypeDeclarationToIncludeNull(ObjectNode node, SchemaGeneratorConfig config) {
+        JsonNode fixedJsonSchemaType = node.get(config.getKeyword(SchemaKeyword.TAG_TYPE));
+        final String nullTypeName = config.getKeyword(SchemaKeyword.TAG_TYPE_NULL);
         if (fixedJsonSchemaType instanceof ArrayNode) {
             // there are already multiple "type" values
             ArrayNode arrayOfTypes = (ArrayNode) fixedJsonSchemaType;
@@ -714,21 +730,16 @@ public class SchemaGenerationContextImpl implements SchemaGenerationContext {
                 }
             }
             // null "type" was not mentioned before, to be safe we need to replace the old array and add the null entry
-            node.putArray(this.getKeyword(SchemaKeyword.TAG_TYPE))
+            node.putArray(config.getKeyword(SchemaKeyword.TAG_TYPE))
                     .addAll(arrayOfTypes)
                     .add(nullTypeName);
         } else if (fixedJsonSchemaType instanceof TextNode && !nullTypeName.equals(fixedJsonSchemaType.textValue())) {
             // add null as second "type" option
-            node.putArray(this.getKeyword(SchemaKeyword.TAG_TYPE))
+            node.putArray(config.getKeyword(SchemaKeyword.TAG_TYPE))
                     .add(fixedJsonSchemaType)
                     .add(nullTypeName);
         }
         // if no "type" is specified, null is allowed already
-    }
-
-    @Override
-    public String getKeyword(SchemaKeyword keyword) {
-        return this.generatorConfig.getKeyword(keyword);
     }
 
     private static class GenericTypeDetails {

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaGeneratorConfigImpl.java
@@ -139,6 +139,11 @@ public class SchemaGeneratorConfigImpl implements SchemaGeneratorConfig {
     }
 
     @Override
+    public boolean shouldAlwaysWrapNullSchemaInAnyOf() {
+        return this.isOptionEnabled(Option.NULLABLE_ALWAYS_AS_ANYOF);
+    }
+
+    @Override
     public boolean shouldUsePlainDefinitionKeys() {
         return this.isOptionEnabled(Option.PLAIN_DEFINITION_KEYS);
     }

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
@@ -274,24 +274,18 @@
                                 {
                                     "type": "null"
                                 }, {
-                                    "anyOf": [
-                                        {
-                                            "type": "null"
-                                        }, {
-                                            "$ref": "#/definitions/TestClass2(String)"
-                                        }
-                                    ],
-                                    "title": "TestClass2<String>",
-                                    "description": "looked-up from method: TestClass2<String>",
-                                    "additionalProperties": false,
-                                    "patternProperties": {
-                                        "^generic.+$": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "type": "object"
+                                    "$ref": "#/definitions/TestClass2(String)"
                                 }
-                            ]
+                            ],
+                            "title": "TestClass2<String>",
+                            "description": "looked-up from method: TestClass2<String>",
+                            "additionalProperties": false,
+                            "patternProperties": {
+                                "^generic.+$": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": ["object", "null"]
                         }
                     },
                     "title": "TestClass2<TestClass2<String>>",
@@ -408,24 +402,18 @@
                                     {
                                         "type": "null"
                                     }, {
-                                        "anyOf": [
-                                            {
-                                                "type": "null"
-                                            }, {
-                                                "$ref": "#/definitions/TestClass1"
-                                            }
-                                        ],
-                                        "title": "TestClass1",
-                                        "description": "looked-up from method: TestClass1",
-                                        "additionalProperties": false,
-                                        "patternProperties": {
-                                            "^generic.+$": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "type": "object"
+                                        "$ref": "#/definitions/TestClass1"
                                     }
-                                ]
+                                ],
+                                "title": "TestClass1",
+                                "description": "looked-up from method: TestClass1",
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                    "^generic.+$": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": ["object", "null"]
                             }
                         }
                     ]

--- a/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
+++ b/jsonschema-generator/src/test/resources/com/github/victools/jsonschema/generator/testclass3-JAVA_OBJECT-methodattributes.json
@@ -274,18 +274,24 @@
                                 {
                                     "type": "null"
                                 }, {
-                                    "$ref": "#/definitions/TestClass2(String)"
+                                    "anyOf": [
+                                        {
+                                            "type": "null"
+                                        }, {
+                                            "$ref": "#/definitions/TestClass2(String)"
+                                        }
+                                    ],
+                                    "title": "TestClass2<String>",
+                                    "description": "looked-up from method: TestClass2<String>",
+                                    "additionalProperties": false,
+                                    "patternProperties": {
+                                        "^generic.+$": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
                                 }
-                            ],
-                            "title": "TestClass2<String>",
-                            "description": "looked-up from method: TestClass2<String>",
-                            "additionalProperties": false,
-                            "patternProperties": {
-                                "^generic.+$": {
-                                    "type": "string"
-                                }
-                            },
-                            "type": ["object", "null"]
+                            ]
                         }
                     },
                     "title": "TestClass2<TestClass2<String>>",
@@ -402,18 +408,24 @@
                                     {
                                         "type": "null"
                                     }, {
-                                        "$ref": "#/definitions/TestClass1"
+                                        "anyOf": [
+                                            {
+                                                "type": "null"
+                                            }, {
+                                                "$ref": "#/definitions/TestClass1"
+                                            }
+                                        ],
+                                        "title": "TestClass1",
+                                        "description": "looked-up from method: TestClass1",
+                                        "additionalProperties": false,
+                                        "patternProperties": {
+                                            "^generic.+$": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "type": "object"
                                     }
-                                ],
-                                "title": "TestClass1",
-                                "description": "looked-up from method: TestClass1",
-                                "additionalProperties": false,
-                                "patternProperties": {
-                                    "^generic.+$": {
-                                        "type": "string"
-                                    }
-                                },
-                                "type": ["object", "null"]
+                                ]
                             }
                         }
                     ]

--- a/slate-docs/source/includes/_main-generator-options.md
+++ b/slate-docs/source/includes/_main-generator-options.md
@@ -336,11 +336,11 @@ configBuilder.without(
       <td rowspan="2" style="text-align: right">36</td>
       <td colspan="2"><code>Option.ALLOF_CLEANUP_AT_THE_END</code></td>
     </tr>
-    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
       <td>At the very end of the schema generation reduce <code>allOf</code> wrappers where it is possible without overwriting any attributes – this also affects the results from custom definitions.</td>
       <td>Do not attempt to reduce <code>allOf</code> wrappers but preserve them as they were generated regardless of them being necessary or not.</td>
     </tr>
+    <tr><th>#</th><th>Behavior if included</th><th>Behavior if excluded</th></tr>
     <tr>
       <td rowspan="2" style="text-align: right">37</td>
       <td colspan="2"><code>Option.STRICT_TYPE_INFO</code></td>
@@ -348,6 +348,14 @@ configBuilder.without(
     <tr>
       <td>As final step in the schema generation process, ensure all sub schemas containing keywords implying a particular "type" (e.g., "properties" implying an "object") have this "type" declared explicitly – this also affects the results from custom definitions.</td>
       <td>No additional "type" indication will be added for each sub schema, e.g. on the collected attributes where the "allOf" clean-up could not be applied or was disabled.</td>
+    </tr>
+    <tr>
+      <td rowspan="2" style="text-align: right">38</td>
+      <td colspan="2"><code>Option.NULLABLE_ALWAYS_AS_ANYOF</code></td>
+    </tr>
+    <tr>
+      <td>A "type": "null" will not be combined with other "type" values in an array. Instead, a separate "anyOf" with a subschema only containing the "type": "null" will be included.</td>
+      <td>For brevity's sake, a "type": "null" may be combined with other "type" values, e.g. as "type": ["null", "object"].</td>
     </tr>
   </tbody>
 </table>
@@ -397,3 +405,4 @@ Below, you can find the lists of <code>Option</code>s included/excluded in the r
 | 35 | `PLAIN_DEFINITION_KEYS`                      | ⬜️ | ⬜️ | ⬜️ |
 | 36 | `ALLOF_CLEANUP_AT_THE_END`                   | ✅ | ✅ | ✅ |
 | 37 | `STRICT_TYPE_INFO`                           | ⬜️ | ⬜️ | ⬜️ |
+| 38 | `NULLABLE_ALWAYS_AS_ANYOF`                   | ⬜️ | ⬜️ | ⬜️ |


### PR DESCRIPTION
Fixes #482.

Introducing new `Option.NULLABLE_ALWAYS_AS_ANYOF` that avoids the `"null"` type being included with other type values, e.g. `"type": ["object", "null"]`