### PR TITLE
fix: Avoid duplicate items in allOf and required arrays

### DIFF
--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtils.java
@@ -271,8 +271,11 @@ public class SchemaCleanUpUtils {
             return null;
         }
         return () -> {
+            Set<JsonNode> arrayItems = new LinkedHashSet<>();
+            arrayNodesToMerge.forEach(node -> node.forEach(arrayItems::add));
+
             ArrayNode mergedArrayNode = this.config.createArrayNode();
-            arrayNodesToMerge.forEach(node -> node.forEach(mergedArrayNode::add));
+            arrayItems.forEach(mergedArrayNode::add);
             return mergedArrayNode;
         };
     }

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtilsTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtilsTest.java
@@ -25,9 +25,11 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigPart;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Stream;
 import org.json.JSONArray;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -115,5 +117,21 @@ public class SchemaCleanUpUtilsTest {
 
         String schemaAsString = schema.toString();
         JSONAssert.assertEquals('\n' + schemaAsString +'\n', expectedOutput, schemaAsString, JSONCompareMode.STRICT);
+    }
+
+    @Test
+    public void testAllOfCleanup() throws Exception {
+        SchemaGeneratorConfigBuilder configBuilder = new SchemaGeneratorConfigBuilder(
+                SchemaVersion.DRAFT_2019_09, OptionPreset.PLAIN_JSON);
+        SchemaCleanUpUtils utilsInstance = new SchemaCleanUpUtils(configBuilder.build());
+
+        JsonNode schema = configBuilder.getObjectMapper().readTree(
+                "{\"allOf\":[{\"type\":\"object\",\"properties\":{\"foo\":{\"type\":\"string\"}},\"required\":[\"foo\"]},{\"type\":\"object\",\"properties\":{\"foo\":{\"type\":\"string\"}},\"required\":[\"foo\"]}]}");
+        utilsInstance.reduceAllOfNodes(List.of((ObjectNode) schema));
+
+        String schemaAsString = schema.toString();
+        JSONAssert.assertEquals('\n' + schemaAsString + '\n',
+                "{\"type\":\"object\",\"properties\":{\"foo\":{\"type\":\"string\"}},\"required\":[\"foo\"]}",
+                schemaAsString, JSONCompareMode.STRICT);
     }
 }

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtilsTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/impl/SchemaCleanUpUtilsTest.java
@@ -16,27 +16,17 @@
 
 package com.github.victools.jsonschema.generator.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.victools.jsonschema.generator.OptionPreset;
-import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
-import com.github.victools.jsonschema.generator.SchemaGeneratorConfigPart;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import java.util.Collections;
-import java.util.List;
 import java.util.stream.Stream;
-import org.json.JSONArray;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.Mock;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 


### PR DESCRIPTION
When performing `allOf` clean-up, avoid duplicate entries in `allOf` and `required` arrays.

Fixes #499.