### PR TITLE
fix!: don't use format "date-time" for LocalDateTime

### DIFF
--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/SimpleTypeModule.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/SimpleTypeModule.java
@@ -84,9 +84,15 @@ public class SimpleTypeModule implements Module {
     public static SimpleTypeModule forPrimitiveAndAdditionalTypes() {
         SimpleTypeModule module = SimpleTypeModule.forPrimitiveTypes();
 
+        /*
+         * LocalDateTime does not fit the definition of "date-time" (a timestamp with time zone)
+         * as per RFC3339: https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+         * See also: https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.7.3.1
+         */
+        module.withStringType(java.time.LocalDateTime.class);
+
         module.withStandardStringType(java.time.LocalDate.class, "date");
-        Stream.of(java.time.LocalDateTime.class, java.time.ZonedDateTime.class,
-                java.time.OffsetDateTime.class, java.time.Instant.class,
+        Stream.of(java.time.ZonedDateTime.class, java.time.OffsetDateTime.class, java.time.Instant.class,
                 java.util.Date.class, java.util.Calendar.class)
                 .forEach(javaType -> module.withStandardStringType(javaType, "date-time"));
         Stream.of(java.time.LocalTime.class, java.time.OffsetTime.class)

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSimpleTypesTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSimpleTypesTest.java
@@ -54,7 +54,7 @@ public class SchemaGeneratorSimpleTypesTest {
             Arguments.of(Float.class, SchemaKeyword.TAG_TYPE_NUMBER, "float", null),
             Arguments.of(float.class, SchemaKeyword.TAG_TYPE_NUMBER, "float", null),
             Arguments.of(java.time.LocalDate.class, SchemaKeyword.TAG_TYPE_STRING, "date", "date"),
-            Arguments.of(java.time.LocalDateTime.class, SchemaKeyword.TAG_TYPE_STRING, "date-time", "date-time"),
+            Arguments.of(java.time.LocalDateTime.class, SchemaKeyword.TAG_TYPE_STRING, null, null),
             Arguments.of(java.time.LocalTime.class, SchemaKeyword.TAG_TYPE_STRING, "time", "time"),
             Arguments.of(java.time.ZonedDateTime.class, SchemaKeyword.TAG_TYPE_STRING, "date-time", "date-time"),
             Arguments.of(java.time.OffsetDateTime.class, SchemaKeyword.TAG_TYPE_STRING, "date-time", "date-time"),


### PR DESCRIPTION
@CarstenWickner sorry that it took me so long, but here we go.
This simply overrides the default behavior and is a breaking change. If you want, I can try to hide it behind a feature flag to preserve backward compatibility. Or you publish a major version increase, your choice.

Btw. I was not sure how to format the code, did you think about integrating the Maven spotless plugin or similar?

Closes #517