### PR TITLE
fix: support objects in `enum` keyword

### DIFF
--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/AttributeCollector.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/AttributeCollector.java
@@ -438,7 +438,8 @@ public class AttributeCollector {
                 || Boolean.class.isAssignableFrom(targetType)
                 || Number.class.isAssignableFrom(targetType)
                 || CharSequence.class.isAssignableFrom(targetType)
-                || Enum.class.isAssignableFrom(targetType);
+                || Enum.class.isAssignableFrom(targetType)
+                || Map.class.isAssignableFrom(targetType);
     }
 
     /**


### PR DESCRIPTION
Adds support for including JSON objects in the `enum` keyword with `withEnumResolver()`, as the spec permits this.

https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-01#name-enum
https://json-schema.org/draft/2019-09/draft-handrews-json-schema-validation-02#rfc.section.6.1.2
https://json-schema.org/draft-07/draft-handrews-json-schema-validation-01#rfc.section.6.1.2
https://json-schema.org/draft-06/draft-wright-json-schema-validation-01#rfc.section.6.23

> Elements in the array might be of any type, including null.

I have tested this in my use-case. If there's a better way to do this, feel free to let me know.

P.S. `Option.FLATTENED_ENUMS` and `Option.FLATTENED_ENUMS_FROM_TOSTRING` needs to be excluded for `withEnumResolver()` to take effect, not sure if this is intended...