### PR TITLE
fix: extract distinct enum values

### DIFF
--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/EnumModule.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/EnumModule.java
@@ -126,6 +126,7 @@ public class EnumModule implements Module {
         }
         return Stream.of(erasedType.getEnumConstants())
                 .map(enumConstant -> enumConstantToString.apply((Enum<?>) enumConstant))
+                .distinct()
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
When using custom `EnumModule`s, sometimes there may be multiple enums resolving to the same value, so make sure they are distinct to reduce the size of the resulting schema.