### PR TITLE
fix: support non-conforming getter names with the JacksonModule

### DIFF
--- a/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
+++ b/jsonschema-module-jackson/src/main/java/com/github/victools/jsonschema/module/jackson/JacksonModule.java
@@ -303,7 +303,18 @@ public class JacksonModule implements Module {
         // other kinds of field ignorals are handled implicitly, i.e. are only available by way of being absent
         return beanDescription.findProperties().stream()
                 .noneMatch(propertyDefinition -> declaredName.equals(propertyDefinition.getInternalName())
-                        || fieldName.equals(propertyDefinition.getInternalName()));
+                        || fieldName.equals(propertyDefinition.getInternalName())
+                        || fieldName.equals(toNonJavaBeanConformingName(propertyDefinition.getInternalName())));
+    }
+
+    private String toNonJavaBeanConformingName(String fieldName) {
+        // a field name like "xIndex" will have a propertyDefinition name "xindex", but should not be ignored.
+        if(fieldName == null || fieldName.length() < 2) {
+            return fieldName;
+        }
+        return fieldName.charAt(0)
+               + fieldName.substring(1, 2).toUpperCase()
+               + fieldName.substring(2);
     }
 
     /**

--- a/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IgnorePropertyTest.java
+++ b/jsonschema-module-jackson/src/test/java/com/github/victools/jsonschema/module/jackson/IgnorePropertyTest.java
@@ -46,7 +46,8 @@ public class IgnorePropertyTest {
         return Stream.of(
             Arguments.of(SubType.class, "[includedChildField, includedParentField1, includedParentField2]"),
             Arguments.of(SuperType.class, "[ignoredParentField2, includedParentField1]"),
-            Arguments.of(TypeWithUnderscoreField.class, "[import]")
+            Arguments.of(TypeWithUnderscoreField.class, "[import]"),
+            Arguments.of(TypeWithNonCompatibleGetter.class, "[aIncludedField2, included1]")
         );
     }
 
@@ -97,6 +98,17 @@ public class IgnorePropertyTest {
 
         public String getIgnoredValue() {
             return "method being ignored, because there is no matching field";
+        }
+    }
+
+    private static class TypeWithNonCompatibleGetter {
+        public String included1;
+
+//        @JsonProperty("aIncludedField2") // This will fix the test
+        private int aIncludedField2;
+
+        public int getAIncludedField2() {
+            return this.aIncludedField2;
         }
     }
 }


### PR DESCRIPTION
Reproduces and fixes https://github.com/victools/jsonschema-generator/issues/535