### PR TITLE
feature: Allow Custom Modules to be configured with options

### DIFF
--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/CustomModule.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/CustomModule.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Christian Scheer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.generator;
+
+import java.util.List;
+
+public interface CustomModule extends Module {
+    void setOptions(List<String> options);
+}

--- a/jsonschema-maven-plugin/README.md
+++ b/jsonschema-maven-plugin/README.md
@@ -223,7 +223,21 @@ To enable a custom module in the generation the following construct can be used:
 </configuration>
 ```
 Make sure your custom module is on the classpath and has a default constructor.
-It is not possible to configure options for custom modules.
+If your module implements `com.github.victools.jsonschema.generator.CustomModule`, you can configure options:
+```xml
+<configuration>
+    <classNames>com.myOrg.myApp.MyClass</classNames>
+    <modules>
+        <module>
+            <className>com.myOrg.myApp.CustomModule</className>
+            <options>
+                <option>MyOptionStringOne</option>
+                <option>MyOptionStringTwo</option>
+            </options>
+        </module>
+    </modules>
+</configuration>
+```
 
 ### Complete Example
 ```xml

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/SchemaGeneratorMojoTest.java
@@ -57,7 +57,8 @@ public class SchemaGeneratorMojoTest extends AbstractMojoTestCase {
         "JakartaValidationModule",
         "Swagger15Module",
         "Swagger2Module",
-        "Complete"
+        "Complete",
+        "CustomModuleWithOptions"
     })
     public void testGeneration(String testCaseName) throws Exception {
         File testCaseLocation = new File("src/test/resources/reference-test-cases");

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/TestCustomModule.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/TestCustomModule.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Christian Scheer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.victools.jsonschema.plugin.maven;
+
+import com.github.victools.jsonschema.generator.CustomModule;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+
+import java.util.List;
+
+public class TestCustomModule implements CustomModule {
+    private String skipFieldsStartingWith;
+
+    @Override
+    public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+        builder.forFields().withIgnoreCheck(field -> field.getName().startsWith(skipFieldsStartingWith));
+    }
+
+    @Override
+    public void setOptions(List<String> options) {
+        if (options.size() > 1) {
+            throw new IllegalArgumentException("More than one option specified");
+        }
+        this.skipFieldsStartingWith = options.get(0);
+    }
+}

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/CustomModuleWithOptions-pom.xml
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/CustomModuleWithOptions-pom.xml
@@ -1,0 +1,22 @@
+<project>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.victools</groupId>
+                <artifactId>jsonschema-maven-plugin</artifactId>
+                <configuration>
+                    <classNames>com.github.victools.jsonschema.plugin.maven.TestClass</classNames>
+                    <schemaFilePath>target/generated-test-sources/CustomModuleWithOptions</schemaFilePath>
+                    <modules>
+                        <module>
+                            <className>com.github.victools.jsonschema.plugin.maven.TestCustomModule</className>
+                            <options>
+                                <option>a</option>
+                            </options>
+                        </module>
+                    </modules>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/CustomModuleWithOptions-reference.json
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/CustomModuleWithOptions-reference.json
@@ -1,0 +1,4 @@
+{
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "type" : "object"
+}


### PR DESCRIPTION
I wrote a custom module to handle Jacksons @JsonView Annotations (happy to open source this as soon it's polished). I had to hardcode the parameter, because custom modules are not configurable at the moment.

This is my attempt to improve on that limitation