### PR TITLE
Fix: Numeric properties are now correctly serialized as numbers

### DIFF
--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/SchemaGeneratorConfigBuilder.java
@@ -46,8 +46,6 @@ public class SchemaGeneratorConfigBuilder {
         return JsonMapper.builder()
                 // since version 4.32.0; pretty print by default (can be overridden by supplying explicit mapper)
                 .enable(SerializationFeature.INDENT_OUTPUT)
-                // since version 4.21.0
-                .enable(JsonWriteFeature.WRITE_NUMBERS_AS_STRINGS)
                 // since version 4.25.0; as the above doesn't always work
                 .enable(JsonNodeFeature.STRIP_TRAILING_BIGDECIMAL_ZEROES)
                 .build();

--- a/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/TestClass.java
+++ b/jsonschema-maven-plugin/src/test/java/com/github/victools/jsonschema/plugin/maven/TestClass.java
@@ -17,9 +17,14 @@
 package com.github.victools.jsonschema.plugin.maven;
 
 import com.fasterxml.jackson.annotation.JsonClassDescription;
+import jakarta.validation.constraints.Size;
 
 @JsonClassDescription("Jackson annotation class")
 public class TestClass {
+
+    @Size(min = 1)
+    private String name;
+
     private int anInt;
 
     public TestClass(int anInt) {
@@ -28,5 +33,9 @@ public class TestClass {
 
     public int getAnInt() {
         return this.anInt;
+    }
+
+    public String getName() {
+        return this.name;
     }
 }

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/Complete-reference.json
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/Complete-reference.json
@@ -1,1 +1,1 @@
-{"type":"object","properties":{"anInt":{"type":"integer"},"getAnInt()":{"type":"integer"}},"description":"Jackson annotation class","additionalProperties":false}
+{"type":"object","properties":{"anInt":{"type":"integer"},"name":{"type":["string","null"]},"getAnInt()":{"type":"integer"},"getName()":{"type":["string","null"]}},"description":"Jackson annotation class","additionalProperties":false}

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/DefaultConfig-reference.json
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/DefaultConfig-reference.json
@@ -4,6 +4,9 @@
   "properties" : {
     "anInt" : {
       "type" : "integer"
+    },
+    "name" : {
+      "type" : "string"
     }
   }
 }

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/JacksonSchemaModule-reference.json
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/JacksonSchemaModule-reference.json
@@ -4,6 +4,9 @@
   "properties" : {
     "anInt" : {
       "type" : "integer"
+    },
+    "name" : {
+      "type" : "string"
     }
   },
   "description" : "Jackson annotation class"

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/JakartaValidationModule-reference.json
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/JakartaValidationModule-reference.json
@@ -4,6 +4,10 @@
   "properties" : {
     "anInt" : {
       "type" : "integer"
+    },
+    "name" : {
+      "type" : "string",
+      "minLength" : 1
     }
   }
 }

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/JavaxValidationModule-reference.json
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/JavaxValidationModule-reference.json
@@ -4,6 +4,9 @@
   "properties" : {
     "anInt" : {
       "type" : "integer"
+    },
+    "name" : {
+      "type" : "string"
     }
   }
 }

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/SchemaVersion-reference.json
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/SchemaVersion-reference.json
@@ -4,6 +4,9 @@
   "properties" : {
     "anInt" : {
       "type" : "integer"
+    },
+    "name" : {
+      "type" : "string"
     }
   }
 }

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/Swagger15Module-reference.json
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/Swagger15Module-reference.json
@@ -4,6 +4,9 @@
   "properties" : {
     "anInt" : {
       "type" : "integer"
+    },
+    "name" : {
+      "type" : "string"
     }
   }
 }

--- a/jsonschema-maven-plugin/src/test/resources/reference-test-cases/Swagger2Module-reference.json
+++ b/jsonschema-maven-plugin/src/test/resources/reference-test-cases/Swagger2Module-reference.json
@@ -4,6 +4,9 @@
   "properties" : {
     "anInt" : {
       "type" : "integer"
+    },
+    "name" : {
+      "type" : "string"
     }
   }
 }


### PR DESCRIPTION
This PR fixes an issue where numeric properties (such as minLength) in the generated JSON Schema were incorrectly serialized as strings instead of numbers. The root cause was a misconfiguration of the ObjectMapper in versions < 5.0.0, where the WRITE_NUMBERS_AS_STRING feature was set but not actually applied. With the migration to Jackson 3 (from version 5.0.0), this bug was resolved, and the setting is now effective.

## Changes

- Ensure numeric properties in the schema are serialized as numbers
- Adjust tests to verify the correct behavior

## Fixed issues

- #576