### PR TITLE
feat: include YearMonth in SimpleTypeModule.forPrimitiveAndAdditionalTypes()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### `jsonschema-generator`
+#### Added
+- include `java.time.YearMonth` in `SimpleTypeModule.forPrimitiveAndAdditionalTypes()` (mapped to `string`)
 
 
 ## [5.0.0] - 2026-02-07

--- a/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/SimpleTypeModule.java
+++ b/jsonschema-generator/src/main/java/com/github/victools/jsonschema/generator/impl/module/SimpleTypeModule.java
@@ -102,6 +102,7 @@ public class SimpleTypeModule implements Module {
         module.withStandardStringType(java.util.UUID.class, "uuid");
         module.withStandardStringType(java.net.URI.class, "uri");
         module.withStringType(java.time.ZoneId.class);
+        module.withStringType(java.time.YearMonth.class);
         module.withIntegerType(java.math.BigInteger.class);
 
         Stream.of(java.math.BigDecimal.class, Number.class)

--- a/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSimpleTypesTest.java
+++ b/jsonschema-generator/src/test/java/com/github/victools/jsonschema/generator/SchemaGeneratorSimpleTypesTest.java
@@ -55,6 +55,7 @@ public class SchemaGeneratorSimpleTypesTest {
             Arguments.of(float.class, SchemaKeyword.TAG_TYPE_NUMBER, "float", null),
             Arguments.of(java.time.LocalDate.class, SchemaKeyword.TAG_TYPE_STRING, "date", "date"),
             Arguments.of(java.time.LocalDateTime.class, SchemaKeyword.TAG_TYPE_STRING, null, null),
+            Arguments.of(java.time.YearMonth.class, SchemaKeyword.TAG_TYPE_STRING, null, null),
             Arguments.of(java.time.LocalTime.class, SchemaKeyword.TAG_TYPE_STRING, "time", "time"),
             Arguments.of(java.time.ZonedDateTime.class, SchemaKeyword.TAG_TYPE_STRING, "date-time", "date-time"),
             Arguments.of(java.time.OffsetDateTime.class, SchemaKeyword.TAG_TYPE_STRING, "date-time", "date-time"),


### PR DESCRIPTION
Resolves #562.

`SimpleTypeModule.forPrimitiveAndAdditionalTypes()` mapped `LocalDate`, `LocalDateTime`, `ZonedDateTime`, `OffsetDateTime`, `Instant`, `LocalTime`, `OffsetTime`, `Duration`, `Period`, `ZoneId`, etc. but not `java.time.YearMonth`. Jackson's `JavaTimeModule` serializes `YearMonth` as a string (e.g. `"2025-10"`), so the generated schema reported `object` instead of `string`.

`YearMonth` is added alongside `ZoneId` via `withStringType`, since RFC3339 does not define a `year-month` standard format. Parameterized test entry added to `SchemaGeneratorSimpleTypesTest`.
